### PR TITLE
Add ability to scan all running processes using -e (Windows only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ the same.
 * [YALIH](https://github.com/Masood-M/YALIH)
 * [Bayshore Networks, Inc.](http://www.bayshorenetworks.com)
 * [ThreatStream, Inc.](http://threatstream.com)
+* [NCC Group](https://www.nccgroup.com)
 
 Are you using it too? Tell me!
 

--- a/libyara/yara.h
+++ b/libyara/yara.h
@@ -23,6 +23,7 @@ limitations under the License.
 
 #ifdef WIN32
 #include <windows.h>
+#include <Psapi.h>
 typedef HANDLE mutex_t;
 #else
 #include <pthread.h>


### PR DESCRIPTION
Simple additions to enable scanning across all running processes, currently implemented on Windows only.

Processes that begin or end whilst yara is running will not be scanned as the process list is built once at startup.
