### PR TITLE
Fix a copy/paste mistake in richhash.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -2643,7 +2643,7 @@ define_function(imphash)
     sprintf(digest_ascii + (i * 2), "%02x", digest[i]);
   }
 
-  digest_ascii[32] = '\0';
+  digest_ascii[SHA256_DIGEST_LENGTH * 2] = '\0';
 
   return_string(digest_ascii);
 }
@@ -2672,7 +2672,7 @@ define_function(richhash)
     sprintf(digest_ascii + (i * 2), "%02x", digest[i]);
   }
 
-  digest_ascii[32] = '\0';
+  digest_ascii[MD5_DIGEST_LENGTH * 2] = '\0';
 
   return_string(digest_ascii);
 }


### PR DESCRIPTION
The richhash function was incorrectly terminating the ASCII representation. This appears to be a copy/paste mistake from the imphash function. To avoid this in the future I switched them to use the appropriate constants.
