### PR TITLE
Fix error in previous commit.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -2643,7 +2643,7 @@ define_function(imphash)
     sprintf(digest_ascii + (i * 2), "%02x", digest[i]);
   }
 
-  digest_ascii[SHA256_DIGEST_LENGTH * 2] = '\0';
+  digest_ascii[MD5_DIGEST_LENGTH * 2] = '\0';
 
   return_string(digest_ascii);
 }
@@ -2672,7 +2672,7 @@ define_function(richhash)
     sprintf(digest_ascii + (i * 2), "%02x", digest[i]);
   }
 
-  digest_ascii[MD5_DIGEST_LENGTH * 2] = '\0';
+  digest_ascii[SHA256_DIGEST_LENGTH * 2] = '\0';
 
   return_string(digest_ascii);
 }


### PR DESCRIPTION
I had the two backwards: imphash uses MD5 while richhash uses SHA256. :(
