### PR TITLE
Fix a NULL ptr deref.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -2567,7 +2567,7 @@ define_function(imphash)
   // If not a PE, return 0.
 
   if (!pe)
-    return_integer(UNDEFINED);
+    return_string(UNDEFINED);
 
   MD5_Init(&ctx);
 


### PR DESCRIPTION
While testing authenticode parsing I came across a binary which does
not have a rich signature. Calling pe.rich_signature.hash() caused
a NULL pointer dereference.
