### PR TITLE
Address an import parsing problem.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -598,6 +598,11 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
   uint64_t offset = pe_rva_to_offset(
       pe, import_descriptor->OriginalFirstThunk);
 
+  // I've seen binaries where OriginalFirstThunk is zero. In this case
+  // use FirstThunk.
+  if (offset == 0)
+    offset = pe_rva_to_offset(pe, import_descriptor->FirstThunk);
+
   if (offset == 0)
     return NULL;
 


### PR DESCRIPTION
I've got a binary here which pefile parses imports correctly but YARA
does not. It appears that when parsing the Import Directory if
OriginalFirstThunk is zero you can use FirstThunk.

I'm not sure this is legal to do, but there is a confirmed difference
in how pefile parses this sample and how YARA does it.
