### PR TITLE
Fix a problem with ord_lookup.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -634,22 +634,19 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
         name = ord_lookup(dll_name, thunks64->u1.Ordinal & 0xFFFF);
       }
 
-      if (name != NULL)
-      {
-        IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
-            yr_calloc(1, sizeof(IMPORTED_FUNCTION));
+      IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
+          yr_calloc(1, sizeof(IMPORTED_FUNCTION));
 
-        imported_func->name = name;
-        imported_func->next = NULL;
+      imported_func->name = name;
+      imported_func->next = NULL;
 
-        if (head == NULL)
-          head = imported_func;
+      if (head == NULL)
+        head = imported_func;
 
-        if (tail != NULL)
-          tail->next = imported_func;
+      if (tail != NULL)
+        tail->next = imported_func;
 
-        tail = imported_func;
-      }
+      tail = imported_func;
 
       thunks64++;
     }
@@ -686,22 +683,19 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
         name = ord_lookup(dll_name, thunks32->u1.Ordinal & 0xFFFF);
       }
 
-      if (name != NULL)
-      {
-        IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
-            yr_calloc(1, sizeof(IMPORTED_FUNCTION));
+      IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
+          yr_calloc(1, sizeof(IMPORTED_FUNCTION));
 
-        imported_func->name = name;
-        imported_func->next = NULL;
+      imported_func->name = name;
+      imported_func->next = NULL;
 
-        if (head == NULL)
-          head = imported_func;
+      if (head == NULL)
+        head = imported_func;
 
-        if (tail != NULL)
-          tail->next = imported_func;
+      if (tail != NULL)
+        tail->next = imported_func;
 
-        tail = imported_func;
-      }
+      tail = imported_func;
 
       thunks32++;
     }

--- a/libyara/modules/pe_utils.c
+++ b/libyara/modules/pe_utils.c
@@ -1661,7 +1661,7 @@ static char *ord_lookup(
   }
 
   if (name[0] == '\0')
-    return NULL;
+    sprintf(name, "ord%u", ord);
 
   return yr_strdup(name);
 }


### PR DESCRIPTION
If the ordinal can not be looked up we must return "ordN" and not NULL.

This was causing things with imports by ordinal that do not map to have
incorrect hashes. For example, this file:

d4ffa4559a1e22167933772d82cf714cd4bb7a0e79511c2424e18bdb619d63a4

The correct imphash for this (according to pefile) is:

74638b0911b0c9268aae1edee5a60a9f
