### PR TITLE
fix: compilation error because of multiple function declarations

### DIFF
--- a/libyara/include/yara/re.h
+++ b/libyara/include/yara/re.h
@@ -161,12 +161,6 @@ int yr_re_compile(
     RE_ERROR* error);
 
 
-RE_NODE* yr_re_node_create(
-    int type,
-    RE_NODE* left,
-    RE_NODE* right);
-
-
 void yr_re_destroy(
     RE* re);
 


### PR DESCRIPTION
/home/poz/local/include/yara/re.h:178:10: error: redundant redeclaration of ‘yr_re_node_create’ [-Werror=redundant-decls]
 RE_NODE\* yr_re_node_create(
          ^
/home/poz/local/include/yara/re.h:164:10: note: previous declaration of ‘yr_re_node_create’ was here
 RE_NODE\* yr_re_node_create(
          ^
cc1: all warnings being treated as errors
