### PR TITLE
Override the functions that Yara uses for memory management.

### DIFF
--- a/libyara/include/yara/libyara.h
+++ b/libyara/include/yara/libyara.h
@@ -33,4 +33,11 @@ YR_API int yr_get_tidx(void);
 
 YR_API void yr_set_tidx(int);
 
+
+YR_API int yr_set_mem_functions(
+        void *(*_malloc)(size_t size), void *(*_calloc)(size_t count, size_t size), void *(*_realloc)(void *ptr, size_t size),
+        void (*_free)(void *ptr),
+        char *(*_strdup)(const char *str), char *(*_strndup)(const char *str, size_t size) );
+
+
 #endif

--- a/libyara/include/yara/mem.h
+++ b/libyara/include/yara/mem.h
@@ -54,6 +54,12 @@ char* yr_strdup(
 char* yr_strndup(
 	const char *str, size_t n);
 
+
+int yr_set_mem_wrapper_functions(
+        void *(*_malloc)(size_t size), void *(*_calloc)(size_t count, size_t size), void *(*_realloc)(void *ptr, size_t size),
+        void (*_free)(void *ptr),
+        char *(*_strdup)(const char *str), char *(*_strndup)(const char *str, size_t size) );
+
 #endif
 
 int yr_heap_alloc();

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -161,3 +161,27 @@ YR_API int yr_get_tidx(void)
   return (int) (size_t) pthread_getspecific(tidx_key) - 1;
   #endif
 }
+
+
+//
+// _yr_set_mem_functions
+//
+// Override the functions that Yara uses for memory management.
+//
+// Returns:
+//    ERROR_SUCCESS if handler set without error
+//    ERROR_WRONG_ARGUMENTS if an handler is missing
+//
+
+YR_API int yr_set_mem_functions(
+        void *(*_malloc)(size_t size), void *(*_calloc)(size_t count, size_t size), void *(*_realloc)(void *ptr, size_t size),
+        void (*_free)(void *ptr),
+        char *(*_strdup)(const char *str), char *(*_strndup)(const char *str, size_t size) )
+{
+  #ifdef _WIN32
+  #else
+    #ifndef DMALLOC
+    return yr_set_mem_wrapper_functions(_malloc,_calloc,_realloc,_free,_strdup,_strndup);
+    #endif
+  #endif
+}

--- a/libyara/libyara.sym
+++ b/libyara/libyara.sym
@@ -26,3 +26,4 @@ yr_rules_define_integer_variable
 yr_rules_define_boolean_variable
 yr_rules_define_string_variable
 yr_rules_print_profiling_info
+yr_set_mem_functions

--- a/libyara/mem.c
+++ b/libyara/mem.c
@@ -106,6 +106,44 @@ char* yr_strndup(const char *str, size_t n)
 
 #include <yara/error.h>
 
+
+struct mem_wrappers
+{
+    void *(*_malloc)(size_t size);
+    void *(*_calloc)(size_t count, size_t size);
+    void *(*_realloc)(void* ptr, size_t size);
+    void (*_free)(void *ptr);
+    char *(*_strdup)(const char *str);
+    char *(*_strndup)(const char *s, size_t size);
+};
+
+static struct mem_wrappers _wrappers = {
+        malloc, calloc, realloc,
+        free,
+        strdup, strndup
+};
+
+
+int yr_set_mem_wrapper_functions(
+        void *(*_malloc)(size_t size), void *(*_calloc)(size_t count, size_t size), void *(*_realloc)(void *ptr, size_t size),
+        void (*_free)(void *ptr),
+        char *(*_strdup)(const char *str), char *(*_strndup)(const char *str, size_t size) )
+{
+    if ( ! (_malloc && _calloc && _realloc && _free && _strdup && _strndup ) )
+        return ERROR_WRONG_ARGUMENTS;
+
+
+    _wrappers._malloc = _malloc;
+    _wrappers._calloc = _calloc;
+    _wrappers._realloc = _realloc;
+    _wrappers._free = _free;
+    _wrappers._strdup = _strdup;
+    _wrappers._strndup = _strndup;
+
+    return ERROR_SUCCESS;
+}
+
+
 int yr_heap_alloc()
 {
   return ERROR_SUCCESS;
@@ -120,37 +158,37 @@ int yr_heap_free()
 
 void* yr_calloc(size_t count, size_t size)
 {
-  return calloc(count, size);
+  return _wrappers._calloc(count, size);
 }
 
 
 void* yr_malloc(size_t size)
 {
-  return malloc(size);
+  return _wrappers._malloc(size);
 }
 
 
 void* yr_realloc(void* ptr, size_t size)
 {
-  return realloc(ptr, size);
+  return _wrappers._realloc(ptr, size);
 }
 
 
 void yr_free(void *ptr)
 {
-  free(ptr);
+  return _wrappers._free(ptr);
 }
 
 
 char* yr_strdup(const char *str)
 {
-  return strdup(str);
+  return _wrappers._strdup(str);
 }
 
 
 char* yr_strndup(const char *str, size_t n)
 {
-  return strndup(str, n);
+  return _wrappers._strndup(str, n);
 }
 
 #endif


### PR DESCRIPTION
User can use yr_set_mem_functions() to override malloc,calloc,realloc,free,strdup and strndup function.
If you want to use the wrapper, you need to define function following the exact original prototype, and to define all of them.

The function yr_set_mem_functions() will return:
- ERROR_SUCCESS if handler set without error
- ERROR_WRONG_ARGUMENTS if an handler is missing

Note: this is not supported on Windows platform, and cannot be used with DMALLOC
