### PR TITLE
fix issue #206

### DIFF
--- a/libyara/re.c
+++ b/libyara/re.c
@@ -1432,7 +1432,7 @@ int _yr_re_fiber_sync(
       case RE_OPCODE_SPLIT_A:
         new_fiber = _yr_re_fiber_split(fiber, fiber_list, fiber_pool);
         if (! new_fiber)
-          return -1;
+          return ERROR_INSUFICIENT_MEMORY;
 
         new_fiber->ip += *(int16_t*)(fiber->ip + 1);
         fiber->ip += 3;
@@ -1441,7 +1441,7 @@ int _yr_re_fiber_sync(
       case RE_OPCODE_SPLIT_B:
         new_fiber = _yr_re_fiber_split(fiber, fiber_list, fiber_pool);
         if (! new_fiber)
-          return -1;
+          return ERROR_INSUFICIENT_MEMORY;
 
         new_fiber->ip += 3;
         fiber->ip += *(int16_t*)(fiber->ip + 1);
@@ -1476,7 +1476,7 @@ int _yr_re_fiber_sync(
           fiber = fiber->next;
     }
   }
-  return 0;
+  return ERROR_SUCCESS;
 }
 
 
@@ -1522,6 +1522,7 @@ int yr_re_exec(
   RE_FIBER* fiber;
   RE_FIBER* next_fiber;
 
+  int rc;
   int count;
   int max_count;
   int match;
@@ -1563,7 +1564,8 @@ int yr_re_exec(
   fibers.head = fiber;
   fibers.tail = fiber;
 
-  if (_yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber) < 0)
+  rc = _yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber);
+  if (rc != ERROR_SUCCESS)
     return -2;
 
   while (fibers.head != NULL)
@@ -1754,13 +1756,15 @@ int yr_re_exec(
 
         case ACTION_CONTINUE:
           fiber->ip += 1;
-          if (_yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber) < 0)
+          rc = _yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber);
+          if (rc != ERROR_SUCCESS)
             return -2;
           break;
 
         default:
           next_fiber = fiber->next;
-          if (_yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber) < 0)
+          rc = _yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber);
+          if (rc != ERROR_SUCCESS)
             return -2;
           fiber = next_fiber;
       }
@@ -1782,7 +1786,8 @@ int yr_re_exec(
       fiber->ip = re_code;
 
       _yr_re_fiber_append(&fibers, fiber);
-      if (_yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber) < 0)
+      rc = _yr_re_fiber_sync(&fibers, &storage->fiber_pool, fiber);
+      if (rc != ERROR_SUCCESS)
         return -2;
     }
   }


### PR DESCRIPTION
Change the prototype of a non-exported function (re.c:_yr_re_fiber_sync) so that it
tells its caller if an error occurred.
