### PR TITLE
DllCharacteristics and subsystem PE flags.

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -75,6 +75,12 @@ Reference
     .. c:type:: SUBSYSTEM_OS2_CUI
     .. c:type:: SUBSYSTEM_POSIX_CUI
     .. c:type:: SUBSYSTEM_NATIVE_WINDOWS
+    .. c:type:: SUBSYSTEM_WINDOWS_CE_GUI
+    .. c:type:: SUBSYSTEM_EFI_APPLICATION
+    .. c:type:: SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER
+    .. c:type:: SUBSYSTEM_EFI_RUNTIME_DRIVER
+    .. c:type:: SUBSYSTEM_XBOX
+    .. c:type:: SUBSYSTEM_WINDOWS_BOOT_APPLICATION
 
     *Example: pe.subsystem == pe.SUBSYSTEM_NATIVE*
 
@@ -94,8 +100,9 @@ Reference
 
 .. c:type:: characteristics
 
-    Bitmap with PE characteristics. Individual characteristics can be inspected
-    by performing a bitwise AND operation with the following constants:
+    Bitmap with PE FileHeader characteristics. Individual characteristics 
+    can be inspected by performing a bitwise AND operation with the 
+    following constants:
 
     .. c:type:: RELOCS_STRIPPED
     .. c:type:: EXECUTABLE_IMAGE
@@ -166,6 +173,37 @@ Reference
     .. c:member:: minor
 
         Minor subsystem version.
+
+.. c:type:: dll_characteristics
+
+    Bitmap with PE OptionalHeader DllCharacteristics.  Do not confuse these
+    flags with the PE FileHeader Characteristics. Individual 
+    characteristics can be inspected by performing a bitwise AND 
+    operation with the following constants:
+
+    .. c:type:: DYNAMIC_BASE
+
+        File can be relocated - also marks the file as ASLR compatible
+
+    .. c:type:: FORCE_INTEGRITY
+    .. c:type:: NX_COMPAT
+
+        Marks the file as DEP compatible
+
+    .. c:type:: NO_ISOLATION
+    .. c:type:: NO_SEH
+
+        The file does not contain structured exception handlers, this must be 
+        set to use SafeSEH
+
+    .. c:type:: NO_BIND
+    .. c:type:: WDM_DRIVER
+
+        Marks the file as a Windows Driver Model (WDM) device driver.
+
+    .. c:type:: TERMINAL_SERVER_AWARE
+
+        Marks the file as terminal server compatible
 
 .. c:type:: number_of_sections
 

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1386,6 +1386,10 @@ void pe_parse_header(
       OptionalHeader(Subsystem),
       pe->object, "subsystem");
 
+  set_integer(
+      OptionalHeader(DllCharacteristics),
+      pe->object, "dllcharacteristics");
+
   pe_iterate_resources(
       pe,
       (RESOURCE_CALLBACK_FUNC) pe_collect_resources,
@@ -2026,6 +2030,21 @@ begin_declarations;
   declare_integer("SUBSYSTEM_OS2_CUI");
   declare_integer("SUBSYSTEM_POSIX_CUI");
   declare_integer("SUBSYSTEM_NATIVE_WINDOWS");
+  declare_integer("SUBSYSTEM_WINDOWS_CE_GUI");
+  declare_integer("SUBSYSTEM_EFI_APPLICATION");
+  declare_integer("SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER");
+  declare_integer("SUBSYSTEM_EFI_RUNTIME_DRIVER");
+  declare_integer("SUBSYSTEM_XBOX");
+  declare_integer("SUBSYSTEM_WINDOWS_BOOT_APPLICATION");
+
+  declare_integer("DLLCHARACTERISTICS_DYNAMIC_BASE");
+  declare_integer("DLLCHARACTERISTICS_FORCE_INTEGRITY");
+  declare_integer("DLLCHARACTERISTICS_NX_COMPAT");
+  declare_integer("DLLCHARACTERISTICS_NO_ISOLATION");
+  declare_integer("DLLCHARACTERISTICS_NO_SEH");
+  declare_integer("DLLCHARACTERISTICS_NO_BIND");
+  declare_integer("DLLCHARACTERISTICS_WDM_DRIVER");
+  declare_integer("DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE");
 
   declare_integer("RELOCS_STRIPPED");
   declare_integer("EXECUTABLE_IMAGE");
@@ -2110,6 +2129,8 @@ begin_declarations;
   end_struct("subsystem_version");
 
   declare_integer("subsystem");
+
+  declare_integer("dllcharacteristics");
 
   begin_struct_array("sections");
     declare_string("name");
@@ -2296,6 +2317,49 @@ int module_load(
   set_integer(
       IMAGE_SUBSYSTEM_NATIVE_WINDOWS, module_object,
       "SUBSYSTEM_NATIVE_WINDOWS");
+  set_integer(
+      IMAGE_SUBSYSTEM_WINDOWS_CE_GUI, module_object,
+      "SUBSYSTEM_WINDOWS_CE_GUI");
+  set_integer(
+      IMAGE_SUBSYSTEM_EFI_APPLICATION, module_object,
+	  "SUBSYSTEM_EFI_APPLICATION");
+  set_integer(
+      IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER, module_object,
+	  "SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER");
+  set_integer(
+      IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER, module_object,
+	  "SUBSYSTEM_EFI_RUNTIME_DRIVER");
+  set_integer(
+      IMAGE_SUBSYSTEM_XBOX, module_object,
+	  "SUBSYSTEM_XBOX");
+  set_integer(
+      IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION, module_object,
+	  "SUBSYSTEM_WINDOWS_BOOT_APPLICATION");
+
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE, module_object,
+	  "DLLCHARACTERISTICS_DYNAMIC_BASE");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY, module_object,
+	  "DLLCHARACTERISTICS_FORCE_INTEGRITY");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_NX_COMPAT, module_object,
+	  "DLLCHARACTERISTICS_NX_COMPAT");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_NO_ISOLATION, module_object,
+	  "DLLCHARACTERISTICS_NO_ISOLATION");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_NO_SEH, module_object,
+	  "DLLCHARACTERISTICS_NO_SEH");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_NO_BIND, module_object,
+	  "DLLCHARACTERISTICS_NO_BIND");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_WDM_DRIVER, module_object,
+	  "DLLCHARACTERISTICS_WDM_DRIVER");
+  set_integer(
+      IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE, module_object,
+	  "DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE");
 
   set_integer(
       IMAGE_FILE_RELOCS_STRIPPED, module_object,

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1388,7 +1388,7 @@ void pe_parse_header(
 
   set_integer(
       OptionalHeader(DllCharacteristics),
-      pe->object, "dllcharacteristics");
+      pe->object, "dll_characteristics");
 
   pe_iterate_resources(
       pe,
@@ -1842,7 +1842,7 @@ define_function(locale)
 define_function(language)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE *)module->data;
 
   uint64_t language = integer_argument(1);
   int64_t n, i;
@@ -1885,7 +1885,7 @@ define_function(is_dll)
 define_function(is_32bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE *)module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);
@@ -1897,7 +1897,7 @@ define_function(is_32bit)
 define_function(is_64bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE *)module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);
@@ -2037,14 +2037,14 @@ begin_declarations;
   declare_integer("SUBSYSTEM_XBOX");
   declare_integer("SUBSYSTEM_WINDOWS_BOOT_APPLICATION");
 
-  declare_integer("DLLCHARACTERISTICS_DYNAMIC_BASE");
-  declare_integer("DLLCHARACTERISTICS_FORCE_INTEGRITY");
-  declare_integer("DLLCHARACTERISTICS_NX_COMPAT");
-  declare_integer("DLLCHARACTERISTICS_NO_ISOLATION");
-  declare_integer("DLLCHARACTERISTICS_NO_SEH");
-  declare_integer("DLLCHARACTERISTICS_NO_BIND");
-  declare_integer("DLLCHARACTERISTICS_WDM_DRIVER");
-  declare_integer("DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE");
+  declare_integer("DYNAMIC_BASE");
+  declare_integer("FORCE_INTEGRITY");
+  declare_integer("NX_COMPAT");
+  declare_integer("NO_ISOLATION");
+  declare_integer("NO_SEH");
+  declare_integer("NO_BIND");
+  declare_integer("WDM_DRIVER");
+  declare_integer("TERMINAL_SERVER_AWARE");
 
   declare_integer("RELOCS_STRIPPED");
   declare_integer("EXECUTABLE_IMAGE");
@@ -2338,28 +2338,28 @@ int module_load(
 
   set_integer(
       IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE, module_object,
-	  "DLLCHARACTERISTICS_DYNAMIC_BASE");
+	  "DYNAMIC_BASE");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY, module_object,
-	  "DLLCHARACTERISTICS_FORCE_INTEGRITY");
+	  "FORCE_INTEGRITY");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_NX_COMPAT, module_object,
-	  "DLLCHARACTERISTICS_NX_COMPAT");
+	  "_NX_COMPAT");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_NO_ISOLATION, module_object,
-	  "DLLCHARACTERISTICS_NO_ISOLATION");
+	  "NO_ISOLATION");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_NO_SEH, module_object,
-	  "DLLCHARACTERISTICS_NO_SEH");
+	  "NO_SEH");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_NO_BIND, module_object,
-	  "DLLCHARACTERISTICS_NO_BIND");
+	  "NO_BIND");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_WDM_DRIVER, module_object,
-	  "DLLCHARACTERISTICS_WDM_DRIVER");
+	  "WDM_DRIVER");
   set_integer(
       IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE, module_object,
-	  "DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE");
+	  "TERMINAL_SERVER_AWARE");
 
   set_integer(
       IMAGE_FILE_RELOCS_STRIPPED, module_object,

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -2130,7 +2130,7 @@ begin_declarations;
 
   declare_integer("subsystem");
 
-  declare_integer("dllcharacteristics");
+  declare_integer("dll_characteristics");
 
   begin_struct_array("sections");
     declare_string("name");


### PR DESCRIPTION
Adds missing subsystem flags and OptionalHeader.DllCharacteristics flags.

Updated to use dll_characteristics and hopefully documented the new flags.  I don't have the necissary environment setup to test the documentation build however.
