### PR TITLE
Set a value of zero for pe.number_of_signatures by default

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -2509,6 +2509,7 @@ int module_load(
         pe_parse_rich_signature(pe, block->base);
 
         #if defined(HAVE_LIBCRYPTO)
+        set_integer(0, pe->object, "number_of_signatures");
         pe_parse_certificates(pe);
         #endif
 


### PR DESCRIPTION
This sets a value of zero for `pe.number_of_signatures` when there are no Authenticode signatures. It is currently set to `UNDEFINED` when there are no signatures.