### PR TITLE
create cache layer for non-string input hashing functions

### DIFF
--- a/libyara/modules/hash.c
+++ b/libyara/modules/hash.c
@@ -479,8 +479,8 @@ int module_load(
     void* module_data,
     size_t module_data_size)
 {
-
   module_object->data = yr_malloc(sizeof(CACHE));
+  memset(module_object->data, 0, sizeof(CACHE));
   return ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
When trying to run rule sets that contain thousands of hashes, processing time can significantly increase.  Allowing the hash module to cache the last computed value, offset, and length it can quickly return the already computed hash value avoiding the cost of recomputing for each rule.

This doesn't add any value to folks with various offsets/lengths.  For users with the same offset + size for rules, this can decrease processing time.