### PR TITLE
fixed building on VS2010

### DIFF
--- a/windows/libyara/libyara.vcxproj
+++ b/windows/libyara/libyara.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="..\..\libyara\sizedstr.c" />
     <ClCompile Include="..\..\libyara\stream.c" />
     <ClCompile Include="..\..\libyara\strutils.c" />
+    <ClCompile Include="..\..\libyara\threading.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
the `threading.c` file wasn't included in the VS2010 solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/virustotal/yara/460)
<!-- Reviewable:end -->
