### PR TITLE
Extend cuckoo module with new methods

### DIFF
--- a/libyara/modules/hash.c
+++ b/libyara/modules/hash.c
@@ -78,7 +78,7 @@ char* get_from_cache(
   key.offset = offset;
   key.length = length;
 
-  return yr_hash_table_lookup_raw_key(
+  return (char*) yr_hash_table_lookup_raw_key(
       hash_table,
       &key,
       sizeof(key),

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1304,7 +1304,7 @@ void pe_parse_certificates(
           // space to hold it, and use i2d_ASN1_INTEGER() one last time to
           // hold it in the allocated buffer.
 
-          unsigned char* serial_der = yr_malloc(bytes);
+          unsigned char* serial_der = (unsigned char*) yr_malloc(bytes);
 
           if (serial_der != NULL)
           {


### PR DESCRIPTION
Extend cuckoo module with new methods

New methods help distinguish between desired access to the registry key or file,
which is very helpful.

Also, new method has been added to check for particular executed command.

New methods:

```
    - cuckoo.registry.key_read(r)
    - cuckoo.registry.key_write(r)
    - cuckoo.registry.key_delete(r)
    - cuckoo.registry.key_value_access(r, r)

    - cuckoo.filesystem.file_read(r)
    - cuckoo.filesystem.file_write(r)
    - cuckoo.filesystem.file_delete(r)

    - cuckoo.process.executed_command(r)
```
