### PR TITLE
Null-terminate string objects explicitly.

### DIFF
--- a/libyara/object.c
+++ b/libyara/object.c
@@ -1075,6 +1075,7 @@ int yr_object_set_string(
     string_obj->value->flags = 0;
 
     memcpy(string_obj->value->c_string, value, len);
+    string_obj->value->c_string[len] = '\0';
   }
   else
   {


### PR DESCRIPTION
String objects created in `yr_object_set_string` (`libyara/object.c`) are copied using `memcpy` without null-terminator into `c_string` attribute of `SIZED_STRING` structure. However, these strings are then treated like regular C-strings. For example in function `section_index_name` in `modules/pe.c`, there is comparison of searched section name with `sect->c_string` using `strcmp`. If the name of the section matches the searched section name or the searched section name is longer than section name the access to uninitialized value happens, because it is the missing null-terminator which is accessed. This can be seen in valgrind as this.

```
==18770== Conditional jump or move depends on uninitialised value(s)
==18770==    at 0x4C2CA6C: strcmp (vg_replace_strmem.c:842)
==18770==    by 0x41BAF2: section_index_name (pe.c:1579)
==18770==    by 0x42EAEC: yr_execute_code (exec.c:591)
==18770==    by 0x414A76: yr_rules_scan_mem_blocks (rules.c:470)
==18770==    by 0x414E24: yr_rules_scan_mem (rules.c:582)
==18770==    by 0x414E24: yr_rules_scan_file (rules.c:606)
```

This should also fix the issues when rules like these weren't matched properly, even though the file clearly contained `.data` section on index 2.

```
import "pe"

rule SimpleRule
{
	condition:
		pe.section_index(".data") == 2
}
```