### PR TITLE
Added stdint.h fallback support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ stamp-h1
 /aclocal.m4
 /ar-lib
 /autom4te.cache/
+/compile
 /config.guess
 /config.h
 /config.h.in
@@ -38,6 +39,7 @@ stamp-h1
 /libtool
 /ltmain.sh
 /missing
+/test-driver
 /ylwrap
 /m4
 !/m4/acx_pthread.m4
@@ -45,6 +47,7 @@ stamp-h1
 # Project specific files
 /yara
 /yarac
+/libyara/modules/.dirstamp
 
 # Linux and Mac files
 *.swp

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -32,12 +32,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assert.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <stddef.h>
 
 
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/strutils.h>
 #include <yara/compiler.h>

--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -27,9 +27,9 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdint.h>
 #include <string.h>
 
+#include <yara/integers.h>
 #include <yara/hash.h>
 #include <yara/mem.h>
 #include <yara/error.h>

--- a/libyara/hex_grammar.y
+++ b/libyara/hex_grammar.y
@@ -30,9 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %{
 
 #include <string.h>
-#include <stdint.h>
 #include <limits.h>
 
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/hex_lexer.h>
 #include <yara/limits.h>

--- a/libyara/include/yara/arena.h
+++ b/libyara/include/yara/arena.h
@@ -30,9 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_ARENA_H
 #define YR_ARENA_H
 
-#include <stdint.h>
 #include <stddef.h>
 
+#include <yara/integers.h>
 #include <yara/stream.h>
 
 #define ARENA_FLAGS_FIXED_SIZE   1

--- a/libyara/include/yara/elf.h
+++ b/libyara/include/yara/elf.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _ELF_H
 #define _ELF_H
 
-#include <stdint.h>
+#include <yara/integers.h>
 
 
 // 32-bit ELF base types

--- a/libyara/include/yara/integers.h
+++ b/libyara/include/yara/integers.h
@@ -27,64 +27,40 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef YR_FILEMAP_H
-#define YR_FILEMAP_H
+#ifndef YR_INTEGERS_H
+#define YR_INTEGERS_H
 
-#ifdef _MSC_VER
-#define off_t              int64_t
-#else
-#include <sys/types.h>
+/* Integer type definitions
+ */
+#if ( defined( _MSC_VER ) && ( _MSC_VER < 1600 ) ) || ( defined( __BORLANDC__ ) && ( __BORLANDC__ <= 0x0560 ) )
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
-#define YR_FILE_DESCRIPTOR    HANDLE
-#else
-#define YR_FILE_DESCRIPTOR    int
+/* Microsoft Visual Studio C++ before Visual Studio 2010 or earlier versions of the Borland C++ Builder
+ * do not support the (u)int#_t type definitions but have __int# defintions instead
+ */
+typedef __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+
+#ifdef __cplusplus
+}
 #endif
 
-#include <stdlib.h>
+#else
 
-#include <yara/integers.h>
-#include <yara/utils.h>
+/* Other "compilers" and later versions of Microsoft Visual Studio C++ and
+ * Borland C/C++ define the types in <stdint.h>
+ */
+#include <stdint.h>
 
-
-typedef struct _YR_MAPPED_FILE
-{
-  YR_FILE_DESCRIPTOR  file;
-  size_t              size;
-  uint8_t*            data;
-  #if defined(_WIN32) || defined(__CYGWIN__)
-  HANDLE              mapping;
-  #endif
-
-} YR_MAPPED_FILE;
-
-
-YR_API int yr_filemap_map(
-    const char* file_path,
-    YR_MAPPED_FILE* pmapped_file);
-
-
-YR_API int yr_filemap_map_fd(
-    YR_FILE_DESCRIPTOR file,
-    off_t offset,
-    size_t size,
-    YR_MAPPED_FILE* pmapped_file);
-
-
-YR_API int yr_filemap_map_ex(
-    const char* file_path,
-    off_t offset,
-    size_t size,
-    YR_MAPPED_FILE* pmapped_file);
-
-
-YR_API void yr_filemap_unmap(
-    YR_MAPPED_FILE* pmapped_file);
-
-
-YR_API void yr_filemap_unmap_fd(
-    YR_MAPPED_FILE* pmapped_file);
+#endif
 
 #endif

--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -44,8 +44,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #else
 
-#include <stdint.h>
 #include <stdlib.h>
+
+#include <yara/integers.h>
 
 typedef uint8_t   BYTE;
 typedef uint16_t  WORD;

--- a/libyara/include/yara/sizedstr.h
+++ b/libyara/include/yara/sizedstr.h
@@ -31,7 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _SIZEDSTR_H
 
 #include <stddef.h>
-#include <stdint.h>
+
+#include <yara/integers.h>
 
 //
 // This struct is used to support strings containing null chars. The length of

--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -32,7 +32,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assert.h>
 #include <stdlib.h>
-#include <stdint.h>
+
+#include <yara/integers.h>
 
 #include "config.h"
 

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -47,11 +47,10 @@ with noyywrap then we can remove this pragma.
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <setjmp.h>
 
-
+#include <yara/integers.h>
 #include <yara/lexer.h>
 #include <yara/sizedstr.h>
 #include <yara/error.h>

--- a/libyara/modules/pe_utils.c
+++ b/libyara/modules/pe_utils.c
@@ -3,7 +3,8 @@
 #if !HAVE_TIMEGM
 
 #include <time.h>
-#include <stdint.h>
+
+#include <yara/integers.h>
 
 static int is_leap(
     unsigned int year)

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -422,8 +422,9 @@ int _yr_parser_write_string(
   return result;
 }
 
-#include <stdint.h>
 #include <limits.h>
+
+#include <yara/integers.h>
 
 
 YR_STRING* yr_parser_reduce_string_declaration(

--- a/libyara/re_grammar.y
+++ b/libyara/re_grammar.y
@@ -29,8 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %{
 
-#include <stdint.h>
-
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/error.h>
 #include <yara/limits.h>


### PR DESCRIPTION
stdint.h fallback support is needed to be able to compile with Visual Studio 2008 e.g. to build a Python module.