### PR TITLE
Added missing return statements -> yarapython documentation

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -186,7 +186,7 @@ Here is an example:
 
   def mycallback(data):
     print data
-    yara.CALLBACK_CONTINUE
+    return yara.CALLBACK_CONTINUE
 
   matches = rules.match('/foo/bar/my_file', callback=mycallback)
 
@@ -314,11 +314,3 @@ Reference
     :param str filepath: Path to the file.
     :param file-object file: A file object supporting the ``write`` method.
     :raises: **YaraError**: If an error occurred while saving the file.
-
-
-
-
-
-
-
-

--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -227,7 +227,7 @@ Here is an example:
 
   def modules_callback(data):
     print data
-    yara.CALLBACK_CONTINUE
+    return yara.CALLBACK_CONTINUE
 
   matches = rules.match('/foo/bar/my_file', modules_callback=modules_callback)
 


### PR DESCRIPTION
The documentation of the callback argument in the `match` function tells to return either `yara.CALLBACK_CONTINUE` or `yara.CALLBACK_ABORT`. The samplecodes however don't add the `return` statements.