### PR TITLE
Add number_of_imports to PE.

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -472,6 +472,12 @@ Reference
 
     *Example:  pe.exports("CPlApplet")*
 
+.. c:type:: number_of_imports
+
+    .. versionadded:: 3.6.0
+
+    Number of imports in the PE.
+
 .. c:function:: imports(dll_name, function_name)
 
     Function returning true if the PE imports *function_name* from *dll_name*,

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -922,6 +922,7 @@ IMPORTED_DLL* pe_parse_imports(
     imports++;
   }
 
+  set_integer(num_imports, pe->object, "number_of_imports");
   return head;
 }
 
@@ -1980,6 +1981,8 @@ begin_declarations;
   declare_function("is_dll", "", "i", is_dll);
   declare_function("is_32bit", "", "i", is_32bit);
   declare_function("is_64bit", "", "i", is_64bit);
+
+  declare_integer("number_of_imports");
 
   declare_integer("resource_timestamp");
 


### PR DESCRIPTION
Expose the number of imports parsed by YARA in the PE module. Sometimes this can
be useful to know, especially if there are zero imports as that may be a sign
that something is obfuscated. For example,
f0501b0b3990dab0d8644729da02acb8ea5f39765b820626dc8873f60f787980 has zero
imports because the import table has been nulled out.