### PR TITLE
Add pe.overlay.offset and pe.overlay.size (closes #432)

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -224,6 +224,22 @@ Reference
 
     *Example: pe.sections[1].characteristics & SECTION_CNT_CODE*
 
+.. c:type:: overlay
+
+    .. versionadded:: 3.6.0
+
+    A structure containing the following integer members:
+
+    .. c:member:: offset
+
+        Overlay section offset.
+
+    .. c:member:: size
+
+        Overlay section size.
+
+    *Example: uint8(0x0d) at pe.overlay.offset and pe.overlay.size > 1024*
+
 .. c:type:: number_of_resources
 
     Number of resources in the PE.

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1301,8 +1301,8 @@ void pe_parse_overlay(PE *pe)
   // This way "overlay" is set to UNDEFINED for files that do not have an overlay section
   if (last_section_end && (pe->data_size > last_section_end))
   {
-    set_integer(last_section_end, pe->object, "overlay");
-    set_integer(pe->data_size - last_section_end, pe->object, "overlay_size");
+    set_integer(last_section_end, pe->object, "overlay.offset");
+    set_integer(pe->data_size - last_section_end, pe->object, "overlay.size");
   }
 }
 
@@ -1992,8 +1992,10 @@ begin_declarations;
     declare_integer("raw_data_size");
   end_struct_array("sections");
 
-  declare_integer("overlay");
-  declare_integer("overlay_size");
+  begin_struct("overlay");
+    declare_integer("offset");
+    declare_integer("size");
+  end_struct("overlay");
 
   begin_struct("rich_signature");
     declare_integer("offset");

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1300,7 +1300,10 @@ void pe_parse_overlay(PE *pe)
 
   // This way "overlay" is set to UNDEFINED for files that do not have an overlay section
   if (last_section_end && (pe->data_size > last_section_end))
+  {
     set_integer(last_section_end, pe->object, "overlay");
+    set_integer(pe->data_size - last_section_end, pe->object, "overlay_size");
+  }
 }
 
 //
@@ -1990,6 +1993,7 @@ begin_declarations;
   end_struct_array("sections");
 
   declare_integer("overlay");
+  declare_integer("overlay_size");
 
   begin_struct("rich_signature");
     declare_integer("offset");


### PR DESCRIPTION
An overlay is data appended to the end of a file. This PR adds the ability to use pe.overlay.offset and pe.overlay.size in Yara rules. For example:

```
import "pe"

private rule has_overlay {
	condition:
		pe.overlay.offset
}

rule big_overlay {
	condition:
		pe.overlay.size > 1024
}

rule overlay_bytes {
	strings:
		$bytes = { 90 41 42 50 56 }
	condition:
		$bytes at pe.overlay.offset
}
```

It closes the issue #432 (also discussed at https://groups.google.com/forum/#!topic/yara-project/5AWlwXyy1oY)