### PR TITLE
Allow MAX_THREADS to be set arbitrarily

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -590,7 +590,7 @@ YR_API int yr_compiler_get_rules(
   yara_rules->match_table = rules_file_header->match_table;
   yara_rules->transition_table = rules_file_header->transition_table;
   yara_rules->code_start = rules_file_header->code_start;
-  yara_rules->tidx_mask = 0;
+  memset(yara_rules->tidx_mask, 0, sizeof(yara_rules->tidx_mask));
 
   FAIL_ON_ERROR_WITH_CLEANUP(
       yr_mutex_create(&yara_rules->mutex),

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -34,10 +34,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <windows.h>
 #endif
 
+#include "utils.h"
 
 // MAX_THREADS is the number of threads that can use a YR_RULES
-// object simultaneosly. This value is limited by the number of
-// bits in tidx_mask.
+// object simultaneosly.
 
 #define MAX_THREADS 32
 

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -44,8 +44,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 #endif
 
-typedef int32_t tidx_mask_t;
-
 
 #define DECLARE_REFERENCE(type, name) \
     union { type name; int64_t name##_; } YR_ALIGN(8)
@@ -369,7 +367,7 @@ typedef struct _YR_AC_AUTOMATON
 
 typedef struct _YR_RULES {
 
-  tidx_mask_t tidx_mask;
+  unsigned char tidx_mask[YR_BITARRAY_NCHARS(MAX_THREADS)];
   uint8_t* code_start;
 
   YR_MUTEX mutex;

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -78,6 +78,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 
 #include <stdlib.h>
+#include <limits.h>
 
 #define assertf(expr, msg, ...) \
     if(!(expr)) { \
@@ -86,5 +87,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }
 
 #endif
+
+// Set, unset, and test bits in an array of unsigned characters by integer
+// index. The underlying array must be of type char or unsigned char to
+// ensure compatibility with the CHAR_BIT constant used in these definitions.
+
+#define YR_BITARRAY_SET(uchar_array_base, bitnum) \
+          (((uchar_array_base)[(bitnum)/CHAR_BIT]) = \
+            ((uchar_array_base)[(bitnum)/CHAR_BIT] | (1 << ((bitnum) % CHAR_BIT))))
+
+#define YR_BITARRAY_UNSET(uchar_array_base, bitnum) \
+          (((uchar_array_base)[(bitnum)/CHAR_BIT]) = \
+            ((uchar_array_base)[(bitnum)/CHAR_BIT] & (~(1 << ((bitnum) % CHAR_BIT)))))
+
+#define YR_BITARRAY_TEST(uchar_array_base, bitnum) \
+          (((uchar_array_base)[(bitnum)/CHAR_BIT] & (1 << ((bitnum) % CHAR_BIT))) != 0)
+
+#define YR_BITARRAY_NCHARS(bitnum) \
+          (((bitnum)+(CHAR_BIT-1))/CHAR_BIT)
 
 #endif


### PR DESCRIPTION
This allows the 32-thread upper limit to be adjusted by converting the int32_t thread mask to a byte array. A potential drawback is that if the rule structure is ever serialized it will be binary incompatible when MAX_THREADS is altered due to the differing structure.