### PR TITLE
Fix variable redefinition

### DIFF
--- a/yara.c
+++ b/yara.c
@@ -1158,7 +1158,8 @@ int main(
     thread_args.rules = rules;
     thread_args.start_time = start_time;
 
-    for (int i = 0; i < threads; i++)
+    int i;
+    for (i = 0; i < threads; i++)
     {
       if (create_thread(&thread[i], scanning_thread, (void*) &thread_args))
       {
@@ -1177,7 +1178,7 @@ int main(
     file_queue_finish();
 
     // Wait for scan threads to finish
-    for (int i = 0; i < threads; i++)
+    for (i = 0; i < threads; i++)
       thread_join(&thread[i]);
 
     file_queue_destroy();

--- a/yara.c
+++ b/yara.c
@@ -987,7 +987,7 @@ int main(
   YR_COMPILER* compiler = NULL;
   YR_RULES* rules = NULL;
 
-  int result;
+  int result, i;
 
   argc = args_parse(options, argc, argv);
 
@@ -1158,7 +1158,6 @@ int main(
     thread_args.rules = rules;
     thread_args.start_time = start_time;
 
-    int i;
     for (i = 0; i < threads; i++)
     {
       if (create_thread(&thread[i], scanning_thread, (void*) &thread_args))


### PR DESCRIPTION
When compiling using `clang-3.8` the build failed because the variable `i` was declared multiple times in the same scope. Fixed this.