### PR TITLE
Fix issue #516.

### DIFF
--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -180,9 +180,6 @@ YR_API void* yr_hash_table_lookup_raw_key(
   YR_HASH_TABLE_ENTRY* entry;
   uint32_t bucket_index;
 
-  if (key_length == 0)
-    return NULL;
-
   bucket_index = hash(0, key, key_length);
 
   if (ns != NULL)

--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -180,6 +180,9 @@ YR_API void* yr_hash_table_lookup_raw_key(
   YR_HASH_TABLE_ENTRY* entry;
   uint32_t bucket_index;
 
+  if (key_length == 0)
+    return NULL;
+
   bucket_index = hash(0, key, key_length);
 
   if (ns != NULL)

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -983,6 +983,15 @@ int yr_parser_reduce_import(
       module_name->c_string,
       compiler->current_namespace->name);
 
+  // if unable to lookup module, error
+
+  if (module_structure == NULL)
+  {
+    yr_compiler_set_error_extra_info(compiler, module_name->c_string);
+    compiler->last_result = ERROR_UNKNOWN_MODULE;
+    return compiler->last_result;
+  }
+
   // if module already imported, do nothing
 
   if (module_structure != NULL)

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -970,7 +970,7 @@ int yr_parser_reduce_import(
 
   char* name;
 
-  if (module_name->length == 0)
+  if (module_name->length == 0 || strlen(module_name->c_string) == 0)
   {
     compiler->last_result = ERROR_UNKNOWN_MODULE;
     yr_compiler_set_error_extra_info(compiler, "");
@@ -982,15 +982,6 @@ int yr_parser_reduce_import(
       compiler->objects_table,
       module_name->c_string,
       compiler->current_namespace->name);
-
-  // if unable to lookup module, error
-
-  if (module_structure == NULL)
-  {
-    yr_compiler_set_error_extra_info(compiler, module_name->c_string);
-    compiler->last_result = ERROR_UNKNOWN_MODULE;
-    return compiler->last_result;
-  }
 
   // if module already imported, do nothing
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -236,6 +236,9 @@ static void test_syntax()
 {
   assert_syntax_error(
       "rule test { strings: $a = \"a\" $a = \"a\" condition: all of them }");
+
+  assert_syntax_error(
+      "import \"\x00\" rule test { condition: false }");
 }
 
 


### PR DESCRIPTION
When attempting to import "\x00" there is a crash due to an integer underflow.
The "\x00" is passed to yr_parser_reduce_import() as a SIZED_STRING, with a
c_string member pointing to "\x00" and a length of 1. Eventually
yr_hash_table_lookup() is given the c_string pointer, which then calls strlen()
on it and passes the length (0) into yr_hash_table_lookup_raw_key(). So at this
point yr_hash_table_lookup_raw_key() is given a pointer to a string containing
"\x00" and a length of 0, which it then passes to hash() which ultimately
subtracts 1 from the 0 length and then looks that value up in the byte_to_int32
array, which is obviously bogus.

This fixes the problem by checking for a key_length of 0 in
yr_hash_table_lookup_raw_key() before attempting to hash it and returns NULL.
The NULL value is now checked for in yr_parser_reduce_import() and a compiler
error is now thrown.

I did a quick check for other places where a similar problem may pop up,
modules are especially concerning, but I haven't found any that don't look right
to me.
