### PR TITLE
Big endian fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,8 @@ case $host_os in
     darwin*) CFLAGS="$CFLAGS -I/opt/local/include" ;;
 esac
 
+AC_C_BIGENDIAN
+
 ACX_PTHREAD(
     [LIBS="$PTHREAD_LIBS $LIBS"
      CFLAGS="$CFLAGS $PTHREAD_CFLAGS"

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -88,27 +88,18 @@ typedef union _STACK_ITEM {
 
 
 #define little_endian_uint8_t(x)     (x)
-#define little_endian_uint16_t(x)    (x)
-#define little_endian_uint32_t(x)    (x)
 #define little_endian_int8_t(x)      (x)
-#define little_endian_int16_t(x)     (x)
-#define little_endian_int32_t(x)     (x)
+#define little_endian_uint16_t(x)    yr_le16toh(x)
+#define little_endian_int16_t(x)     yr_le16toh(x)
+#define little_endian_uint32_t(x)    yr_le32toh(x)
+#define little_endian_int32_t(x)     yr_le32toh(x)
 
-#define big_endian_uint8_t(x)         (x)
-
-#define big_endian_uint16_t(x) \
-    (((((uint16_t)(x) & 0xFF)) << 8) | \
-     ((((uint16_t)(x) & 0xFF00)) >> 8))
-
-#define big_endian_uint32_t(x) \
-    (((((uint32_t)(x) & 0xFF)) << 24) | \
-     ((((uint32_t)(x) & 0xFF00)) << 8) | \
-     ((((uint32_t)(x) & 0xFF0000)) >> 8) | \
-     ((((uint32_t)(x) & 0xFF000000)) >> 24))
-
-#define big_endian_int8_t(x)   big_endian_uint8_t(x)
-#define big_endian_int16_t(x)  big_endian_uint16_t(x)
-#define big_endian_int32_t(x)  big_endian_uint32_t(x)
+#define big_endian_uint8_t(x)        (x)
+#define big_endian_int8_t(x)         (x)
+#define big_endian_uint16_t(x)       yr_be16toh(x)
+#define big_endian_int16_t(x)        yr_be16toh(x)
+#define big_endian_uint32_t(x)       yr_be32toh(x)
+#define big_endian_int32_t(x)        yr_be32toh(x)
 
 
 #define function_read(type, endianess) \

--- a/libyara/exefiles.c
+++ b/libyara/exefiles.c
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/pe.h>
 #include <yara/elf.h>
 #include <yara/exec.h>
+#include <yara/utils.h>
 
 #ifndef NULL
 #define NULL 0
@@ -56,26 +57,26 @@ PIMAGE_NT_HEADERS32 yr_get_pe_header(
 
   mz_header = (PIMAGE_DOS_HEADER) buffer;
 
-  if (mz_header->e_magic != IMAGE_DOS_SIGNATURE)
+  if (yr_le16toh(mz_header->e_magic) != IMAGE_DOS_SIGNATURE)
     return NULL;
 
-  if (mz_header->e_lfanew < 0)
+  if ((int32_t)yr_le32toh(mz_header->e_lfanew) < 0)
     return NULL;
 
-  headers_size = mz_header->e_lfanew + \
+  headers_size = yr_le32toh(mz_header->e_lfanew) +  \
                  sizeof(pe_header->Signature) + \
                  sizeof(IMAGE_FILE_HEADER);
 
   if (buffer_length < headers_size)
     return NULL;
 
-  pe_header = (PIMAGE_NT_HEADERS32) (buffer + mz_header->e_lfanew);
+  pe_header = (PIMAGE_NT_HEADERS32) (buffer + yr_le32toh(mz_header->e_lfanew));
 
-  headers_size += pe_header->FileHeader.SizeOfOptionalHeader;
+  headers_size += yr_le16toh(pe_header->FileHeader.SizeOfOptionalHeader);
 
-  if (pe_header->Signature == IMAGE_NT_SIGNATURE &&
-      (pe_header->FileHeader.Machine == IMAGE_FILE_MACHINE_I386 ||
-       pe_header->FileHeader.Machine == IMAGE_FILE_MACHINE_AMD64) &&
+  if (yr_le32toh(pe_header->Signature) == IMAGE_NT_SIGNATURE &&
+      (yr_le16toh(pe_header->FileHeader.Machine) == IMAGE_FILE_MACHINE_I386 ||
+       yr_le16toh(pe_header->FileHeader.Machine) == IMAGE_FILE_MACHINE_AMD64) &&
       buffer_length > headers_size)
   {
     return pe_header;
@@ -101,16 +102,16 @@ uint64_t yr_pe_rva_to_offset(
   section_rva = 0;
   section_offset = 0;
 
-  while(i < MIN(pe_header->FileHeader.NumberOfSections, 60))
+  while(i < MIN(yr_le16toh(pe_header->FileHeader.NumberOfSections), 60))
   {
     if ((uint8_t*) section - \
         (uint8_t*) pe_header + sizeof(IMAGE_SECTION_HEADER) < buffer_length)
     {
       if (rva >= section->VirtualAddress &&
-          section_rva <= section->VirtualAddress)
+          section_rva <= yr_le32toh(section->VirtualAddress))
       {
-        section_rva = section->VirtualAddress;
-        section_offset = section->PointerToRawData;
+        section_rva = yr_le32toh(section->VirtualAddress);
+        section_offset = yr_le32toh(section->PointerToRawData);
       }
 
       section++;
@@ -137,7 +138,7 @@ int yr_get_elf_type(
 
   elf_ident = (elf_ident_t*) buffer;
 
-  if (elf_ident->magic == ELF_MAGIC)
+  if (yr_le32toh(elf_ident->magic) == ELF_MAGIC)
   {
     return elf_ident->_class;
   }
@@ -161,38 +162,38 @@ uint64_t yr_elf_rva_to_offset_32(
 
   // check to prevent integer wraps
 
-  if (ULONG_MAX - elf_header->sh_entry_count <
-      sizeof(elf32_section_header_t) * elf_header->sh_entry_count)
+  if (ULONG_MAX - yr_le16toh(elf_header->sh_entry_count) <
+      sizeof(elf32_section_header_t) * yr_le16toh(elf_header->sh_entry_count))
     return 0;
 
   // check that 'sh_offset' doesn't wrap when added to the
   // size of entries.
 
-  if (ULONG_MAX - elf_header->sh_offset <
-      sizeof(elf32_section_header_t) * elf_header->sh_entry_count)
+  if (ULONG_MAX - yr_le32toh(elf_header->sh_offset) <
+      sizeof(elf32_section_header_t) * yr_le16toh(elf_header->sh_entry_count))
     return 0;
 
-  if (elf_header->sh_offset + \
+  if (yr_le32toh(elf_header->sh_offset) + \
       sizeof(elf32_section_header_t) * \
-      elf_header->sh_entry_count > buffer_length)
+      yr_le16toh(elf_header->sh_entry_count) > buffer_length)
     return 0;
 
   section = (elf32_section_header_t*) \
-      ((unsigned char*) elf_header + elf_header->sh_offset);
+      ((unsigned char*) elf_header + yr_le32toh(elf_header->sh_offset));
 
-  for (i = 0; i < elf_header->sh_entry_count; i++)
+  for (i = 0; i < yr_le16toh(elf_header->sh_entry_count); i++)
   {
-    if (section->type != ELF_SHT_NULL &&
-        section->type != ELF_SHT_NOBITS &&
-        rva >= section->addr &&
-        rva <  section->addr + section->size)
+    if (yr_le32toh(section->type) != ELF_SHT_NULL &&
+        yr_le32toh(section->type) != ELF_SHT_NOBITS &&
+        rva >= yr_le32toh(section->addr) &&
+        rva <  yr_le32toh(section->addr) + yr_le32toh(section->size))
     {
       // prevent integer wrapping with the return value
 
-      if (ULONG_MAX - section->offset < (rva - section->addr))
+      if (ULONG_MAX - yr_le32toh(section->offset) < (rva - yr_le32toh(section->addr)))
         return 0;
       else
-        return section->offset + (rva - section->addr);
+        return yr_le32toh(section->offset) + (rva - yr_le32toh(section->addr));
     }
 
     section++;
@@ -216,26 +217,26 @@ uint64_t yr_elf_rva_to_offset_64(
 
   // check that 'sh_offset' doesn't wrap when added to the
   // size of entries.
-  if(ULONG_MAX - elf_header->sh_offset <
-     sizeof(elf64_section_header_t) * elf_header->sh_entry_count)
+  if(ULONG_MAX - yr_le64toh(elf_header->sh_offset) <
+     sizeof(elf64_section_header_t) * yr_le16toh(elf_header->sh_entry_count))
     return 0;
 
-  if (elf_header->sh_offset + \
+  if (yr_le64toh(elf_header->sh_offset) + \
       sizeof(elf64_section_header_t) * \
-      elf_header->sh_entry_count > buffer_length)
+      yr_le16toh(elf_header->sh_entry_count) > buffer_length)
     return 0;
 
   section = (elf64_section_header_t*) \
-      ((uint8_t*) elf_header + elf_header->sh_offset);
+    ((uint8_t*) elf_header + yr_le64toh(elf_header->sh_offset));
 
-  for (i = 0; i < elf_header->sh_entry_count; i++)
+  for (i = 0; i < yr_le16toh(elf_header->sh_entry_count); i++)
   {
-    if (section->type != ELF_SHT_NULL &&
-        section->type != ELF_SHT_NOBITS &&
-        rva >= section->addr &&
-        rva <  section->addr + section->size)
+    if (yr_le32toh(section->type) != ELF_SHT_NULL &&
+        yr_le32toh(section->type) != ELF_SHT_NOBITS &&
+        rva >= yr_le64toh(section->addr) &&
+        rva <  yr_le64toh(section->addr) + yr_le64toh(section->size))
     {
-      return section->offset + (rva - section->addr);
+      return yr_le64toh(section->offset) + (rva - yr_le64toh(section->addr));
     }
 
     section++;
@@ -259,7 +260,7 @@ uint64_t yr_get_entry_point_offset(
   {
     return yr_pe_rva_to_offset(
         pe_header,
-        pe_header->OptionalHeader.AddressOfEntryPoint,
+        yr_le32toh(pe_header->OptionalHeader.AddressOfEntryPoint),
         buffer_length - ((uint8_t*) pe_header - buffer));
   }
 
@@ -269,14 +270,14 @@ uint64_t yr_get_entry_point_offset(
       elf_header32 = (elf32_header_t*) buffer;
       return yr_elf_rva_to_offset_32(
           elf_header32,
-          elf_header32->entry,
+          yr_le32toh(elf_header32->entry),
           buffer_length);
 
     case ELF_CLASS_64:
       elf_header64 = (elf64_header_t*) buffer;
       return yr_elf_rva_to_offset_64(
           elf_header64,
-          elf_header64->entry,
+          yr_le64toh(elf_header64->entry),
           buffer_length);
   }
 

--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -68,18 +68,18 @@
 
 
 /* Copy the first part of user declarations.  */
-#line 17 "grammar.y" /* yacc.c:339  */
+#line 30 "grammar.y" /* yacc.c:339  */
 
 
 
 #include <assert.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <stddef.h>
 
 
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/strutils.h>
 #include <yara/compiler.h>
@@ -277,7 +277,7 @@ extern int yara_yydebug;
 
 union YYSTYPE
 {
-#line 191 "grammar.y" /* yacc.c:355  */
+#line 204 "grammar.y" /* yacc.c:355  */
 
   EXPRESSION      expression;
   SIZED_STRING*   sized_string;
@@ -606,19 +606,19 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   205,   205,   207,   208,   209,   210,   211,   216,   229,
-     238,   228,   261,   264,   292,   295,   322,   327,   328,   333,
-     334,   340,   343,   361,   374,   411,   412,   417,   433,   446,
-     459,   472,   489,   490,   496,   495,   511,   510,   526,   540,
-     541,   546,   547,   548,   549,   554,   639,   685,   743,   788,
-     789,   793,   818,   854,   900,   922,   931,   940,   955,   967,
-     981,   994,  1006,  1036,  1005,  1152,  1151,  1231,  1237,  1244,
-    1243,  1306,  1305,  1366,  1375,  1384,  1393,  1402,  1411,  1420,
-    1424,  1432,  1433,  1438,  1460,  1472,  1488,  1487,  1493,  1504,
-    1505,  1510,  1517,  1528,  1529,  1533,  1541,  1545,  1555,  1569,
-    1585,  1595,  1604,  1629,  1641,  1653,  1669,  1681,  1697,  1742,
-    1761,  1779,  1797,  1815,  1841,  1859,  1869,  1879,  1889,  1899,
-    1909,  1919
+       0,   218,   218,   220,   221,   222,   223,   224,   229,   242,
+     251,   241,   274,   277,   305,   308,   335,   340,   341,   346,
+     347,   353,   356,   374,   387,   424,   425,   430,   446,   459,
+     472,   485,   502,   503,   509,   508,   524,   523,   539,   553,
+     554,   559,   560,   561,   562,   567,   652,   698,   756,   801,
+     802,   806,   831,   867,   913,   935,   944,   953,   968,   980,
+     994,  1007,  1019,  1049,  1018,  1163,  1162,  1241,  1247,  1254,
+    1253,  1316,  1315,  1376,  1385,  1394,  1403,  1412,  1421,  1430,
+    1434,  1442,  1443,  1448,  1470,  1482,  1498,  1497,  1503,  1514,
+    1515,  1520,  1527,  1538,  1539,  1543,  1551,  1555,  1565,  1579,
+    1595,  1605,  1614,  1639,  1651,  1663,  1679,  1691,  1707,  1752,
+    1771,  1789,  1807,  1825,  1851,  1869,  1879,  1889,  1899,  1909,
+    1919,  1929
 };
 #endif
 
@@ -1333,55 +1333,55 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, void *yyscanner, Y
   switch (yytype)
     {
           case 10: /* _IDENTIFIER_  */
-#line 181 "grammar.y" /* yacc.c:1257  */
+#line 194 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1339 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 11: /* _STRING_IDENTIFIER_  */
-#line 185 "grammar.y" /* yacc.c:1257  */
+#line 198 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1345 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 12: /* _STRING_COUNT_  */
-#line 182 "grammar.y" /* yacc.c:1257  */
+#line 195 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1351 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 13: /* _STRING_OFFSET_  */
-#line 183 "grammar.y" /* yacc.c:1257  */
+#line 196 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1357 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 14: /* _STRING_LENGTH_  */
-#line 184 "grammar.y" /* yacc.c:1257  */
+#line 197 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1363 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 15: /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
-#line 186 "grammar.y" /* yacc.c:1257  */
+#line 199 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1369 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 19: /* _TEXT_STRING_  */
-#line 187 "grammar.y" /* yacc.c:1257  */
+#line 200 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1375 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 20: /* _HEX_STRING_  */
-#line 188 "grammar.y" /* yacc.c:1257  */
+#line 201 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1381 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 21: /* _REGEXP_  */
-#line 189 "grammar.y" /* yacc.c:1257  */
+#line 202 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1387 "grammar.c" /* yacc.c:1257  */
         break;
@@ -1649,7 +1649,7 @@ yyreduce:
   switch (yyn)
     {
         case 8:
-#line 217 "grammar.y" /* yacc.c:1646  */
+#line 230 "grammar.y" /* yacc.c:1646  */
     {
         int result = yr_parser_reduce_import(yyscanner, (yyvsp[0].sized_string));
 
@@ -1661,7 +1661,7 @@ yyreduce:
     break;
 
   case 9:
-#line 229 "grammar.y" /* yacc.c:1646  */
+#line 242 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = yr_parser_reduce_rule_declaration_phase_1(
             yyscanner, (int32_t) (yyvsp[-2].integer), (yyvsp[0].c_string));
@@ -1674,7 +1674,7 @@ yyreduce:
     break;
 
   case 10:
-#line 238 "grammar.y" /* yacc.c:1646  */
+#line 251 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = (yyvsp[-4].rule); // rule created in phase 1
 
@@ -1686,7 +1686,7 @@ yyreduce:
     break;
 
   case 11:
-#line 246 "grammar.y" /* yacc.c:1646  */
+#line 259 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = (yyvsp[-7].rule); // rule created in phase 1
 
@@ -1701,7 +1701,7 @@ yyreduce:
     break;
 
   case 12:
-#line 261 "grammar.y" /* yacc.c:1646  */
+#line 274 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = NULL;
       }
@@ -1709,7 +1709,7 @@ yyreduce:
     break;
 
   case 13:
-#line 265 "grammar.y" /* yacc.c:1646  */
+#line 278 "grammar.y" /* yacc.c:1646  */
     {
         // Each rule have a list of meta-data info, consisting in a
         // sequence of YR_META structures. The last YR_META structure does
@@ -1736,7 +1736,7 @@ yyreduce:
     break;
 
   case 14:
-#line 292 "grammar.y" /* yacc.c:1646  */
+#line 305 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = NULL;
       }
@@ -1744,7 +1744,7 @@ yyreduce:
     break;
 
   case 15:
-#line 296 "grammar.y" /* yacc.c:1646  */
+#line 309 "grammar.y" /* yacc.c:1646  */
     {
         // Each rule have a list of strings, consisting in a sequence
         // of YR_STRING structures. The last YR_STRING structure does not
@@ -1771,31 +1771,31 @@ yyreduce:
     break;
 
   case 17:
-#line 327 "grammar.y" /* yacc.c:1646  */
+#line 340 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = 0;  }
 #line 1777 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 328 "grammar.y" /* yacc.c:1646  */
+#line 341 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
 #line 1783 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 333 "grammar.y" /* yacc.c:1646  */
+#line 346 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = RULE_GFLAGS_PRIVATE; }
 #line 1789 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 334 "grammar.y" /* yacc.c:1646  */
+#line 347 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = RULE_GFLAGS_GLOBAL; }
 #line 1795 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 340 "grammar.y" /* yacc.c:1646  */
+#line 353 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.c_string) = NULL;
       }
@@ -1803,7 +1803,7 @@ yyreduce:
     break;
 
   case 22:
-#line 344 "grammar.y" /* yacc.c:1646  */
+#line 357 "grammar.y" /* yacc.c:1646  */
     {
         // Tags list is represented in the arena as a sequence
         // of null-terminated strings, the sequence ends with an
@@ -1821,7 +1821,7 @@ yyreduce:
     break;
 
   case 23:
-#line 362 "grammar.y" /* yacc.c:1646  */
+#line 375 "grammar.y" /* yacc.c:1646  */
     {
         char* identifier;
 
@@ -1838,7 +1838,7 @@ yyreduce:
     break;
 
   case 24:
-#line 375 "grammar.y" /* yacc.c:1646  */
+#line 388 "grammar.y" /* yacc.c:1646  */
     {
         char* tag_name = (yyvsp[-1].c_string);
         size_t tag_length = tag_name != NULL ? strlen(tag_name) : 0;
@@ -1874,19 +1874,19 @@ yyreduce:
     break;
 
   case 25:
-#line 411 "grammar.y" /* yacc.c:1646  */
+#line 424 "grammar.y" /* yacc.c:1646  */
     {  (yyval.meta) = (yyvsp[0].meta); }
 #line 1880 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 412 "grammar.y" /* yacc.c:1646  */
+#line 425 "grammar.y" /* yacc.c:1646  */
     {  (yyval.meta) = (yyvsp[-1].meta); }
 #line 1886 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 418 "grammar.y" /* yacc.c:1646  */
+#line 431 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string = (yyvsp[0].sized_string);
 
@@ -1906,7 +1906,7 @@ yyreduce:
     break;
 
   case 28:
-#line 434 "grammar.y" /* yacc.c:1646  */
+#line 447 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1923,7 +1923,7 @@ yyreduce:
     break;
 
   case 29:
-#line 447 "grammar.y" /* yacc.c:1646  */
+#line 460 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1940,7 +1940,7 @@ yyreduce:
     break;
 
   case 30:
-#line 460 "grammar.y" /* yacc.c:1646  */
+#line 473 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1957,7 +1957,7 @@ yyreduce:
     break;
 
   case 31:
-#line 473 "grammar.y" /* yacc.c:1646  */
+#line 486 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1974,19 +1974,19 @@ yyreduce:
     break;
 
   case 32:
-#line 489 "grammar.y" /* yacc.c:1646  */
+#line 502 "grammar.y" /* yacc.c:1646  */
     { (yyval.string) = (yyvsp[0].string); }
 #line 1980 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 490 "grammar.y" /* yacc.c:1646  */
+#line 503 "grammar.y" /* yacc.c:1646  */
     { (yyval.string) = (yyvsp[-1].string); }
 #line 1986 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 496 "grammar.y" /* yacc.c:1646  */
+#line 509 "grammar.y" /* yacc.c:1646  */
     {
         compiler->error_line = yyget_lineno(yyscanner);
       }
@@ -1994,7 +1994,7 @@ yyreduce:
     break;
 
   case 35:
-#line 500 "grammar.y" /* yacc.c:1646  */
+#line 513 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, (int32_t) (yyvsp[0].integer), (yyvsp[-4].c_string), (yyvsp[-1].sized_string));
@@ -2009,7 +2009,7 @@ yyreduce:
     break;
 
   case 36:
-#line 511 "grammar.y" /* yacc.c:1646  */
+#line 524 "grammar.y" /* yacc.c:1646  */
     {
         compiler->error_line = yyget_lineno(yyscanner);
       }
@@ -2017,7 +2017,7 @@ yyreduce:
     break;
 
   case 37:
-#line 515 "grammar.y" /* yacc.c:1646  */
+#line 528 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, (int32_t) (yyvsp[0].integer) | STRING_GFLAGS_REGEXP, (yyvsp[-4].c_string), (yyvsp[-1].sized_string));
@@ -2033,7 +2033,7 @@ yyreduce:
     break;
 
   case 38:
-#line 527 "grammar.y" /* yacc.c:1646  */
+#line 540 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, STRING_GFLAGS_HEXADECIMAL, (yyvsp[-2].c_string), (yyvsp[0].sized_string));
@@ -2047,43 +2047,43 @@ yyreduce:
     break;
 
   case 39:
-#line 540 "grammar.y" /* yacc.c:1646  */
+#line 553 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = 0; }
 #line 2053 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 541 "grammar.y" /* yacc.c:1646  */
+#line 554 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
 #line 2059 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 546 "grammar.y" /* yacc.c:1646  */
+#line 559 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_WIDE; }
 #line 2065 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 547 "grammar.y" /* yacc.c:1646  */
+#line 560 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_ASCII; }
 #line 2071 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 548 "grammar.y" /* yacc.c:1646  */
+#line 561 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_NO_CASE; }
 #line 2077 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 549 "grammar.y" /* yacc.c:1646  */
+#line 562 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_FULL_WORD; }
 #line 2083 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 555 "grammar.y" /* yacc.c:1646  */
+#line 568 "grammar.y" /* yacc.c:1646  */
     {
         int var_index = yr_parser_lookup_loop_variable(yyscanner, (yyvsp[0].c_string));
 
@@ -2128,7 +2128,7 @@ yyreduce:
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_OBJ_LOAD,
-                  PTR_TO_INT64(id),
+                  id,
                   NULL,
                   NULL);
 
@@ -2148,7 +2148,7 @@ yyreduce:
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_PUSH_RULE,
-                  PTR_TO_INT64(rule),
+                  rule,
                   NULL,
                   NULL);
 
@@ -2172,7 +2172,7 @@ yyreduce:
     break;
 
   case 46:
-#line 640 "grammar.y" /* yacc.c:1646  */
+#line 653 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT* field = NULL;
 
@@ -2192,7 +2192,7 @@ yyreduce:
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_OBJ_FIELD,
-                  PTR_TO_INT64(ident),
+                  ident,
                   NULL,
                   NULL);
 
@@ -2222,7 +2222,7 @@ yyreduce:
     break;
 
   case 47:
-#line 686 "grammar.y" /* yacc.c:1646  */
+#line 699 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT_ARRAY* array;
         YR_OBJECT_DICTIONARY* dict;
@@ -2283,7 +2283,7 @@ yyreduce:
     break;
 
   case 48:
-#line 744 "grammar.y" /* yacc.c:1646  */
+#line 757 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT_FUNCTION* function;
         char* args_fmt;
@@ -2302,7 +2302,7 @@ yyreduce:
             compiler->last_result = yr_parser_emit_with_arg_reloc(
                 yyscanner,
                 OP_CALL,
-                PTR_TO_INT64(args_fmt),
+                args_fmt,
                 NULL,
                 NULL);
 
@@ -2328,19 +2328,19 @@ yyreduce:
     break;
 
   case 49:
-#line 788 "grammar.y" /* yacc.c:1646  */
+#line 801 "grammar.y" /* yacc.c:1646  */
     { (yyval.c_string) = yr_strdup(""); }
 #line 2334 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 789 "grammar.y" /* yacc.c:1646  */
+#line 802 "grammar.y" /* yacc.c:1646  */
     { (yyval.c_string) = (yyvsp[0].c_string); }
 #line 2340 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 794 "grammar.y" /* yacc.c:1646  */
+#line 807 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.c_string) = (char*) yr_malloc(MAX_FUNCTION_ARGS + 1);
 
@@ -2369,7 +2369,7 @@ yyreduce:
     break;
 
   case 52:
-#line 819 "grammar.y" /* yacc.c:1646  */
+#line 832 "grammar.y" /* yacc.c:1646  */
     {
         if (strlen((yyvsp[-2].c_string)) == MAX_FUNCTION_ARGS)
         {
@@ -2405,7 +2405,7 @@ yyreduce:
     break;
 
   case 53:
-#line 855 "grammar.y" /* yacc.c:1646  */
+#line 868 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string = (yyvsp[0].sized_string);
         RE* re;
@@ -2437,7 +2437,7 @@ yyreduce:
           compiler->last_result = yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_PUSH,
-              PTR_TO_INT64(re->root_node->forward_code),
+              re->root_node->forward_code,
               NULL,
               NULL);
 
@@ -2451,7 +2451,7 @@ yyreduce:
     break;
 
   case 54:
-#line 901 "grammar.y" /* yacc.c:1646  */
+#line 914 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_STRING)
         {
@@ -2474,7 +2474,7 @@ yyreduce:
     break;
 
   case 55:
-#line 923 "grammar.y" /* yacc.c:1646  */
+#line 936 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -2487,7 +2487,7 @@ yyreduce:
     break;
 
   case 56:
-#line 932 "grammar.y" /* yacc.c:1646  */
+#line 945 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 0, NULL, NULL);
@@ -2500,7 +2500,7 @@ yyreduce:
     break;
 
   case 57:
-#line 941 "grammar.y" /* yacc.c:1646  */
+#line 954 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "matches");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_REGEXP, "matches");
@@ -2519,7 +2519,7 @@ yyreduce:
     break;
 
   case 58:
-#line 956 "grammar.y" /* yacc.c:1646  */
+#line 969 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "contains");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_STRING, "contains");
@@ -2535,7 +2535,7 @@ yyreduce:
     break;
 
   case 59:
-#line 968 "grammar.y" /* yacc.c:1646  */
+#line 981 "grammar.y" /* yacc.c:1646  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner,
@@ -2553,7 +2553,7 @@ yyreduce:
     break;
 
   case 60:
-#line 982 "grammar.y" /* yacc.c:1646  */
+#line 995 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "at");
 
@@ -2570,7 +2570,7 @@ yyreduce:
     break;
 
   case 61:
-#line 995 "grammar.y" /* yacc.c:1646  */
+#line 1008 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-2].c_string), OP_FOUND_IN, UNDEFINED);
@@ -2585,7 +2585,7 @@ yyreduce:
     break;
 
   case 62:
-#line 1006 "grammar.y" /* yacc.c:1646  */
+#line 1019 "grammar.y" /* yacc.c:1646  */
     {
         int var_index;
 
@@ -2619,7 +2619,7 @@ yyreduce:
     break;
 
   case 63:
-#line 1036 "grammar.y" /* yacc.c:1646  */
+#line 1049 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2658,7 +2658,7 @@ yyreduce:
     break;
 
   case 64:
-#line 1071 "grammar.y" /* yacc.c:1646  */
+#line 1084 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2684,8 +2684,7 @@ yyreduce:
           yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_JNUNDEF,
-              PTR_TO_INT64(
-                  compiler->loop_address[compiler->loop_depth]),
+              compiler->loop_address[compiler->loop_depth],
               NULL,
               NULL);
         }
@@ -2708,8 +2707,7 @@ yyreduce:
           yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_JLE,
-              PTR_TO_INT64(
-                compiler->loop_address[compiler->loop_depth]),
+              compiler->loop_address[compiler->loop_depth],
               NULL,
               NULL);
 
@@ -2739,11 +2737,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2743 "grammar.c" /* yacc.c:1646  */
+#line 2741 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 1152 "grammar.y" /* yacc.c:1646  */
+#line 1163 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2773,11 +2771,11 @@ yyreduce:
         compiler->loop_identifier[compiler->loop_depth] = NULL;
         compiler->loop_depth++;
       }
-#line 2777 "grammar.c" /* yacc.c:1646  */
+#line 2775 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 1182 "grammar.y" /* yacc.c:1646  */
+#line 1193 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2802,8 +2800,7 @@ yyreduce:
         yr_parser_emit_with_arg_reloc(
             yyscanner,
             OP_JNUNDEF,
-            PTR_TO_INT64(
-                compiler->loop_address[compiler->loop_depth]),
+            compiler->loop_address[compiler->loop_depth],
             NULL,
             NULL);
 
@@ -2827,34 +2824,34 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
 
       }
-#line 2831 "grammar.c" /* yacc.c:1646  */
+#line 2828 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 1232 "grammar.y" /* yacc.c:1646  */
+#line 1242 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_OF, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2841 "grammar.c" /* yacc.c:1646  */
+#line 2838 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 1238 "grammar.y" /* yacc.c:1646  */
+#line 1248 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_NOT, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2851 "grammar.c" /* yacc.c:1646  */
+#line 2848 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 1244 "grammar.y" /* yacc.c:1646  */
+#line 1254 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
-        int64_t* jmp_destination_addr;
+        void* jmp_destination_addr;
 
         compiler->last_result = yr_parser_emit_with_arg_reloc(
             yyscanner,
@@ -2877,11 +2874,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2881 "grammar.c" /* yacc.c:1646  */
+#line 2878 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 1270 "grammar.y" /* yacc.c:1646  */
+#line 1280 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* and_addr;
@@ -2910,21 +2907,21 @@ yyreduce:
         // page, so we can compute the address for the opcode following the AND
         // by simply adding one to its address.
 
-        *(fixup->address) = PTR_TO_INT64(and_addr + 1);
+        *(void**)(fixup->address) = (void*)(and_addr + 1);
 
         compiler->fixup_stack_head = fixup->next;
         yr_free(fixup);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2921 "grammar.c" /* yacc.c:1646  */
+#line 2918 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 1306 "grammar.y" /* yacc.c:1646  */
+#line 1316 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
-        int64_t* jmp_destination_addr;
+        void* jmp_destination_addr;
 
         compiler->last_result = yr_parser_emit_with_arg_reloc(
             yyscanner,
@@ -2946,11 +2943,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2950 "grammar.c" /* yacc.c:1646  */
+#line 2947 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 1331 "grammar.y" /* yacc.c:1646  */
+#line 1341 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* or_addr;
@@ -2979,18 +2976,18 @@ yyreduce:
         // page, so we can compute the address for the opcode following the OR
         // by simply adding one to its address.
 
-        *(fixup->address) = PTR_TO_INT64(or_addr + 1);
+        *(void**)(fixup->address) = (void*)(or_addr + 1);
 
         compiler->fixup_stack_head = fixup->next;
         yr_free(fixup);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2990 "grammar.c" /* yacc.c:1646  */
+#line 2987 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 1367 "grammar.y" /* yacc.c:1646  */
+#line 1377 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -2999,11 +2996,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3003 "grammar.c" /* yacc.c:1646  */
+#line 3000 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 1376 "grammar.y" /* yacc.c:1646  */
+#line 1386 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3012,11 +3009,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3016 "grammar.c" /* yacc.c:1646  */
+#line 3013 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 1385 "grammar.y" /* yacc.c:1646  */
+#line 1395 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3025,11 +3022,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3029 "grammar.c" /* yacc.c:1646  */
+#line 3026 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 1394 "grammar.y" /* yacc.c:1646  */
+#line 1404 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3038,11 +3035,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3042 "grammar.c" /* yacc.c:1646  */
+#line 3039 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 1403 "grammar.y" /* yacc.c:1646  */
+#line 1413 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "==", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3051,11 +3048,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3055 "grammar.c" /* yacc.c:1646  */
+#line 3052 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 1412 "grammar.y" /* yacc.c:1646  */
+#line 1422 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "!=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3064,39 +3061,39 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3068 "grammar.c" /* yacc.c:1646  */
+#line 3065 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 1421 "grammar.y" /* yacc.c:1646  */
+#line 1431 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3076 "grammar.c" /* yacc.c:1646  */
+#line 3073 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 1425 "grammar.y" /* yacc.c:1646  */
+#line 1435 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[-1].expression);
       }
-#line 3084 "grammar.c" /* yacc.c:1646  */
+#line 3081 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 1432 "grammar.y" /* yacc.c:1646  */
+#line 1442 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = INTEGER_SET_ENUMERATION; }
-#line 3090 "grammar.c" /* yacc.c:1646  */
+#line 3087 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 1433 "grammar.y" /* yacc.c:1646  */
+#line 1443 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = INTEGER_SET_RANGE; }
-#line 3096 "grammar.c" /* yacc.c:1646  */
+#line 3093 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 1439 "grammar.y" /* yacc.c:1646  */
+#line 1449 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[-3].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3114,11 +3111,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3118 "grammar.c" /* yacc.c:1646  */
+#line 3115 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 1461 "grammar.y" /* yacc.c:1646  */
+#line 1471 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3130,11 +3127,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3134 "grammar.c" /* yacc.c:1646  */
+#line 3131 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 1473 "grammar.y" /* yacc.c:1646  */
+#line 1483 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3145,77 +3142,77 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3149 "grammar.c" /* yacc.c:1646  */
+#line 3146 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 1488 "grammar.y" /* yacc.c:1646  */
+#line 1498 "grammar.y" /* yacc.c:1646  */
     {
         // Push end-of-list marker
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
-#line 3158 "grammar.c" /* yacc.c:1646  */
+#line 3155 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 1494 "grammar.y" /* yacc.c:1646  */
+#line 1504 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
         yr_parser_emit_pushes_for_strings(yyscanner, "$*");
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3169 "grammar.c" /* yacc.c:1646  */
+#line 3166 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 1511 "grammar.y" /* yacc.c:1646  */
+#line 1521 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
         yr_free((yyvsp[0].c_string));
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3180 "grammar.c" /* yacc.c:1646  */
+#line 3177 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 1518 "grammar.y" /* yacc.c:1646  */
+#line 1528 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
         yr_free((yyvsp[0].c_string));
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3191 "grammar.c" /* yacc.c:1646  */
+#line 3188 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 1530 "grammar.y" /* yacc.c:1646  */
+#line 1540 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
-#line 3199 "grammar.c" /* yacc.c:1646  */
+#line 3196 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 1534 "grammar.y" /* yacc.c:1646  */
+#line 1544 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL, NULL);
       }
-#line 3207 "grammar.c" /* yacc.c:1646  */
+#line 3204 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 1542 "grammar.y" /* yacc.c:1646  */
+#line 1552 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[-1].expression);
       }
-#line 3215 "grammar.c" /* yacc.c:1646  */
+#line 3212 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 1546 "grammar.y" /* yacc.c:1646  */
+#line 1556 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit(
             yyscanner, OP_FILESIZE, NULL);
@@ -3225,11 +3222,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3229 "grammar.c" /* yacc.c:1646  */
+#line 3226 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 1556 "grammar.y" /* yacc.c:1646  */
+#line 1566 "grammar.y" /* yacc.c:1646  */
     {
         yywarning(yyscanner,
             "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" "
@@ -3243,11 +3240,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3247 "grammar.c" /* yacc.c:1646  */
+#line 3244 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 1570 "grammar.y" /* yacc.c:1646  */
+#line 1580 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-1].expression), EXPRESSION_TYPE_INTEGER, "intXXXX or uintXXXX");
 
@@ -3263,11 +3260,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3267 "grammar.c" /* yacc.c:1646  */
+#line 3264 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 1586 "grammar.y" /* yacc.c:1646  */
+#line 1596 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, (yyvsp[0].integer), NULL, NULL);
@@ -3277,11 +3274,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = (yyvsp[0].integer);
       }
-#line 3281 "grammar.c" /* yacc.c:1646  */
+#line 3278 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 1596 "grammar.y" /* yacc.c:1646  */
+#line 1606 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg_double(
             yyscanner, OP_PUSH, (yyvsp[0].double_), NULL, NULL);
@@ -3290,11 +3287,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
       }
-#line 3294 "grammar.c" /* yacc.c:1646  */
+#line 3291 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 1605 "grammar.y" /* yacc.c:1646  */
+#line 1615 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string;
 
@@ -3310,7 +3307,7 @@ yyreduce:
           compiler->last_result = yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_PUSH,
-              PTR_TO_INT64(sized_string),
+              sized_string,
               NULL,
               NULL);
 
@@ -3319,11 +3316,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_STRING;
         (yyval.expression).value.sized_string = sized_string;
       }
-#line 3323 "grammar.c" /* yacc.c:1646  */
+#line 3320 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 1630 "grammar.y" /* yacc.c:1646  */
+#line 1640 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[0].c_string), OP_COUNT, UNDEFINED);
@@ -3335,11 +3332,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3339 "grammar.c" /* yacc.c:1646  */
+#line 3336 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 1642 "grammar.y" /* yacc.c:1646  */
+#line 1652 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_OFFSET, UNDEFINED);
@@ -3351,11 +3348,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3355 "grammar.c" /* yacc.c:1646  */
+#line 3352 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 1654 "grammar.y" /* yacc.c:1646  */
+#line 1664 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3371,11 +3368,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3375 "grammar.c" /* yacc.c:1646  */
+#line 3372 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 1670 "grammar.y" /* yacc.c:1646  */
+#line 1680 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_LENGTH, UNDEFINED);
@@ -3387,11 +3384,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3391 "grammar.c" /* yacc.c:1646  */
+#line 3388 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 1682 "grammar.y" /* yacc.c:1646  */
+#line 1692 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3407,11 +3404,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3411 "grammar.c" /* yacc.c:1646  */
+#line 3408 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 1698 "grammar.y" /* yacc.c:1646  */
+#line 1708 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_INTEGER)  // loop identifier
         {
@@ -3456,11 +3453,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3460 "grammar.c" /* yacc.c:1646  */
+#line 3457 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 1743 "grammar.y" /* yacc.c:1646  */
+#line 1753 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER | EXPRESSION_TYPE_FLOAT, "-");
 
@@ -3479,11 +3476,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3483 "grammar.c" /* yacc.c:1646  */
+#line 3480 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 1762 "grammar.y" /* yacc.c:1646  */
+#line 1772 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "+", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3501,11 +3498,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3505 "grammar.c" /* yacc.c:1646  */
+#line 3502 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 1780 "grammar.y" /* yacc.c:1646  */
+#line 1790 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "-", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3523,11 +3520,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3527 "grammar.c" /* yacc.c:1646  */
+#line 3524 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 1798 "grammar.y" /* yacc.c:1646  */
+#line 1808 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "*", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3545,11 +3542,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3549 "grammar.c" /* yacc.c:1646  */
+#line 3546 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 1816 "grammar.y" /* yacc.c:1646  */
+#line 1826 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "\\", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3575,11 +3572,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3579 "grammar.c" /* yacc.c:1646  */
+#line 3576 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 1842 "grammar.y" /* yacc.c:1646  */
+#line 1852 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "%");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "%");
@@ -3597,11 +3594,11 @@ yyreduce:
           ERROR_IF(compiler->last_result != ERROR_SUCCESS);
         }
       }
-#line 3601 "grammar.c" /* yacc.c:1646  */
+#line 3598 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 1860 "grammar.y" /* yacc.c:1646  */
+#line 1870 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3611,11 +3608,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(^, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3615 "grammar.c" /* yacc.c:1646  */
+#line 3612 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 1870 "grammar.y" /* yacc.c:1646  */
+#line 1880 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3625,11 +3622,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(&, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3629 "grammar.c" /* yacc.c:1646  */
+#line 3626 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1880 "grammar.y" /* yacc.c:1646  */
+#line 1890 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "|");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "|");
@@ -3639,11 +3636,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(|, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3643 "grammar.c" /* yacc.c:1646  */
+#line 3640 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 1890 "grammar.y" /* yacc.c:1646  */
+#line 1900 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "~");
 
@@ -3653,11 +3650,11 @@ yyreduce:
         (yyval.expression).value.integer = ((yyvsp[0].expression).value.integer == UNDEFINED) ?
             UNDEFINED : ~((yyvsp[0].expression).value.integer);
       }
-#line 3657 "grammar.c" /* yacc.c:1646  */
+#line 3654 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1900 "grammar.y" /* yacc.c:1646  */
+#line 1910 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "<<");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "<<");
@@ -3667,11 +3664,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(<<, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3671 "grammar.c" /* yacc.c:1646  */
+#line 3668 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1910 "grammar.y" /* yacc.c:1646  */
+#line 1920 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, ">>");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, ">>");
@@ -3681,19 +3678,19 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(>>, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3685 "grammar.c" /* yacc.c:1646  */
+#line 3682 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1920 "grammar.y" /* yacc.c:1646  */
+#line 1930 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3693 "grammar.c" /* yacc.c:1646  */
+#line 3690 "grammar.c" /* yacc.c:1646  */
     break;
 
 
-#line 3697 "grammar.c" /* yacc.c:1646  */
+#line 3694 "grammar.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3921,5 +3918,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1925 "grammar.y" /* yacc.c:1906  */
+#line 1935 "grammar.y" /* yacc.c:1906  */
 

--- a/libyara/grammar.h
+++ b/libyara/grammar.h
@@ -152,7 +152,7 @@ extern int yara_yydebug;
 
 union YYSTYPE
 {
-#line 191 "grammar.y" /* yacc.c:1909  */
+#line 204 "grammar.y" /* yacc.c:1909  */
 
   EXPRESSION      expression;
   SIZED_STRING*   sized_string;

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -609,7 +609,7 @@ identifier
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_OBJ_LOAD,
-                  PTR_TO_INT64(id),
+                  id,
                   NULL,
                   NULL);
 
@@ -629,7 +629,7 @@ identifier
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_PUSH_RULE,
-                  PTR_TO_INT64(rule),
+                  rule,
                   NULL,
                   NULL);
 
@@ -669,7 +669,7 @@ identifier
               compiler->last_result = yr_parser_emit_with_arg_reloc(
                   yyscanner,
                   OP_OBJ_FIELD,
-                  PTR_TO_INT64(ident),
+                  ident,
                   NULL,
                   NULL);
 
@@ -772,7 +772,7 @@ identifier
             compiler->last_result = yr_parser_emit_with_arg_reloc(
                 yyscanner,
                 OP_CALL,
-                PTR_TO_INT64(args_fmt),
+                args_fmt,
                 NULL,
                 NULL);
 
@@ -896,7 +896,7 @@ regexp
           compiler->last_result = yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_PUSH,
-              PTR_TO_INT64(re->root_node->forward_code),
+              re->root_node->forward_code,
               NULL,
               NULL);
 
@@ -1106,8 +1106,7 @@ expression
           yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_JNUNDEF,
-              PTR_TO_INT64(
-                  compiler->loop_address[compiler->loop_depth]),
+              compiler->loop_address[compiler->loop_depth],
               NULL,
               NULL);
         }
@@ -1130,8 +1129,7 @@ expression
           yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_JLE,
-              PTR_TO_INT64(
-                compiler->loop_address[compiler->loop_depth]),
+              compiler->loop_address[compiler->loop_depth],
               NULL,
               NULL);
 
@@ -1216,8 +1214,7 @@ expression
         yr_parser_emit_with_arg_reloc(
             yyscanner,
             OP_JNUNDEF,
-            PTR_TO_INT64(
-                compiler->loop_address[compiler->loop_depth]),
+            compiler->loop_address[compiler->loop_depth],
             NULL,
             NULL);
 
@@ -1256,7 +1253,7 @@ expression
     | boolean_expression _AND_
       {
         YR_FIXUP* fixup;
-        int64_t* jmp_destination_addr;
+        void* jmp_destination_addr;
 
         compiler->last_result = yr_parser_emit_with_arg_reloc(
             yyscanner,
@@ -1308,7 +1305,7 @@ expression
         // page, so we can compute the address for the opcode following the AND
         // by simply adding one to its address.
 
-        *(fixup->address) = PTR_TO_INT64(and_addr + 1);
+        *(void**)(fixup->address) = (void*)(and_addr + 1);
 
         compiler->fixup_stack_head = fixup->next;
         yr_free(fixup);
@@ -1318,7 +1315,7 @@ expression
     | boolean_expression _OR_
       {
         YR_FIXUP* fixup;
-        int64_t* jmp_destination_addr;
+        void* jmp_destination_addr;
 
         compiler->last_result = yr_parser_emit_with_arg_reloc(
             yyscanner,
@@ -1369,7 +1366,7 @@ expression
         // page, so we can compute the address for the opcode following the OR
         // by simply adding one to its address.
 
-        *(fixup->address) = PTR_TO_INT64(or_addr + 1);
+        *(void**)(fixup->address) = (void*)(or_addr + 1);
 
         compiler->fixup_stack_head = fixup->next;
         yr_free(fixup);
@@ -1630,7 +1627,7 @@ primary_expression
           compiler->last_result = yr_parser_emit_with_arg_reloc(
               yyscanner,
               OP_PUSH,
-              PTR_TO_INT64(sized_string),
+              sized_string,
               NULL,
               NULL);
 

--- a/libyara/hex_grammar.c
+++ b/libyara/hex_grammar.c
@@ -68,13 +68,13 @@
 
 
 /* Copy the first part of user declarations.  */
-#line 17 "hex_grammar.y" /* yacc.c:339  */
+#line 30 "hex_grammar.y" /* yacc.c:339  */
 
 
 #include <string.h>
-#include <stdint.h>
 #include <limits.h>
 
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/hex_lexer.h>
 #include <yara/limits.h>
@@ -157,7 +157,7 @@ extern int hex_yydebug;
 
 union YYSTYPE
 {
-#line 65 "hex_grammar.y" /* yacc.c:355  */
+#line 78 "hex_grammar.y" /* yacc.c:355  */
 
   int64_t integer;
   RE_NODE *re_node;
@@ -476,9 +476,9 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    92,    92,   101,   105,   114,   176,   180,   193,   197,
-     206,   220,   219,   232,   261,   299,   327,   353,   357,   371,
-     379
+       0,   105,   105,   114,   118,   127,   189,   193,   206,   210,
+     219,   233,   232,   245,   274,   312,   340,   366,   370,   384,
+     392
 };
 #endif
 
@@ -1017,43 +1017,43 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, void *yyscanner, H
   switch (yytype)
     {
           case 16: /* tokens  */
-#line 81 "hex_grammar.y" /* yacc.c:1257  */
+#line 94 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1023 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 17: /* token_sequence  */
-#line 82 "hex_grammar.y" /* yacc.c:1257  */
+#line 95 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1029 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 18: /* token_or_range  */
-#line 83 "hex_grammar.y" /* yacc.c:1257  */
+#line 96 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1035 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 19: /* token  */
-#line 84 "hex_grammar.y" /* yacc.c:1257  */
+#line 97 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1041 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 21: /* range  */
-#line 87 "hex_grammar.y" /* yacc.c:1257  */
+#line 100 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1047 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 22: /* alternatives  */
-#line 86 "hex_grammar.y" /* yacc.c:1257  */
+#line 99 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1053 "hex_grammar.c" /* yacc.c:1257  */
         break;
 
     case 23: /* byte  */
-#line 85 "hex_grammar.y" /* yacc.c:1257  */
+#line 98 "hex_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
 #line 1059 "hex_grammar.c" /* yacc.c:1257  */
         break;
@@ -1321,7 +1321,7 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 93 "hex_grammar.y" /* yacc.c:1646  */
+#line 106 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->root_node = (yyvsp[-1].re_node);
@@ -1330,7 +1330,7 @@ yyreduce:
     break;
 
   case 3:
-#line 102 "hex_grammar.y" /* yacc.c:1646  */
+#line 115 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
@@ -1338,7 +1338,7 @@ yyreduce:
     break;
 
   case 4:
-#line 106 "hex_grammar.y" /* yacc.c:1646  */
+#line 119 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_CONCAT, (yyvsp[-1].re_node), (yyvsp[0].re_node));
 
@@ -1351,7 +1351,7 @@ yyreduce:
     break;
 
   case 5:
-#line 115 "hex_grammar.y" /* yacc.c:1646  */
+#line 128 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* new_concat;
         RE_NODE* leftmost_concat = NULL;
@@ -1413,7 +1413,7 @@ yyreduce:
     break;
 
   case 6:
-#line 177 "hex_grammar.y" /* yacc.c:1646  */
+#line 190 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
@@ -1421,7 +1421,7 @@ yyreduce:
     break;
 
   case 7:
-#line 181 "hex_grammar.y" /* yacc.c:1646  */
+#line 194 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_CONCAT, (yyvsp[-1].re_node), (yyvsp[0].re_node));
 
@@ -1434,7 +1434,7 @@ yyreduce:
     break;
 
   case 8:
-#line 194 "hex_grammar.y" /* yacc.c:1646  */
+#line 207 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
@@ -1442,7 +1442,7 @@ yyreduce:
     break;
 
   case 9:
-#line 198 "hex_grammar.y" /* yacc.c:1646  */
+#line 211 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
         (yyval.re_node)->greedy = FALSE;
@@ -1451,7 +1451,7 @@ yyreduce:
     break;
 
   case 10:
-#line 207 "hex_grammar.y" /* yacc.c:1646  */
+#line 220 "hex_grammar.y" /* yacc.c:1646  */
     {
         lex_env->token_count++;
 
@@ -1468,7 +1468,7 @@ yyreduce:
     break;
 
   case 11:
-#line 220 "hex_grammar.y" /* yacc.c:1646  */
+#line 233 "hex_grammar.y" /* yacc.c:1646  */
     {
         lex_env->inside_or++;
       }
@@ -1476,7 +1476,7 @@ yyreduce:
     break;
 
   case 12:
-#line 224 "hex_grammar.y" /* yacc.c:1646  */
+#line 237 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[-1].re_node);
         lex_env->inside_or--;
@@ -1485,7 +1485,7 @@ yyreduce:
     break;
 
   case 13:
-#line 233 "hex_grammar.y" /* yacc.c:1646  */
+#line 246 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* re_any;
 
@@ -1518,7 +1518,7 @@ yyreduce:
     break;
 
   case 14:
-#line 262 "hex_grammar.y" /* yacc.c:1646  */
+#line 275 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* re_any;
 
@@ -1560,7 +1560,7 @@ yyreduce:
     break;
 
   case 15:
-#line 300 "hex_grammar.y" /* yacc.c:1646  */
+#line 313 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* re_any;
 
@@ -1592,7 +1592,7 @@ yyreduce:
     break;
 
   case 16:
-#line 328 "hex_grammar.y" /* yacc.c:1646  */
+#line 341 "hex_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* re_any;
 
@@ -1618,7 +1618,7 @@ yyreduce:
     break;
 
   case 17:
-#line 354 "hex_grammar.y" /* yacc.c:1646  */
+#line 367 "hex_grammar.y" /* yacc.c:1646  */
     {
           (yyval.re_node) = (yyvsp[0].re_node);
       }
@@ -1626,7 +1626,7 @@ yyreduce:
     break;
 
   case 18:
-#line 358 "hex_grammar.y" /* yacc.c:1646  */
+#line 371 "hex_grammar.y" /* yacc.c:1646  */
     {
         mark_as_not_fast_hex_regexp();
 
@@ -1641,7 +1641,7 @@ yyreduce:
     break;
 
   case 19:
-#line 372 "hex_grammar.y" /* yacc.c:1646  */
+#line 385 "hex_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_LITERAL, NULL, NULL);
 
@@ -1653,7 +1653,7 @@ yyreduce:
     break;
 
   case 20:
-#line 380 "hex_grammar.y" /* yacc.c:1646  */
+#line 393 "hex_grammar.y" /* yacc.c:1646  */
     {
         uint8_t mask = (uint8_t) ((yyvsp[0].integer) >> 8);
 
@@ -1905,5 +1905,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 401 "hex_grammar.y" /* yacc.c:1906  */
+#line 414 "hex_grammar.y" /* yacc.c:1906  */
 

--- a/libyara/hex_grammar.h
+++ b/libyara/hex_grammar.h
@@ -60,7 +60,7 @@ extern int hex_yydebug;
 
 union YYSTYPE
 {
-#line 65 "hex_grammar.y" /* yacc.c:1909  */
+#line 78 "hex_grammar.y" /* yacc.c:1909  */
 
   int64_t integer;
   RE_NODE *re_node;

--- a/libyara/hex_lexer.c
+++ b/libyara/hex_lexer.c
@@ -9,7 +9,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 1
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -88,25 +88,13 @@ typedef unsigned int flex_uint32_t;
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
-
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
@@ -238,12 +226,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -322,7 +310,7 @@ static void hex_yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner
 
 YY_BUFFER_STATE hex_yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE hex_yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE hex_yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+YY_BUFFER_STATE hex_yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
 
 void *hex_yyalloc (yy_size_t ,yyscan_t yyscanner );
 void *hex_yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -366,17 +354,14 @@ typedef int yy_state_type;
 static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
 static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
 static int yy_get_next_buffer (yyscan_t yyscanner );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -514,7 +499,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /* Lexical analyzer for hex strings */
-#line 20 "hex_lexer.l"
+#line 33 "hex_lexer.l"
 
 /* Disable warnings for unused functions in this file.
 
@@ -557,7 +542,7 @@ with noyywrap then we can remove this pragma.
 #define YY_NO_INPUT 1
 
 
-#line 548 "hex_lexer.c"
+#line 546 "hex_lexer.c"
 
 #define INITIAL 0
 #define comment 1
@@ -588,8 +573,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -642,7 +627,7 @@ FILE *hex_yyget_out (yyscan_t yyscanner );
 
 void hex_yyset_out  (FILE * _out_str ,yyscan_t yyscanner );
 
-yy_size_t hex_yyget_leng (yyscan_t yyscanner );
+			int hex_yyget_leng (yyscan_t yyscanner );
 
 char *hex_yyget_text (yyscan_t yyscanner );
 
@@ -707,7 +692,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -731,7 +716,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -832,11 +817,11 @@ YY_DECL
 		}
 
 	{
-#line 81 "hex_lexer.l"
+#line 94 "hex_lexer.l"
 
 
 
-#line 827 "hex_lexer.c"
+#line 825 "hex_lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -866,7 +851,7 @@ yy_match:
 				if ( yy_current_state >= 35 )
 					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 34 );
@@ -903,7 +888,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 84 "hex_lexer.l"
+#line 97 "hex_lexer.l"
 {
 
   yylval->integer = xtoi(yytext);
@@ -912,7 +897,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 90 "hex_lexer.l"
+#line 103 "hex_lexer.l"
 {
 
   yytext[1] = '0'; // replace ? by 0
@@ -922,7 +907,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 97 "hex_lexer.l"
+#line 110 "hex_lexer.l"
 {
 
   yytext[0] = '0'; // replace ? by 0
@@ -932,7 +917,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 104 "hex_lexer.l"
+#line 117 "hex_lexer.l"
 {
 
   yylval->integer = 0x0000;
@@ -941,7 +926,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 110 "hex_lexer.l"
+#line 123 "hex_lexer.l"
 {
 
   BEGIN(range);
@@ -951,24 +936,24 @@ YY_RULE_SETUP
 case 6:
 /* rule 6 can match eol */
 YY_RULE_SETUP
-#line 116 "hex_lexer.l"
+#line 129 "hex_lexer.l"
 // skip comments
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 118 "hex_lexer.l"
+#line 131 "hex_lexer.l"
 // skip single-line comments
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 120 "hex_lexer.l"
+#line 133 "hex_lexer.l"
 {
   return yytext[0];
 }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 124 "hex_lexer.l"
+#line 137 "hex_lexer.l"
 {
 
   yylval->integer = atoi(yytext);
@@ -977,7 +962,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 130 "hex_lexer.l"
+#line 143 "hex_lexer.l"
 {
 
   BEGIN(INITIAL);
@@ -987,12 +972,12 @@ YY_RULE_SETUP
 case 11:
 /* rule 11 can match eol */
 YY_RULE_SETUP
-#line 136 "hex_lexer.l"
+#line 149 "hex_lexer.l"
 // skip whitespaces
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 138 "hex_lexer.l"
+#line 151 "hex_lexer.l"
 {
 
   yyerror(yyscanner, lex_env, "invalid character in hex string jump");
@@ -1002,12 +987,12 @@ YY_RULE_SETUP
 case 13:
 /* rule 13 can match eol */
 YY_RULE_SETUP
-#line 144 "hex_lexer.l"
+#line 157 "hex_lexer.l"
 // skip whitespaces
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 146 "hex_lexer.l"
+#line 159 "hex_lexer.l"
 {        // pass valid characters to the parser
 
   return yytext[0];
@@ -1015,7 +1000,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 151 "hex_lexer.l"
+#line 164 "hex_lexer.l"
 {               // reject all other characters
 
   yyerror(yyscanner, lex_env, "invalid character in hex string");
@@ -1024,10 +1009,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 157 "hex_lexer.l"
+#line 170 "hex_lexer.l"
 ECHO;
 	YY_BREAK
-#line 1018 "hex_lexer.c"
+#line 1016 "hex_lexer.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(comment):
 case YY_STATE_EOF(range):
@@ -1218,7 +1203,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1232,7 +1217,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1245,7 +1230,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1287,9 +1272,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) hex_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
@@ -1328,7 +1313,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			if ( yy_current_state >= 35 )
 				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 		}
 
 	return yy_current_state;
@@ -1357,7 +1342,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( yy_current_state >= 35 )
 			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 	yy_is_jam = (yy_current_state == 34);
 
 	(void)yyg;
@@ -1393,7 +1378,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -1417,7 +1402,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( hex_yywrap(yyscanner ) )
-						return EOF;
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -1680,7 +1665,7 @@ void hex_yypop_buffer_state (yyscan_t yyscanner)
  */
 static void hex_yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -1689,7 +1674,7 @@ static void hex_yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; // After all that talk, this was set to 1 anyways...
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)hex_yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
@@ -1736,7 +1721,7 @@ YY_BUFFER_STATE hex_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yys
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
 	b = (YY_BUFFER_STATE) hex_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
@@ -1745,7 +1730,7 @@ YY_BUFFER_STATE hex_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yys
 	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
@@ -1768,7 +1753,7 @@ YY_BUFFER_STATE hex_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yys
 YY_BUFFER_STATE hex_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
     
-	return hex_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return hex_yy_scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to hex_yylex() will
@@ -1778,7 +1763,7 @@ YY_BUFFER_STATE hex_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE hex_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE hex_yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -1786,7 +1771,7 @@ YY_BUFFER_STATE hex_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_
 	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
+	n = (yy_size_t) _yybytes_len + 2;
 	buf = (char *) hex_yyalloc(n ,yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in hex_yy_scan_bytes()" );
@@ -1812,7 +1797,7 @@ YY_BUFFER_STATE hex_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -1895,7 +1880,7 @@ FILE *hex_yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t hex_yyget_leng  (yyscan_t yyscanner)
+int hex_yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2066,10 +2051,10 @@ static int yy_init_globals (yyscan_t yyscanner)
      * This function is called from hex_yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2082,8 +2067,8 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2153,7 +2138,7 @@ void *hex_yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return (void *) malloc( size );
+	return malloc(size);
 }
 
 void *hex_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
@@ -2168,7 +2153,7 @@ void *hex_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void hex_yyfree (void * ptr , yyscan_t yyscanner)
@@ -2180,7 +2165,7 @@ void hex_yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 157 "hex_lexer.l"
+#line 170 "hex_lexer.l"
 
 
 

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -54,7 +54,7 @@ typedef void (*YR_COMPILER_CALLBACK_FUNC)(
 
 typedef struct _YR_FIXUP
 {
-  int64_t* address;
+  void* address;
   struct _YR_FIXUP* next;
 
 } YR_FIXUP;

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -272,7 +272,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #define sized_string_argument(n) \
-    ((SIZED_STRING*)(size_t)((int64_t*) __args)[n-1])
+    (*(SIZED_STRING**) &(((int64_t*) __args)[n-1]))
 
 #define string_argument(n) \
     (sized_string_argument(n)->c_string)

--- a/libyara/include/yara/parser.h
+++ b/libyara/include/yara/parser.h
@@ -59,9 +59,9 @@ int yr_parser_emit_with_arg_double(
 int yr_parser_emit_with_arg_reloc(
     yyscan_t yyscanner,
     uint8_t instruction,
-    int64_t argument,
+    void* argument,
     uint8_t** instruction_address,
-    int64_t** argument_address);
+    void** argument_address);
 
 
 int yr_parser_check_types(

--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_PE_H
 
 #include <yara/types.h>
+#include <yara/utils.h>
 
 #pragma pack(push, 1)
 
@@ -312,7 +313,7 @@ typedef struct _IMAGE_NT_HEADERS64 {
 #define IMAGE_FIRST_SECTION( ntheader ) ((PIMAGE_SECTION_HEADER) \
     ((BYTE*)ntheader + \
      FIELD_OFFSET( IMAGE_NT_HEADERS32, OptionalHeader ) + \
-     ((PIMAGE_NT_HEADERS32)(ntheader))->FileHeader.SizeOfOptionalHeader \
+     yr_le16toh(((PIMAGE_NT_HEADERS32)(ntheader))->FileHeader.SizeOfOptionalHeader) \
     ))
 
 // Subsystem Values

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -68,8 +68,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define yr_min(x, y) ((x < y) ? (x) : (y))
 #define yr_max(x, y) ((x > y) ? (x) : (y))
 
-#define PTR_TO_INT64(x)  ((int64_t) (size_t) x)
-
 
 #ifdef NDEBUG
 

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_UTILS_H
 #define YR_UTILS_H
 
+#include <config.h>
+
 #ifndef TRUE
 #define TRUE 1
 #endif
@@ -67,6 +69,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define yr_min(x, y) ((x < y) ? (x) : (y))
 #define yr_max(x, y) ((x > y) ? (x) : (y))
+
+#if defined(__GNUC__)
+#define yr_bswap16(x) __builtin_bswap16(x)
+#define yr_bswap32(x) __builtin_bswap32(x)
+#define yr_bswap64(x) __builtin_bswap64(x)
+#elif defined(_MSC_VER)
+#define yr_bswap16(x) _byteswap_ushort(x)
+#define yr_bswap32(x) _byteswap_ulong(x)
+#define yr_bswap64(x) _byteswap_uint64(x)
+#else
+#error Unknown compiler: Add yr_bswap* definitions
+#endif
+
+#if defined(WORDS_BIGENDIAN)
+#define yr_le16toh(x) yr_bswap16(x)
+#define yr_le32toh(x) yr_bswap32(x)
+#define yr_le64toh(x) yr_bswap64(x)
+#define yr_be16toh(x) (x)
+#define yr_be32toh(x) (x)
+#define yr_be64toh(x) (x)
+#else
+#define yr_le16toh(x) (x)
+#define yr_le32toh(x) (x)
+#define yr_le64toh(x) (x)
+#define yr_be16toh(x) yr_bswap16(x)
+#define yr_be32toh(x) yr_bswap32(x)
+#define yr_be64toh(x) yr_bswap64(x)
+#endif
 
 
 #ifdef NDEBUG

--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -9,7 +9,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 1
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -88,25 +88,13 @@ typedef unsigned int flex_uint32_t;
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
-
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
@@ -238,12 +226,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -322,7 +310,7 @@ static void yara_yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanne
 
 YY_BUFFER_STATE yara_yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE yara_yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yara_yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yara_yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
 
 void *yara_yyalloc (yy_size_t ,yyscan_t yyscanner );
 void *yara_yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -366,17 +354,14 @@ typedef int yy_state_type;
 static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
 static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
 static int yy_get_next_buffer (yyscan_t yyscanner );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -815,7 +800,7 @@ with noyywrap then we can remove this pragma.
 
 
 
-#line 819 "lexer.c"
+#line 804 "lexer.c"
 
 #define INITIAL 0
 #define str 1
@@ -848,8 +833,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -902,7 +887,7 @@ FILE *yara_yyget_out (yyscan_t yyscanner );
 
 void yara_yyset_out  (FILE * _out_str ,yyscan_t yyscanner );
 
-yy_size_t yara_yyget_leng (yyscan_t yyscanner );
+			int yara_yyget_leng (yyscan_t yyscanner );
 
 char *yara_yyget_text (yyscan_t yyscanner );
 
@@ -967,7 +952,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -991,7 +976,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1095,7 +1080,7 @@ YY_DECL
 #line 129 "lexer.l"
 
 
-#line 1099 "lexer.c"
+#line 1084 "lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1125,7 +1110,7 @@ yy_match:
 				if ( yy_current_state >= 243 )
 					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 242 );
@@ -1920,7 +1905,7 @@ YY_RULE_SETUP
 #line 652 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1924 "lexer.c"
+#line 1909 "lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2107,7 +2092,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2121,7 +2106,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2134,7 +2119,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2176,9 +2161,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yara_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
@@ -2217,7 +2202,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			if ( yy_current_state >= 243 )
 				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 		}
 
 	return yy_current_state;
@@ -2246,7 +2231,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( yy_current_state >= 243 )
 			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 	yy_is_jam = (yy_current_state == 242);
 
 	(void)yyg;
@@ -2282,7 +2267,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2306,7 +2291,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( yara_yywrap(yyscanner ) )
-						return EOF;
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2569,7 +2554,7 @@ void yara_yypop_buffer_state (yyscan_t yyscanner)
  */
 static void yara_yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -2578,7 +2563,7 @@ static void yara_yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; // After all that talk, this was set to 1 anyways...
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)yara_yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
@@ -2625,7 +2610,7 @@ YY_BUFFER_STATE yara_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yy
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
 	b = (YY_BUFFER_STATE) yara_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
@@ -2634,7 +2619,7 @@ YY_BUFFER_STATE yara_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yy
 	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
@@ -2657,7 +2642,7 @@ YY_BUFFER_STATE yara_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yy
 YY_BUFFER_STATE yara_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
     
-	return yara_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return yara_yy_scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yara_yylex() will
@@ -2667,7 +2652,7 @@ YY_BUFFER_STATE yara_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yara_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yara_yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2675,7 +2660,7 @@ YY_BUFFER_STATE yara_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes
 	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
+	n = (yy_size_t) _yybytes_len + 2;
 	buf = (char *) yara_yyalloc(n ,yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yara_yy_scan_bytes()" );
@@ -2701,7 +2686,7 @@ YY_BUFFER_STATE yara_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -2784,7 +2769,7 @@ FILE *yara_yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yara_yyget_leng  (yyscan_t yyscanner)
+int yara_yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2955,10 +2940,10 @@ static int yy_init_globals (yyscan_t yyscanner)
      * This function is called from yara_yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2971,8 +2956,8 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -3042,7 +3027,7 @@ void *yara_yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return (void *) malloc( size );
+	return malloc(size);
 }
 
 void *yara_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
@@ -3057,7 +3042,7 @@ void *yara_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yara_yyfree (void * ptr , yyscan_t yyscanner)

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -111,11 +111,13 @@ int yr_parser_emit_with_arg(
 int yr_parser_emit_with_arg_reloc(
     yyscan_t yyscanner,
     uint8_t instruction,
-    int64_t argument,
+    void* argument,
     uint8_t** instruction_address,
-    int64_t** argument_address)
+    void** argument_address)
 {
   int64_t* ptr = NULL;
+  DECLARE_REFERENCE(void*, argument) a;
+  a.argument = argument;
 
   int result = yr_arena_write_data(
       yyget_extra(yyscanner)->code_arena,
@@ -126,7 +128,7 @@ int yr_parser_emit_with_arg_reloc(
   if (result == ERROR_SUCCESS)
     result = yr_arena_write_data(
         yyget_extra(yyscanner)->code_arena,
-        &argument,
+        &a,
         sizeof(int64_t),
         (void**) &ptr);
 
@@ -138,7 +140,7 @@ int yr_parser_emit_with_arg_reloc(
         EOL);
 
   if (argument_address != NULL)
-    *argument_address = ptr;
+    *argument_address = (void*)ptr;
 
   return result;
 }
@@ -180,7 +182,7 @@ int yr_parser_emit_pushes_for_strings(
         yr_parser_emit_with_arg_reloc(
             yyscanner,
             OP_PUSH,
-            PTR_TO_INT64(string),
+            string,
             NULL,
             NULL);
 
@@ -747,7 +749,7 @@ YR_RULE* yr_parser_reduce_rule_declaration_phase_1(
   compiler->last_result = yr_parser_emit_with_arg_reloc(
       yyscanner,
       OP_INIT_RULE,
-      PTR_TO_INT64(rule),
+      rule,
       NULL,
       NULL);
 
@@ -798,7 +800,7 @@ int yr_parser_reduce_rule_declaration_phase_2(
   compiler->last_result = yr_parser_emit_with_arg_reloc(
       yyscanner,
       OP_MATCH_RULE,
-      PTR_TO_INT64(rule),
+      rule,
       NULL,
       NULL);
 
@@ -875,7 +877,7 @@ int yr_parser_reduce_string_identifier(
       yr_parser_emit_with_arg_reloc(
           yyscanner,
           OP_PUSH,
-          PTR_TO_INT64(string),
+          string,
           NULL,
           NULL);
 
@@ -1021,7 +1023,7 @@ int yr_parser_reduce_import(
     compiler->last_result = yr_parser_emit_with_arg_reloc(
         yyscanner,
         OP_IMPORT,
-        PTR_TO_INT64(name),
+        name,
         NULL,
         NULL);
 

--- a/libyara/re_grammar.c
+++ b/libyara/re_grammar.c
@@ -68,11 +68,10 @@
 
 
 /* Copy the first part of user declarations.  */
-#line 17 "re_grammar.y" /* yacc.c:339  */
+#line 30 "re_grammar.y" /* yacc.c:339  */
 
 
-#include <stdint.h>
-
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/error.h>
 #include <yara/limits.h>
@@ -100,7 +99,7 @@
     } \
 
 
-#line 104 "re_grammar.c" /* yacc.c:339  */
+#line 103 "re_grammar.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -168,14 +167,14 @@ extern int re_yydebug;
 
 union YYSTYPE
 {
-#line 58 "re_grammar.y" /* yacc.c:355  */
+#line 70 "re_grammar.y" /* yacc.c:355  */
 
   int integer;
   uint32_t range;
   RE_NODE* re_node;
   uint8_t* class_vector;
 
-#line 179 "re_grammar.c" /* yacc.c:355  */
+#line 178 "re_grammar.c" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -191,7 +190,7 @@ int re_yyparse (void *yyscanner, RE_LEX_ENVIRONMENT *lex_env);
 
 /* Copy the second part of user declarations.  */
 
-#line 195 "re_grammar.c" /* yacc.c:358  */
+#line 194 "re_grammar.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -489,10 +488,10 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    89,    89,    94,    98,   102,   111,   125,   129,   140,
-     150,   162,   172,   184,   197,   211,   224,   238,   242,   248,
-     254,   260,   269,   273,   279,   287,   293,   299,   305,   311,
-     317,   323
+       0,   101,   101,   106,   110,   114,   123,   137,   141,   152,
+     162,   174,   184,   196,   209,   223,   236,   250,   254,   260,
+     266,   272,   281,   285,   291,   299,   305,   311,   317,   323,
+     329,   335
 };
 #endif
 
@@ -1037,33 +1036,33 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, void *yyscanner, R
   switch (yytype)
     {
           case 6: /* _CLASS_  */
-#line 81 "re_grammar.y" /* yacc.c:1257  */
+#line 93 "re_grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).class_vector)); }
-#line 1043 "re_grammar.c" /* yacc.c:1257  */
+#line 1042 "re_grammar.c" /* yacc.c:1257  */
         break;
 
     case 26: /* alternative  */
-#line 82 "re_grammar.y" /* yacc.c:1257  */
+#line 94 "re_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
-#line 1049 "re_grammar.c" /* yacc.c:1257  */
+#line 1048 "re_grammar.c" /* yacc.c:1257  */
         break;
 
     case 27: /* concatenation  */
-#line 83 "re_grammar.y" /* yacc.c:1257  */
+#line 95 "re_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
-#line 1055 "re_grammar.c" /* yacc.c:1257  */
+#line 1054 "re_grammar.c" /* yacc.c:1257  */
         break;
 
     case 28: /* repeat  */
-#line 84 "re_grammar.y" /* yacc.c:1257  */
+#line 96 "re_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
-#line 1061 "re_grammar.c" /* yacc.c:1257  */
+#line 1060 "re_grammar.c" /* yacc.c:1257  */
         break;
 
     case 29: /* single  */
-#line 85 "re_grammar.y" /* yacc.c:1257  */
+#line 97 "re_grammar.y" /* yacc.c:1257  */
       { yr_re_node_destroy(((*yyvaluep).re_node)); }
-#line 1067 "re_grammar.c" /* yacc.c:1257  */
+#line 1066 "re_grammar.c" /* yacc.c:1257  */
         break;
 
 
@@ -1329,24 +1328,24 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 90 "re_grammar.y" /* yacc.c:1646  */
+#line 102 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->root_node = (yyvsp[0].re_node);
       }
-#line 1338 "re_grammar.c" /* yacc.c:1646  */
+#line 1337 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 99 "re_grammar.y" /* yacc.c:1646  */
+#line 111 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
-#line 1346 "re_grammar.c" /* yacc.c:1646  */
+#line 1345 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 103 "re_grammar.y" /* yacc.c:1646  */
+#line 115 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_ALT, (yyvsp[-2].re_node), (yyvsp[0].re_node));
 
@@ -1355,11 +1354,11 @@ yyreduce:
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1359 "re_grammar.c" /* yacc.c:1646  */
+#line 1358 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 112 "re_grammar.y" /* yacc.c:1646  */
+#line 124 "re_grammar.y" /* yacc.c:1646  */
     {
         RE_NODE* node = yr_re_node_create(RE_NODE_EMPTY, NULL, NULL);
 
@@ -1370,19 +1369,19 @@ yyreduce:
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1374 "re_grammar.c" /* yacc.c:1646  */
+#line 1373 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 126 "re_grammar.y" /* yacc.c:1646  */
+#line 138 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
-#line 1382 "re_grammar.c" /* yacc.c:1646  */
+#line 1381 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 130 "re_grammar.y" /* yacc.c:1646  */
+#line 142 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_CONCAT, (yyvsp[-1].re_node), (yyvsp[0].re_node));
 
@@ -1390,11 +1389,11 @@ yyreduce:
         DESTROY_NODE_IF((yyval.re_node) == NULL, (yyvsp[0].re_node));
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1394 "re_grammar.c" /* yacc.c:1646  */
+#line 1393 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 141 "re_grammar.y" /* yacc.c:1646  */
+#line 153 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_GREEDY;
@@ -1404,11 +1403,11 @@ yyreduce:
         DESTROY_NODE_IF((yyval.re_node) == NULL, (yyvsp[-1].re_node));
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1408 "re_grammar.c" /* yacc.c:1646  */
+#line 1407 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 151 "re_grammar.y" /* yacc.c:1646  */
+#line 163 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_UNGREEDY;
@@ -1420,11 +1419,11 @@ yyreduce:
 
         (yyval.re_node)->greedy = FALSE;
       }
-#line 1424 "re_grammar.c" /* yacc.c:1646  */
+#line 1423 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 163 "re_grammar.y" /* yacc.c:1646  */
+#line 175 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_GREEDY;
@@ -1434,11 +1433,11 @@ yyreduce:
         DESTROY_NODE_IF((yyval.re_node) == NULL, (yyvsp[-1].re_node));
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1438 "re_grammar.c" /* yacc.c:1646  */
+#line 1437 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 173 "re_grammar.y" /* yacc.c:1646  */
+#line 185 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_UNGREEDY;
@@ -1450,11 +1449,11 @@ yyreduce:
 
         (yyval.re_node)->greedy = FALSE;
       }
-#line 1454 "re_grammar.c" /* yacc.c:1646  */
+#line 1453 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 185 "re_grammar.y" /* yacc.c:1646  */
+#line 197 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_GREEDY;
@@ -1467,11 +1466,11 @@ yyreduce:
         (yyval.re_node)->start = 0;
         (yyval.re_node)->end = 1;
       }
-#line 1471 "re_grammar.c" /* yacc.c:1646  */
+#line 1470 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 198 "re_grammar.y" /* yacc.c:1646  */
+#line 210 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_UNGREEDY;
@@ -1485,11 +1484,11 @@ yyreduce:
         (yyval.re_node)->end = 1;
         (yyval.re_node)->greedy = FALSE;
       }
-#line 1489 "re_grammar.c" /* yacc.c:1646  */
+#line 1488 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 212 "re_grammar.y" /* yacc.c:1646  */
+#line 224 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_GREEDY;
@@ -1502,11 +1501,11 @@ yyreduce:
         (yyval.re_node)->start = (yyvsp[0].range) & 0xFFFF;;
         (yyval.re_node)->end = (yyvsp[0].range) >> 16;;
       }
-#line 1506 "re_grammar.c" /* yacc.c:1646  */
+#line 1505 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 225 "re_grammar.y" /* yacc.c:1646  */
+#line 237 "re_grammar.y" /* yacc.c:1646  */
     {
         RE* re = yyget_extra(yyscanner);
         re->flags |= RE_FLAGS_UNGREEDY;
@@ -1520,77 +1519,77 @@ yyreduce:
         (yyval.re_node)->end = (yyvsp[-1].range) >> 16;;
         (yyval.re_node)->greedy = FALSE;
       }
-#line 1524 "re_grammar.c" /* yacc.c:1646  */
+#line 1523 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 239 "re_grammar.y" /* yacc.c:1646  */
+#line 251 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[0].re_node);
       }
-#line 1532 "re_grammar.c" /* yacc.c:1646  */
+#line 1531 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 243 "re_grammar.y" /* yacc.c:1646  */
+#line 255 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_WORD_BOUNDARY, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1542 "re_grammar.c" /* yacc.c:1646  */
+#line 1541 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 249 "re_grammar.y" /* yacc.c:1646  */
+#line 261 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_NON_WORD_BOUNDARY, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1552 "re_grammar.c" /* yacc.c:1646  */
+#line 1551 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 255 "re_grammar.y" /* yacc.c:1646  */
+#line 267 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_ANCHOR_START, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1562 "re_grammar.c" /* yacc.c:1646  */
+#line 1561 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 261 "re_grammar.y" /* yacc.c:1646  */
+#line 273 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_ANCHOR_END, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1572 "re_grammar.c" /* yacc.c:1646  */
+#line 1571 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 270 "re_grammar.y" /* yacc.c:1646  */
+#line 282 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = (yyvsp[-1].re_node);
       }
-#line 1580 "re_grammar.c" /* yacc.c:1646  */
+#line 1579 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 274 "re_grammar.y" /* yacc.c:1646  */
+#line 286 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_ANY, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1590 "re_grammar.c" /* yacc.c:1646  */
+#line 1589 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 280 "re_grammar.y" /* yacc.c:1646  */
+#line 292 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_LITERAL, NULL, NULL);
 
@@ -1598,71 +1597,71 @@ yyreduce:
 
         (yyval.re_node)->value = (yyvsp[0].integer);
       }
-#line 1602 "re_grammar.c" /* yacc.c:1646  */
+#line 1601 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 288 "re_grammar.y" /* yacc.c:1646  */
+#line 300 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_WORD_CHAR, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1612 "re_grammar.c" /* yacc.c:1646  */
+#line 1611 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 294 "re_grammar.y" /* yacc.c:1646  */
+#line 306 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_NON_WORD_CHAR, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1622 "re_grammar.c" /* yacc.c:1646  */
+#line 1621 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 300 "re_grammar.y" /* yacc.c:1646  */
+#line 312 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_SPACE, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1632 "re_grammar.c" /* yacc.c:1646  */
+#line 1631 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 306 "re_grammar.y" /* yacc.c:1646  */
+#line 318 "re_grammar.y" /* yacc.c:1646  */
     {
          (yyval.re_node) = yr_re_node_create(RE_NODE_NON_SPACE, NULL, NULL);
 
          ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1642 "re_grammar.c" /* yacc.c:1646  */
+#line 1641 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 312 "re_grammar.y" /* yacc.c:1646  */
+#line 324 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_DIGIT, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1652 "re_grammar.c" /* yacc.c:1646  */
+#line 1651 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 318 "re_grammar.y" /* yacc.c:1646  */
+#line 330 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_NON_DIGIT, NULL, NULL);
 
         ERROR_IF((yyval.re_node) == NULL, ERROR_INSUFICIENT_MEMORY);
       }
-#line 1662 "re_grammar.c" /* yacc.c:1646  */
+#line 1661 "re_grammar.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 324 "re_grammar.y" /* yacc.c:1646  */
+#line 336 "re_grammar.y" /* yacc.c:1646  */
     {
         (yyval.re_node) = yr_re_node_create(RE_NODE_CLASS, NULL, NULL);
 
@@ -1670,11 +1669,11 @@ yyreduce:
 
         (yyval.re_node)->class_vector = (yyvsp[0].class_vector);
       }
-#line 1674 "re_grammar.c" /* yacc.c:1646  */
+#line 1673 "re_grammar.c" /* yacc.c:1646  */
     break;
 
 
-#line 1678 "re_grammar.c" /* yacc.c:1646  */
+#line 1677 "re_grammar.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1902,5 +1901,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 332 "re_grammar.y" /* yacc.c:1906  */
+#line 344 "re_grammar.y" /* yacc.c:1906  */
 

--- a/libyara/re_grammar.h
+++ b/libyara/re_grammar.h
@@ -78,7 +78,7 @@ extern int re_yydebug;
 
 union YYSTYPE
 {
-#line 58 "re_grammar.y" /* yacc.c:1909  */
+#line 70 "re_grammar.y" /* yacc.c:1909  */
 
   int integer;
   uint32_t range;

--- a/libyara/re_lexer.c
+++ b/libyara/re_lexer.c
@@ -9,7 +9,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 1
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -88,25 +88,13 @@ typedef unsigned int flex_uint32_t;
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
-
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
@@ -238,12 +226,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -322,7 +310,7 @@ static void re_yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner 
 
 YY_BUFFER_STATE re_yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE re_yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE re_yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
+YY_BUFFER_STATE re_yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
 
 void *re_yyalloc (yy_size_t ,yyscan_t yyscanner );
 void *re_yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -366,17 +354,14 @@ typedef int yy_state_type;
 static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
 static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
 static int yy_get_next_buffer (yyscan_t yyscanner );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -582,7 +567,7 @@ int read_escaped_char(
 
 #define YY_NO_UNISTD_H 1
 
-#line 586 "re_lexer.c"
+#line 571 "re_lexer.c"
 
 #define INITIAL 0
 #define char_class 1
@@ -612,8 +597,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -666,7 +651,7 @@ FILE *re_yyget_out (yyscan_t yyscanner );
 
 void re_yyset_out  (FILE * _out_str ,yyscan_t yyscanner );
 
-yy_size_t re_yyget_leng (yyscan_t yyscanner );
+			int re_yyget_leng (yyscan_t yyscanner );
 
 char *re_yyget_text (yyscan_t yyscanner );
 
@@ -731,7 +716,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -755,7 +740,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -859,7 +844,7 @@ YY_DECL
 #line 99 "re_lexer.l"
 
 
-#line 863 "re_lexer.c"
+#line 848 "re_lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -889,7 +874,7 @@ yy_match:
 				if ( yy_current_state >= 45 )
 					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 			++yy_cp;
 			}
 		while ( yy_current_state != 44 );
@@ -1354,7 +1339,7 @@ YY_RULE_SETUP
 #line 464 "re_lexer.l"
 ECHO;
 	YY_BREAK
-#line 1358 "re_lexer.c"
+#line 1343 "re_lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1541,7 +1526,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1555,7 +1540,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1568,7 +1553,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1610,9 +1595,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) re_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
@@ -1651,7 +1636,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			if ( yy_current_state >= 45 )
 				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 		}
 
 	return yy_current_state;
@@ -1680,7 +1665,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( yy_current_state >= 45 )
 			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
 	yy_is_jam = (yy_current_state == 44);
 
 	(void)yyg;
@@ -1716,7 +1701,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -1740,7 +1725,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( re_yywrap(yyscanner ) )
-						return EOF;
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2003,7 +1988,7 @@ void re_yypop_buffer_state (yyscan_t yyscanner)
  */
 static void re_yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -2012,7 +1997,7 @@ static void re_yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; // After all that talk, this was set to 1 anyways...
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)re_yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
@@ -2059,7 +2044,7 @@ YY_BUFFER_STATE re_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
 	b = (YY_BUFFER_STATE) re_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
@@ -2068,7 +2053,7 @@ YY_BUFFER_STATE re_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
@@ -2091,7 +2076,7 @@ YY_BUFFER_STATE re_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
 YY_BUFFER_STATE re_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
     
-	return re_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return re_yy_scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to re_yylex() will
@@ -2101,7 +2086,7 @@ YY_BUFFER_STATE re_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE re_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE re_yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2109,7 +2094,7 @@ YY_BUFFER_STATE re_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_l
 	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
+	n = (yy_size_t) _yybytes_len + 2;
 	buf = (char *) re_yyalloc(n ,yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in re_yy_scan_bytes()" );
@@ -2135,7 +2120,7 @@ YY_BUFFER_STATE re_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_l
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -2218,7 +2203,7 @@ FILE *re_yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t re_yyget_leng  (yyscan_t yyscanner)
+int re_yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2389,10 +2374,10 @@ static int yy_init_globals (yyscan_t yyscanner)
      * This function is called from re_yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2405,8 +2390,8 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2476,7 +2461,7 @@ void *re_yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return (void *) malloc( size );
+	return malloc(size);
 }
 
 void *re_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
@@ -2491,7 +2476,7 @@ void *re_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void re_yyfree (void * ptr , yyscan_t yyscanner)

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -1,8 +1,11 @@
 #include <yara.h>
+#include <config.h>
+#include <stdio.h>
 #include "util.h"
 
 int main(int argc, char** argv)
 {
+#if (defined(HAVE_ENDIAN_H) && BYTE_ORDER == LITTLE_ENDIAN) || defined(_MSC)
   yr_initialize();
 
   assert_true_rule_file("import \"pe\" rule test { condition: pe.imports(\"KERNEL32.dll\", \"DeleteCriticalSection\") }",
@@ -24,5 +27,9 @@ int main(int argc, char** argv)
       "tests/data/tiny-idata-51ff");
 
   yr_finalize();
+#else
+  puts("Not testing pe module on big-endian architectures ... yet");
+  exit(77);
+#endif
   return 0;
 }

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -619,10 +619,9 @@ static void test_at()
 static void test_in()
 {
   assert_true_rule_blob(
-      "import \"pe\" \
-       rule test { \
+      "rule test { \
         strings: $a = { 6a 2a 58 c3 } \
-        condition: $a in (pe.entry_point .. pe.entry_point + 1) }",
+        condition: $a in (entrypoint .. entrypoint + 1) }",
       PE32_FILE);
 }
 


### PR DESCRIPTION
This set of patches fixes a number of issues on big-endian architectures as described in #493. I have successfully built and tested these with Debian/unstable on powerpc and ppc64 (not ppc64el).

The pe module has not been fixed to work on big-endian, so far; I have disabled the pe-specific tests for the time being. I'm going to fix the module code if these fixes get merged.