### PR TITLE
Fix isnan already defined

### DIFF
--- a/libyara/include/yara/object.h
+++ b/libyara/include/yara/object.h
@@ -33,7 +33,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef _MSC_VER
 
 #include <float.h>
+#ifndef isnan
 #define isnan _isnan
+#endif
 
 #ifndef INFINITY
 #define INFINITY (DBL_MAX + DBL_MAX)


### PR DESCRIPTION
In recent vs15 compailer isnan function is already defined, so I wrapped
the definition with #ifndef