### PR TITLE
-r safe argument added

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 YR_API int yr_compiler_create(
-    YR_COMPILER** compiler)
+    YR_COMPILER** compiler, int safe)
 {
   int result;
   YR_COMPILER* new_compiler;
@@ -68,6 +68,7 @@ YR_API int yr_compiler_create(
   new_compiler->compiled_rules_arena = NULL;
   new_compiler->namespaces_count = 0;
   new_compiler->current_rule = NULL;
+  new_compiler->safe = safe;
 
   result = yr_hash_table_create(10007, &new_compiler->rules_table);
 

--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -1405,6 +1405,7 @@ yyparse (void *yyscanner, YR_COMPILER* compiler)
 {
 /* The lookahead symbol.  */
 int yychar;
+char message[512];
 
 
 /* The semantic value of the lookahead symbol.  */
@@ -2457,9 +2458,12 @@ yyreduce:
         {
           if ((yyvsp[0].expression).value.sized_string != NULL)
           {
-            yywarning(yyscanner,
-              "Using literal string \"%s\" in a boolean operation.",
-              (yyvsp[0].expression).value.sized_string->c_string);
+		    if (compiler->safe) {
+			  snprintf(message, sizeof(message), "Using literal string \"%s\" in a boolean operation.", (yyvsp[0].expression).value.sized_string->c_string);
+			  yyerror(yyscanner, compiler, message);
+			} else {
+              yywarning(yyscanner, "Using literal string \"%s\" in a boolean operation.", (yyvsp[0].expression).value.sized_string->c_string);
+			}
           }
 
           compiler->last_result = yr_parser_emit(
@@ -3228,9 +3232,11 @@ yyreduce:
   case 98:
 #line 1566 "grammar.y" /* yacc.c:1646  */
     {
-        yywarning(yyscanner,
-            "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" "
-            "function from PE module instead.");
+	    if (compiler->safe) {
+		  yyerror(yyscanner, compiler, "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" function from PE module instead.");
+		} else {
+          yywarning(yyscanner, "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" function from PE module instead.");
+		}
 
         compiler->last_result = yr_parser_emit(
             yyscanner, OP_ENTRYPOINT, NULL);

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -92,6 +92,7 @@ typedef struct _YR_COMPILER
   YR_FIXUP*         fixup_stack_head;
 
   int               namespaces_count;
+  int				safe;
 
   uint8_t*          loop_address[MAX_LOOP_NESTING];
   char*             loop_identifier[MAX_LOOP_NESTING];
@@ -153,7 +154,7 @@ void _yr_compiler_pop_file_name(
 
 
 YR_API int yr_compiler_create(
-    YR_COMPILER** compiler);
+    YR_COMPILER** compiler, int safe);
 
 
 YR_API void yr_compiler_destroy(

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -562,10 +562,13 @@ YR_STRING* yr_parser_reduce_string_declaration(
 
     if (yr_re_contains_dot_star(re))
     {
-      yywarning(
-          yyscanner,
-          "%s contains .*, consider using .{N} with a reasonable value for N",
-          identifier);
+	  if (compiler->safe) {
+	    snprintf(message, sizeof(message), "%s contains .*, consider using .{N} with a reasonable value for N", identifier);
+        yyerror(yyscanner, compiler, message);
+	  }
+	  else {
+		yywarning(yyscanner, "%s contains .*, consider using .{N} with a reasonable value for N", identifier);
+	  }
     }
 
     compiler->last_result = yr_re_split_at_chaining_point(
@@ -670,11 +673,12 @@ YR_STRING* yr_parser_reduce_string_declaration(
 
   if (min_atom_quality < 3 && compiler->callback != NULL)
   {
-    yywarning(
-        yyscanner,
-        "%s is slowing down scanning%s",
-        string->identifier,
-        min_atom_quality < 2 ? " (critical!)" : "");
+    if (compiler->safe) {
+	  snprintf(message, sizeof(message), "%s is slowing down scanning%s", string->identifier, min_atom_quality < 2 ? " (critical!)" : "");
+	  yyerror(yyscanner, compiler, message);
+	} else {
+      yywarning(yyscanner, "%s is slowing down scanning%s", string->identifier, min_atom_quality < 2 ? " (critical!)" : "");
+	}
   }
 
 _exit:

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -1345,7 +1345,7 @@ void test_file_descriptor()
     exit(EXIT_FAILURE);
   }
 #endif
-  if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+  if (yr_compiler_create(&compiler, FALSE) != ERROR_SUCCESS)
   {
     perror("yr_compiler_create");
     exit(EXIT_FAILURE);

--- a/tests/util.c
+++ b/tests/util.c
@@ -62,7 +62,7 @@ YR_RULES* compile_rule(
 
   compile_error[0] = '\0';
 
-  if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+  if (yr_compiler_create(&compiler, FALSE) != ERROR_SUCCESS)
   {
     perror("yr_compiler_create");
     goto _exit;

--- a/yara.c
+++ b/yara.c
@@ -125,6 +125,7 @@ int limit = 0;
 int timeout = 1000000;
 int stack_size = DEFAULT_STACK_SIZE;
 int threads = 8;
+int safe = FALSE;
 
 
 #define USAGE_STRING \
@@ -189,6 +190,8 @@ args_option_t options[] =
 
   OPT_BOOLEAN('h', "help", &show_help,
       "show this help and exit"),
+
+  OPT_BOOLEAN('r', "safe", &safe, "treat warnings as errors"),
 
   OPT_END()
 };
@@ -1080,7 +1083,7 @@ int main(
     // Rules file didn't contain compiled rules, let's handle it
     // as a text file containing rules in source form.
 
-    if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+    if (yr_compiler_create(&compiler, safe) != ERROR_SUCCESS)
       exit_with_code(EXIT_FAILURE);
 
     result = define_external_variables(NULL, compiler);

--- a/yarac.c
+++ b/yarac.c
@@ -60,6 +60,7 @@ char* ext_vars[MAX_ARGS_EXT_VAR + 1];
 int ignore_warnings = FALSE;
 int show_version = FALSE;
 int show_help = FALSE;
+int safe = FALSE;
 
 
 #define USAGE_STRING \
@@ -78,6 +79,8 @@ args_option_t options[] =
 
   OPT_BOOLEAN('h', "help", &show_help,
       "show this help and exit"),
+	  
+  OPT_BOOLEAN('r', "safe", &safe, "treat warnings as errors"),
 
   OPT_END()
 };
@@ -209,7 +212,7 @@ int main(
   if (result != ERROR_SUCCESS)
     exit_with_code(EXIT_FAILURE);
 
-  if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+  if (yr_compiler_create(&compiler, safe) != ERROR_SUCCESS)
     exit_with_code(EXIT_FAILURE);
 
   if (!define_external_variables(compiler))


### PR DESCRIPTION
Added argument that allows me to treats compiler warnings as errors. We use yara to scan files with 1 big rule file. Rules can be added to this file by many users and we want to prevent users from breaking the file / hurting scan performance.