### PR TITLE
Add manifest flag (-M, --manifest)

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -50,6 +50,10 @@ Available options are:
 
   Print metadata.
 
+.. options:: -M --manifest
+
+  Read FILE as a manifest with PID or filename per line.
+
 .. option:: -s --print-strings
 
   Print matching strings.

--- a/yara.c
+++ b/yara.c
@@ -1037,7 +1037,7 @@ struct manifest_entry* get_manifest_entries(const char* filename)
     }
 
     // Allocate the entry we just read.
-    *current = (manifest_entry*) malloc(sizeof(struct manifest_entry));
+    *current = (struct manifest_entry*) malloc(sizeof(struct manifest_entry));
     (*current)->name = (char*) malloc(filename_len + 1);
     strncpy((*current)->name, line_buffer, filename_len + 1);
     (*current)->next = NULL;


### PR DESCRIPTION
Adds a new flag `-M, --manifest` which reads the final `FILE` argument as a manifest file containing a PID or filename per line so the user can specify multiple targets.

```
Usage: yara [OPTION]... RULES_FILE FILE | DIR | PID

  -M,  --manifest      read FILE as a manifest with PID or filename per line
```

This feature gives the user a lot of flexibility to setup multiple search targets, including the case of "all active processes" by generating a manifest file with a PID listing, for example:

1. UNIX: `$ ps ax | awk '{print $1}' | sed 1d > manifest.txt`
1. Windows: `C:\> wmic process get ProcessId | more +1 > manifest.txt`

This solution solves what I think is a good general case of targeting which is to search some number of files and/or some number of active processes, plus it leaves manifest file generation as a separate concern from YARA itself so there is no system dependent code here.