### PR TITLE
Add missing NULL check, causing crash on truncated samples.

### DIFF
--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -515,7 +515,7 @@ void dotnet_parse_tilde_2(
             else
               name = pe_get_dotnet_string(pe, string_offset, *(WORD*) typeref_row);
 
-            if (strncmp(name, "GuidAttribute", 13) != 0)
+            if (name != NULL && strncmp(name, "GuidAttribute", 13) != 0)
             {
               row_ptr += row_size;
               continue;


### PR DESCRIPTION
Add missing NULL pointer check, which was causing crashes when run against corrupt binaries where the GuidAttribute string is not actually in the binary. Only times I've seen this is when the binary has been truncated.