### PR TITLE
Rva to offset exposed

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -589,3 +589,11 @@ Reference
     Function returning true if the PE is 64bits.
 
     *Example: pe.is_64bit()*
+
+.. c:function:: rva_to_offset(addr)
+
+ .. versionadded:: 3.6.0
+
+  Function returning the file offset for RVA *addr*.
+
+  *Example: pe.rva_to_offset(pe.entry_point)*

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1912,6 +1912,25 @@ define_function(calculate_checksum)
 }
 
 
+define_function(rva_to_offset)
+{
+  YR_OBJECT* module = module();
+  PE* pe = (PE*) module->data;
+
+  uint64_t rva, offset;
+
+  if (pe == NULL)
+    return_integer(UNDEFINED);
+
+  rva = integer_argument(1);
+  offset = pe_rva_to_offset(pe, rva);
+  if (offset == -1)
+    return_integer(UNDEFINED);
+
+  return_integer(offset);
+}
+
+
 begin_declarations;
 
   declare_integer("MACHINE_UNKNOWN");
@@ -2109,6 +2128,8 @@ begin_declarations;
 
   declare_integer("number_of_signatures");
   #endif
+
+  declare_function("rva_to_offset", "i", "i", rva_to_offset);
 
 end_declarations;
 


### PR DESCRIPTION
Make rva_to_offset function available in the PE module. It's a very niche function but can be useful for doing deep dives into certain families of malware.