### PR TITLE
Fix ELF module issues on big endian system

### DIFF
--- a/libyara/exefiles.c
+++ b/libyara/exefiles.c
@@ -157,11 +157,12 @@ static uint64_t yr_elf_rva_to_offset_32(
 {
   // if the binary is an executable then prefer the program headers to resolve
   // the offset
-  if (elf_header->type == ELF_ET_EXEC)
+  if (yr_le16toh(elf_header->type) == ELF_ET_EXEC)
   {
     int i;
     elf32_program_header_t* program;
-    if (elf_header->ph_offset == 0 || elf_header->ph_entry_count == 0)
+    if (yr_le32toh(elf_header->ph_offset) == 0 ||
+        yr_le16toh(elf_header->ph_entry_count == 0))
       return 0;
 
     // check to prevent integer wraps
@@ -199,7 +200,8 @@ static uint64_t yr_elf_rva_to_offset_32(
     int i;
     elf32_section_header_t* section;
 
-    if (elf_header->sh_offset == 0 || elf_header->sh_entry_count == 0)
+    if (yr_le32toh(elf_header->sh_offset) == 0 ||
+        yr_le16toh(elf_header->sh_entry_count == 0))
       return 0;
 
     // check to prevent integer wraps
@@ -253,11 +255,12 @@ static uint64_t yr_elf_rva_to_offset_64(
 {
   // if the binary is an executable then prefer the program headers to resolve
   // the offset
-  if (elf_header->type == ELF_ET_EXEC)
+  if (yr_le16toh(elf_header->type) == ELF_ET_EXEC)
   {
     int i;
     elf64_program_header_t* program;
-    if (elf_header->ph_offset == 0 || elf_header->ph_entry_count == 0)
+    if (yr_le64toh(elf_header->ph_offset) == 0 ||
+        yr_le16toh(elf_header->ph_entry_count == 0))
       return 0;
 
     // check that 'ph_offset' doesn't wrap when added to the
@@ -290,7 +293,8 @@ static uint64_t yr_elf_rva_to_offset_64(
     int i;
     elf64_section_header_t* section;
 
-    if (elf_header->sh_offset == 0 || elf_header->sh_entry_count == 0)
+    if (yr_le64toh(elf_header->sh_offset) == 0 ||
+        yr_le16toh(elf_header->sh_entry_count) == 0)
       return 0;
 
     // check that 'sh_offset' doesn't wrap when added to the

--- a/libyara/modules/elf.c
+++ b/libyara/modules/elf.c
@@ -72,7 +72,7 @@ uint64_t elf_rva_to_offset_##bits##_##bo(                                      \
     uint64_t rva,                                                              \
     size_t elf_size)                                                           \
 {                                                                              \
-  if (elf_header->type == ELF_ET_EXEC)                                         \
+  if (yr_##bo##16toh(elf_header->type) == ELF_ET_EXEC)                         \
   {                                                                            \
     int i;                                                                     \
                                                                                \
@@ -224,12 +224,12 @@ void parse_elf_header_##bits##_##bo(                                           \
       set_integer(yr_##bo##bits##toh(section->offset), elf_obj,                \
                   "sections[%i].offset", i);                                   \
                                                                                \
-      if (yr_##bo##bits##toh(section->name) < elf_size &&                      \
+      if (yr_##bo##32toh(section->name) < elf_size &&                          \
           str_table > (char*) elf &&                                           \
-          str_table + yr_##bo##bits##toh(section->name) <                      \
+          str_table + yr_##bo##32toh(section->name) <                          \
             (char*) elf + elf_size)                                            \
       {                                                                        \
-        set_string(str_table + yr_##bo##bits##toh(section->name), elf_obj,     \
+        set_string(str_table + yr_##bo##32toh(section->name), elf_obj,         \
                    "sections[%i].name", i);                                    \
       }                                                                        \
                                                                                \


### PR DESCRIPTION
I created a build of YARA for a mips (big endian) system. Included in that build were the slightly more expanded unit tests for the ELF module that I included in #610. A couple of the tests were failing. There turned out to be two reasons:

1. A handful of places were using raw access of the ELF header values instead of first calling the endian.h functions.

2. Access to section name offset was using yr_##bo##bits##toh but this field is always 32 bits.

Changes were simple. All tests now pass.