### PR TITLE
Linux Memory Scan Can Leave Process In Stopped State

### DIFF
--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -352,6 +352,7 @@ int _yr_process_attach(
     int pid,
     YR_PROC_ITERATOR_CTX* context)
 {
+  int status;
   char buffer[256];
 
   context->pid = pid;
@@ -377,6 +378,22 @@ int _yr_process_attach(
 
   if (ptrace(PTRACE_ATTACH, pid, NULL, 0) == -1)
   {
+    fclose(context->maps);
+    context->maps = NULL;
+
+    close(context->mem_fd);
+    context->mem_fd = -1;
+
+    return ERROR_COULD_NOT_ATTACH_TO_PROCESS;
+  }
+
+  status = 0;
+  if (waitpid(-1, &status, 0) == -1)
+  {
+    // this is a strange error state where we attached but the proc didn't
+    // stop. Try to detach and clean up.
+    ptrace(PTRACE_DETACH, context->pid, NULL, 0);
+
     fclose(context->maps);
     context->maps = NULL;
 

--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -388,7 +388,7 @@ int _yr_process_attach(
   }
 
   status = 0;
-  if (waitpid(-1, &status, 0) == -1)
+  if (waitpid(pid, &status, 0) == -1)
   {
     // this is a strange error state where we attached but the proc didn't
     // stop. Try to detach and clean up.


### PR DESCRIPTION
I was testing memory scanning on CentOS 5.11 x86 and ran into some odd behavior. For some reason syslogd stopped working. Looking at syslogd's /proc/pid/status it appeared to be stuck in the "stopped" state. At first, this was difficult to consistently reproduce (due to the way YARA was being used). However, I was able to consistently reproduce the error via YARA, proc, and a while loop:

```sh
[root@localhost yara-master]# ps aux | grep syslogd
root      3973  0.0  0.0   1828   588 ?        Ss   11:54   0:00 syslogd -m 0
root      5057  0.0  0.0   4032   692 pts/1    S+   11:55   0:00 grep syslogd
[root@localhost yara-master]# status=1; while [ $status -eq 1 ]; do ./yara ./rule.yar 3973; grep -q "stop" /proc/3973/status; status=$?; done;
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
single_section 3973
[root@localhost yara-master]# cat /proc/3973/status
Name:   syslogd
State:  T (stopped)
SleepAVG:       98%
Tgid:   3973
Pid:    3973
PPid:   1
TracerPid:      0
Uid:    0       0       0       0
Gid:    0       0       0       0
FDSize: 32
Groups:
VmPeak:     1868 kB
VmSize:     1828 kB
VmLck:         0 kB
VmHWM:      1652 kB
VmRSS:      1652 kB
VmData:      160 kB
VmStk:        88 kB
VmExe:        32 kB
VmLib:      1516 kB
VmPTE:        36 kB
StaBrk: 08148000 kB
Brk:    08169000 kB
StaStk: bfc90110 kB
Threads:        1
SigQ:   2/64759
SigPnd: 0000000000000000
ShdPnd: 0000000000002000
SigBlk: 0000000000000000
SigIgn: 0000000000000206
SigCgt: 0000000000016001
CapInh: 0000000000000000
CapPrm: 00000000fffffeff
CapEff: 00000000fffffeff
Cpus_allowed:   0000000f
Mems_allowed:   1
```
I know that is a lot of text. The basic summary is that YARA scans syslogd's memory over and over again until /proc/pid/status contains the word "stop". The rule in use is simple:

```sh
rule single_section
{
    condition:
        true
}
```

The above is reproducible with master (on CentOS 5.11 at least) every time.

So I started looking at YARA's ptrace logic. I assumed there was a path that didn't appropriately detach and left the child process in a bad state. Instead, I realized that YARA never actually waits for the child process to stop after the initial attach. Quote from the ptrace man page:

>       PTRACE_ATTACH
>              Attach to the process specified in pid, making it a tracee of the calling process.  The tracee is sent a SIGSTOP, but will not necessarily have stopped by the completion of this  call;

Emphasis on "**will not necessarily have stopped by the completion of this  call**". I theorized that YARA was attaching and detaching before syslogd had a chance to act on the first SIGSTOP. When I added wait() logic after the attach (aka this diff), the bash while loop that I provide above continues forever (ie. syslogd never gets stuck in the stop state). And by forever I mean I ran it for ~4 minutes and assumed it was good.

One note about this patch: I think the error state of wait() == -1 is incredibly unlikely. So I didn't introduce a new error #define. Also, I used the blocking version of wait. There is a NOHANG version and we could obviously loop for a certain amount of seconds, but (again) I feel like that error state is so unlikely... Otherwise, I think the patch is tolerable.
