### PR TITLE
Use the counter of actual constants that were added, not the ones tha…

### DIFF
--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -607,7 +607,7 @@ void dotnet_parse_tilde_2(
               blob_result.length,
               pe->object,
               "constants[%i]",
-              i);
+              counter);
 
           counter++;
           row_ptr += row_size;


### PR DESCRIPTION
…t were attempted to be processed.

This fixes a bug where the number of constants does not match the actual number in the array.