### PR TITLE
3.5 security fixes

### DIFF
--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -68,18 +68,18 @@
 
 
 /* Copy the first part of user declarations.  */
-#line 17 "grammar.y" /* yacc.c:339  */
+#line 30 "grammar.y" /* yacc.c:339  */
 
 
 
 #include <assert.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <stddef.h>
 
 
+#include <yara/integers.h>
 #include <yara/utils.h>
 #include <yara/strutils.h>
 #include <yara/compiler.h>
@@ -277,7 +277,7 @@ extern int yara_yydebug;
 
 union YYSTYPE
 {
-#line 191 "grammar.y" /* yacc.c:355  */
+#line 204 "grammar.y" /* yacc.c:355  */
 
   EXPRESSION      expression;
   SIZED_STRING*   sized_string;
@@ -546,16 +546,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   408
+#define YYLAST   406
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  72
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  41
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  121
+#define YYNRULES  122
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  209
+#define YYNSTATES  210
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
@@ -606,19 +606,19 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   205,   205,   207,   208,   209,   210,   211,   216,   229,
-     238,   228,   261,   264,   292,   295,   322,   327,   328,   333,
-     334,   340,   343,   361,   374,   411,   412,   417,   433,   446,
-     459,   472,   489,   490,   496,   495,   511,   510,   526,   540,
-     541,   546,   547,   548,   549,   554,   639,   685,   743,   788,
-     789,   793,   818,   854,   900,   922,   931,   940,   955,   967,
-     981,   994,  1006,  1036,  1005,  1152,  1151,  1231,  1237,  1244,
-    1243,  1306,  1305,  1366,  1375,  1384,  1393,  1402,  1411,  1420,
-    1424,  1432,  1433,  1438,  1460,  1472,  1488,  1487,  1493,  1504,
-    1505,  1510,  1517,  1528,  1529,  1533,  1541,  1545,  1555,  1569,
-    1585,  1595,  1604,  1629,  1641,  1653,  1669,  1681,  1697,  1742,
-    1761,  1779,  1797,  1815,  1841,  1859,  1869,  1879,  1889,  1899,
-    1909,  1919
+       0,   218,   218,   220,   221,   222,   223,   224,   229,   242,
+     251,   241,   274,   277,   305,   308,   335,   340,   341,   346,
+     347,   353,   356,   374,   387,   424,   425,   430,   446,   459,
+     472,   485,   502,   503,   509,   508,   524,   523,   539,   553,
+     554,   559,   560,   561,   562,   567,   652,   698,   756,   801,
+     802,   806,   831,   867,   913,   935,   944,   953,   968,   980,
+     994,  1007,  1018,  1024,  1054,  1023,  1170,  1169,  1249,  1255,
+    1262,  1261,  1324,  1323,  1384,  1393,  1402,  1411,  1420,  1429,
+    1438,  1442,  1450,  1451,  1456,  1478,  1490,  1506,  1505,  1511,
+    1522,  1523,  1528,  1535,  1546,  1547,  1551,  1559,  1563,  1573,
+    1587,  1603,  1613,  1622,  1647,  1659,  1671,  1687,  1699,  1715,
+    1760,  1779,  1797,  1815,  1833,  1859,  1877,  1887,  1897,  1907,
+    1917,  1927,  1937
 };
 #endif
 
@@ -672,7 +672,7 @@ static const yytype_uint16 yytoknum[] =
 #define yypact_value_is_default(Yystate) \
   (!!((Yystate) == (-73)))
 
-#define YYTABLE_NINF -94
+#define YYTABLE_NINF -95
 
 #define yytable_value_is_error(Yytable_value) \
   0
@@ -681,27 +681,27 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     -73,    79,   -73,   -32,    -4,   -73,   -73,    94,   -73,   -73,
-     -73,   -73,    13,   -73,   -73,   -73,   -73,    -8,    72,     6,
-     -73,    78,   111,   -73,    61,   122,   123,    82,   -73,    90,
-     123,   -73,   147,   150,    16,   -73,    96,   147,   -73,   101,
-      97,   -73,   -73,   -73,   -73,   151,    53,   -73,    48,   -73,
-     -73,   -73,   149,   145,   -73,    -9,   -73,   103,   107,   -73,
-     -73,   106,   -73,   -73,   -73,   -73,   -73,   -73,   110,   -73,
-     -73,   135,    48,   135,    48,   -33,   -73,    64,   -73,   144,
-     306,   -73,   -73,   135,   108,   135,   135,   135,   135,    -7,
-     322,   -73,   -73,   -73,    64,   117,   163,   168,   135,    48,
-     -73,   -73,    -6,   167,   135,   135,   135,   135,   135,   135,
-     135,   135,   135,   135,   135,   135,   135,   135,   135,   135,
-     135,    86,    86,   322,   135,   -73,   243,   261,   183,   203,
-     159,    -6,   -73,   -73,   -73,   279,   121,   125,    95,    48,
-      48,   -73,   -73,   -73,   -73,   322,   337,   351,   -43,   322,
-     322,   322,   322,   322,   322,    40,    40,    58,    58,   -73,
-     -73,   -73,   -73,   -73,   -73,   -73,   -73,   129,   -73,   -73,
-     -73,   -73,   128,   -73,   -73,    48,   152,   -73,    15,   135,
-     131,   -73,    95,   -73,   -73,    71,   -73,   223,   135,   133,
-     -73,   132,   -73,    15,   -73,    73,   129,   -73,    48,   -73,
-     -73,   135,   134,    31,   322,    48,   -73,    49,   -73
+     -73,    90,   -73,   -32,   -10,   -73,   -73,    93,   -73,   -73,
+     -73,   -73,     1,   -73,   -73,   -73,   -73,   -49,     7,   -36,
+     -73,    20,    26,   -73,   -28,    92,    46,     4,   -73,    40,
+      46,   -73,   100,   119,    16,   -73,    72,   100,   -73,    77,
+      83,   -73,   -73,   -73,   -73,   134,    59,   -73,    48,   -73,
+     -73,   -73,   133,   136,   -73,   -18,   -73,    88,    95,   -73,
+     -73,    91,   -73,   -73,   -73,   -73,   -73,   -73,   102,   -73,
+     -73,   126,    48,   126,    48,   -44,   -73,    85,   -73,   127,
+     297,   -73,   -73,   126,   110,   126,   126,   126,   126,     2,
+     313,   -73,   -73,   -73,    85,   111,   154,   172,   126,    48,
+     -73,   -73,    -6,   162,   126,   126,   126,   126,   126,   126,
+     126,   126,   126,   126,   126,   126,   126,   126,   126,   126,
+     126,    60,    60,   313,   126,   -73,   234,   252,   174,   194,
+     -73,   153,    -6,   -73,   -73,   -73,   270,   117,   120,   108,
+      48,    48,   -73,   -73,   -73,   -73,   313,   328,   342,   349,
+     313,   313,   313,   313,   313,   313,   113,   113,    53,    53,
+     -73,   -73,   -73,   -73,   -73,   -73,   -73,   -73,   121,   -73,
+     -73,   -73,   -73,   124,   -73,   -73,    48,   151,   -73,    -1,
+     126,   125,   -73,   108,   -73,   -73,    18,   -73,   214,   126,
+     129,   -73,   143,   -73,    -1,   -73,    63,   121,   -73,    48,
+     -73,   -73,   126,   144,    31,   313,    48,   -73,    33,   -73
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -714,31 +714,31 @@ static const yytype_uint8 yydefact[] =
       23,    22,    12,    24,     0,    14,     0,     0,    10,     0,
       13,    25,     0,     0,     0,    26,     0,    15,    32,     0,
        0,    28,    27,    30,    31,     0,    34,    33,     0,    11,
-      29,    38,     0,     0,    45,    59,   103,   105,   107,   100,
-     101,     0,   102,    53,    97,    98,    94,    95,     0,    55,
-      56,     0,     0,     0,     0,   108,   121,    16,    54,     0,
-      79,    39,    39,     0,     0,     0,     0,     0,     0,     0,
-      93,   109,    68,   118,     0,    54,    79,     0,     0,    49,
-      71,    69,     0,     0,     0,     0,     0,     0,     0,     0,
+      29,    38,     0,     0,    45,    59,   104,   106,   108,   101,
+     102,     0,   103,    53,    98,    99,    95,    96,     0,    55,
+      56,     0,     0,     0,     0,   109,   122,    16,    54,     0,
+      80,    39,    39,     0,     0,     0,     0,     0,     0,     0,
+      94,   110,    69,   119,     0,    54,    80,     0,     0,    49,
+      72,    70,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,    35,    37,    60,     0,    61,     0,     0,     0,     0,
-       0,     0,    80,    96,    46,     0,     0,    50,    51,     0,
-       0,    88,    86,    67,    57,    58,   117,   115,   116,    77,
-      78,    73,    75,    74,    76,   119,   120,   110,   111,   112,
-     113,   114,    42,    41,    43,    44,    40,     0,   104,   106,
-      99,    62,     0,    47,    48,     0,    72,    70,     0,     0,
-       0,    65,    52,    91,    92,     0,    89,     0,     0,     0,
-      82,     0,    87,     0,    83,     0,    84,    63,     0,    90,
-      81,     0,     0,     0,    85,     0,    66,     0,    64
+      62,     0,     0,    81,    97,    46,     0,     0,    50,    51,
+       0,     0,    89,    87,    68,    57,    58,   118,   116,   117,
+      78,    79,    74,    76,    75,    77,   120,   121,   111,   112,
+     113,   114,   115,    42,    41,    43,    44,    40,     0,   105,
+     107,   100,    63,     0,    47,    48,     0,    73,    71,     0,
+       0,     0,    66,    52,    92,    93,     0,    90,     0,     0,
+       0,    83,     0,    88,     0,    84,     0,    85,    64,     0,
+      91,    82,     0,     0,     0,    86,     0,    67,     0,    65
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-     -73,   -73,   199,   218,   -73,   -73,   -73,   -73,   -73,   -73,
-     -73,   -73,   -73,   -73,   192,   -73,   186,   -73,   -73,   142,
-     -73,   -73,   -73,   -73,   126,   -48,   -72,   -73,   -73,   -73,
-     -73,   -73,   -73,    50,   -73,   100,   -73,   -73,    35,   164,
+     -73,   -73,   211,   212,   -73,   -73,   -73,   -73,   -73,   -73,
+     -73,   -73,   -73,   -73,   189,   -73,   183,   -73,   -73,   139,
+     -73,   -73,   -73,   -73,   130,   -48,   -72,   -73,   -73,   -73,
+     -73,   -73,   -73,    41,   -73,   103,   -73,   -73,    29,   164,
      -67
 };
 
@@ -747,8 +747,8 @@ static const yytype_int16 yydefgoto[] =
 {
       -1,     1,     5,     6,    17,    33,    25,    28,    40,     7,
       15,    19,    21,    30,    31,    37,    38,    52,    53,   121,
-     166,    75,   136,   137,    76,    94,    78,   180,   202,   191,
-     140,   139,   189,   125,   195,   143,   178,   185,   186,    79,
+     167,    75,   137,   138,    76,    94,    78,   181,   203,   192,
+     141,   140,   190,   125,   196,   144,   179,   186,   187,    79,
       80
 };
 
@@ -757,92 +757,92 @@ static const yytype_int16 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      77,    90,    95,   130,    91,     4,    93,    96,   114,   115,
-     116,   117,   118,   119,   120,    11,   123,    83,   126,   127,
-     128,   129,    84,    16,    92,   131,   183,   138,   141,     8,
-     184,   135,    41,    97,    98,    42,    99,   145,   146,   147,
-     148,   149,   150,   151,   152,   153,   154,   155,   156,   157,
-     158,   159,   160,   161,    43,    44,    18,   167,    54,    55,
-      56,    57,    58,   142,    59,    60,    61,    62,    22,    63,
-      45,   100,   101,    51,   -36,    64,    65,    66,    67,     2,
-       3,    68,    20,   -17,   -17,   -17,    69,    70,    23,   100,
-     101,   176,   177,   116,   117,   118,   119,   120,    12,    13,
-      14,   206,    71,   182,   100,   101,    72,    73,   162,   163,
-     164,   165,   187,   118,   119,   120,     4,    74,    24,   208,
-      54,   196,    56,    57,    58,    26,    59,    60,    61,    62,
-      27,    63,   179,    29,   204,   -54,   -54,    64,    65,    66,
-      67,   192,   193,   200,   201,    54,    32,    56,    57,    58,
-     203,    59,    60,    61,    62,    34,    63,   207,    36,    39,
-      49,    46,    64,    65,    71,    48,    82,    50,    81,    73,
-      85,   105,   106,   107,    86,    87,   102,   124,   134,    88,
-     114,   115,   116,   117,   118,   119,   120,   132,    63,    71,
-     171,   174,   181,   101,    73,   -93,   175,   197,   103,   104,
-     188,   198,     9,   205,    88,   105,   106,   107,   108,   109,
-     110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
-     120,    10,    35,    47,   122,   105,   106,   107,   199,   144,
-     190,   172,    89,   133,   114,   115,   116,   117,   118,   119,
-     120,     0,     0,     0,     0,   105,   106,   107,     0,     0,
-       0,     0,     0,   170,   114,   115,   116,   117,   118,   119,
-     120,     0,     0,     0,     0,   105,   106,   107,     0,     0,
-       0,     0,     0,   133,   114,   115,   116,   117,   118,   119,
-     120,     0,     0,     0,     0,   105,   106,   107,     0,     0,
-       0,     0,     0,   194,   114,   115,   116,   117,   118,   119,
-     120,     0,     0,   105,   106,   107,     0,     0,     0,     0,
-       0,   168,   114,   115,   116,   117,   118,   119,   120,     0,
-       0,   105,   106,   107,     0,     0,     0,     0,     0,   169,
-     114,   115,   116,   117,   118,   119,   120,     0,   -93,     0,
-       0,   103,   104,     0,     0,     0,     0,   173,   105,   106,
-     107,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,   119,   120,   105,   106,   107,     0,     0,     0,
+      77,    90,    95,   130,    91,     4,    93,    96,    83,    11,
+     184,    16,   131,    84,   185,    18,   123,    20,   126,   127,
+     128,   129,    97,    98,    92,    99,    22,   139,   142,     8,
+      23,   136,    41,    24,   132,    42,    26,   146,   147,   148,
+     149,   150,   151,   152,   153,   154,   155,   156,   157,   158,
+     159,   160,   161,   162,    43,    44,    29,   168,    54,    55,
+      56,    57,    58,   143,    59,    60,    61,    62,    32,    63,
+      45,   100,   101,   100,   101,    64,    65,    66,    67,    51,
+     -36,    68,   163,   164,   165,   166,    69,    70,   193,   194,
+       2,     3,   177,   178,   -17,   -17,   -17,    12,    13,    14,
+      27,   207,    71,   209,   183,    34,    72,    73,   118,   119,
+     120,    36,    54,   188,    56,    57,    58,    74,    59,    60,
+      61,    62,   197,    63,   180,   100,   101,     4,    39,    64,
+      65,    66,    67,   201,   202,   205,    54,    46,    56,    57,
+      58,    48,    59,    60,    61,    62,    49,    63,   -54,   -54,
+      50,   204,    81,    64,    65,    85,    71,    82,   208,   102,
+      87,    73,    86,   105,   106,   107,   116,   117,   118,   119,
+     120,    88,   114,   115,   116,   117,   118,   119,   120,   124,
+      71,   133,   135,    63,   172,    73,   -94,   175,   182,   103,
+     104,   176,   101,   198,   189,    88,   105,   106,   107,   108,
+     109,   110,   111,   112,   113,   114,   115,   116,   117,   118,
+     119,   120,   199,   206,     9,    10,   105,   106,   107,    35,
+      47,   122,   191,   200,   134,   114,   115,   116,   117,   118,
+     119,   120,    89,   145,     0,   173,   105,   106,   107,     0,
+       0,     0,     0,     0,   171,   114,   115,   116,   117,   118,
+     119,   120,     0,     0,     0,     0,   105,   106,   107,     0,
+       0,     0,     0,     0,   134,   114,   115,   116,   117,   118,
+     119,   120,     0,     0,     0,     0,   105,   106,   107,     0,
+       0,     0,     0,     0,   195,   114,   115,   116,   117,   118,
+     119,   120,     0,     0,   105,   106,   107,     0,     0,     0,
+       0,     0,   169,   114,   115,   116,   117,   118,   119,   120,
+       0,     0,   105,   106,   107,     0,     0,     0,     0,     0,
+     170,   114,   115,   116,   117,   118,   119,   120,     0,   -94,
+       0,     0,   103,   104,     0,     0,     0,     0,   174,   105,
+     106,   107,   108,   109,   110,   111,   112,   113,   114,   115,
+     116,   117,   118,   119,   120,   105,   106,   107,     0,     0,
+       0,     0,     0,     0,   114,   115,   116,   117,   118,   119,
+     120,   106,   107,     0,     0,     0,     0,     0,     0,   114,
+     115,   116,   117,   118,   119,   120,   107,     0,     0,     0,
        0,     0,     0,   114,   115,   116,   117,   118,   119,   120,
-     106,   107,     0,     0,     0,     0,     0,     0,   114,   115,
-     116,   117,   118,   119,   120,   107,     0,     0,     0,     0,
-       0,     0,   114,   115,   116,   117,   118,   119,   120
+     114,   115,   116,   117,   118,   119,   120
 };
 
 static const yytype_int16 yycheck[] =
 {
-      48,    68,    74,    10,    71,    37,    73,    74,    51,    52,
-      53,    54,    55,    56,    57,    19,    83,    26,    85,    86,
-      87,    88,    31,    10,    72,    32,    11,    99,    34,    61,
-      15,    98,    16,    66,    67,    19,    69,   104,   105,   106,
+      48,    68,    74,     1,    71,    37,    73,    74,    26,    19,
+      11,    10,    10,    31,    15,    64,    83,    10,    85,    86,
+      87,    88,    66,    67,    72,    69,    62,    99,    34,    61,
+      10,    98,    16,     7,    32,    19,    64,   104,   105,   106,
      107,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,   119,   120,    38,    39,    64,   124,    10,    11,
-      12,    13,    14,    69,    16,    17,    18,    19,    62,    21,
-      54,    40,    41,    20,    21,    27,    28,    29,    30,     0,
-       1,    33,    10,     4,     5,     6,    38,    39,    10,    40,
-      41,   139,   140,    53,    54,    55,    56,    57,     4,     5,
-       6,    70,    54,   175,    40,    41,    58,    59,    22,    23,
-      24,    25,   179,    55,    56,    57,    37,    69,     7,    70,
-      10,   188,    12,    13,    14,    64,    16,    17,    18,    19,
-       8,    21,     3,    10,   201,    40,    41,    27,    28,    29,
-      30,    70,    71,    70,    71,    10,    64,    12,    13,    14,
-     198,    16,    17,    18,    19,    65,    21,   205,    11,     9,
-      63,    65,    27,    28,    54,    64,    21,    16,    19,    59,
-      67,    42,    43,    44,    67,    69,    32,    69,    10,    69,
-      51,    52,    53,    54,    55,    56,    57,    70,    21,    54,
-      31,    70,    64,    41,    59,    32,    71,    64,    35,    36,
-      69,    69,     3,    69,    69,    42,    43,    44,    45,    46,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      57,     3,    30,    37,    82,    42,    43,    44,   193,   103,
-     180,   131,    68,    70,    51,    52,    53,    54,    55,    56,
-      57,    -1,    -1,    -1,    -1,    42,    43,    44,    -1,    -1,
-      -1,    -1,    -1,    70,    51,    52,    53,    54,    55,    56,
-      57,    -1,    -1,    -1,    -1,    42,    43,    44,    -1,    -1,
-      -1,    -1,    -1,    70,    51,    52,    53,    54,    55,    56,
-      57,    -1,    -1,    -1,    -1,    42,    43,    44,    -1,    -1,
-      -1,    -1,    -1,    70,    51,    52,    53,    54,    55,    56,
-      57,    -1,    -1,    42,    43,    44,    -1,    -1,    -1,    -1,
-      -1,    68,    51,    52,    53,    54,    55,    56,    57,    -1,
-      -1,    42,    43,    44,    -1,    -1,    -1,    -1,    -1,    68,
-      51,    52,    53,    54,    55,    56,    57,    -1,    32,    -1,
-      -1,    35,    36,    -1,    -1,    -1,    -1,    68,    42,    43,
-      44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
-      54,    55,    56,    57,    42,    43,    44,    -1,    -1,    -1,
+     117,   118,   119,   120,    38,    39,    10,   124,    10,    11,
+      12,    13,    14,    69,    16,    17,    18,    19,    64,    21,
+      54,    40,    41,    40,    41,    27,    28,    29,    30,    20,
+      21,    33,    22,    23,    24,    25,    38,    39,    70,    71,
+       0,     1,   140,   141,     4,     5,     6,     4,     5,     6,
+       8,    70,    54,    70,   176,    65,    58,    59,    55,    56,
+      57,    11,    10,   180,    12,    13,    14,    69,    16,    17,
+      18,    19,   189,    21,     3,    40,    41,    37,     9,    27,
+      28,    29,    30,    70,    71,   202,    10,    65,    12,    13,
+      14,    64,    16,    17,    18,    19,    63,    21,    40,    41,
+      16,   199,    19,    27,    28,    67,    54,    21,   206,    32,
+      69,    59,    67,    42,    43,    44,    53,    54,    55,    56,
+      57,    69,    51,    52,    53,    54,    55,    56,    57,    69,
+      54,    70,    10,    21,    31,    59,    32,    70,    64,    35,
+      36,    71,    41,    64,    69,    69,    42,    43,    44,    45,
+      46,    47,    48,    49,    50,    51,    52,    53,    54,    55,
+      56,    57,    69,    69,     3,     3,    42,    43,    44,    30,
+      37,    82,   181,   194,    70,    51,    52,    53,    54,    55,
+      56,    57,    68,   103,    -1,   132,    42,    43,    44,    -1,
+      -1,    -1,    -1,    -1,    70,    51,    52,    53,    54,    55,
+      56,    57,    -1,    -1,    -1,    -1,    42,    43,    44,    -1,
+      -1,    -1,    -1,    -1,    70,    51,    52,    53,    54,    55,
+      56,    57,    -1,    -1,    -1,    -1,    42,    43,    44,    -1,
+      -1,    -1,    -1,    -1,    70,    51,    52,    53,    54,    55,
+      56,    57,    -1,    -1,    42,    43,    44,    -1,    -1,    -1,
+      -1,    -1,    68,    51,    52,    53,    54,    55,    56,    57,
+      -1,    -1,    42,    43,    44,    -1,    -1,    -1,    -1,    -1,
+      68,    51,    52,    53,    54,    55,    56,    57,    -1,    32,
+      -1,    -1,    35,    36,    -1,    -1,    -1,    -1,    68,    42,
+      43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    42,    43,    44,    -1,    -1,
+      -1,    -1,    -1,    -1,    51,    52,    53,    54,    55,    56,
+      57,    43,    44,    -1,    -1,    -1,    -1,    -1,    -1,    51,
+      52,    53,    54,    55,    56,    57,    44,    -1,    -1,    -1,
       -1,    -1,    -1,    51,    52,    53,    54,    55,    56,    57,
-      43,    44,    -1,    -1,    -1,    -1,    -1,    -1,    51,    52,
-      53,    54,    55,    56,    57,    44,    -1,    -1,    -1,    -1,
-      -1,    -1,    51,    52,    53,    54,    55,    56,    57
+      51,    52,    53,    54,    55,    56,    57
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
@@ -862,14 +862,14 @@ static const yytype_uint8 yystos[] =
       40,    41,    32,    35,    36,    42,    43,    44,    45,    46,
       47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
       57,    91,    91,   112,    69,   105,   112,   112,   112,   112,
-      10,    32,    70,    70,    10,   112,    94,    95,    98,   103,
-     102,    34,    69,   107,    96,   112,   112,   112,   112,   112,
+       1,    10,    32,    70,    70,    10,   112,    94,    95,    98,
+     103,   102,    34,    69,   107,    96,   112,   112,   112,   112,
      112,   112,   112,   112,   112,   112,   112,   112,   112,   112,
-     112,   112,    22,    23,    24,    25,    92,   112,    68,    68,
-      70,    31,   107,    68,    70,    71,    97,    97,   108,     3,
-      99,    64,    98,    11,    15,   109,   110,   112,    69,   104,
-     105,   101,    70,    71,    70,   106,   112,    64,    69,   110,
-      70,    71,   100,    97,   112,    69,    70,    97,    70
+     112,   112,   112,    22,    23,    24,    25,    92,   112,    68,
+      68,    70,    31,   107,    68,    70,    71,    97,    97,   108,
+       3,    99,    64,    98,    11,    15,   109,   110,   112,    69,
+     104,   105,   101,    70,    71,    70,   106,   112,    64,    69,
+     110,    70,    71,   100,    97,   112,    69,    70,    97,    70
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
@@ -881,13 +881,13 @@ static const yytype_uint8 yyr1[] =
       86,    86,    87,    87,    89,    88,    90,    88,    88,    91,
       91,    92,    92,    92,    92,    93,    93,    93,    93,    94,
       94,    95,    95,    96,    97,    98,    98,    98,    98,    98,
-      98,    98,    99,   100,    98,   101,    98,    98,    98,   102,
-      98,   103,    98,    98,    98,    98,    98,    98,    98,    98,
-      98,   104,   104,   105,   106,   106,   108,   107,   107,   109,
-     109,   110,   110,   111,   111,   111,   112,   112,   112,   112,
+      98,    98,    98,    99,   100,    98,   101,    98,    98,    98,
+     102,    98,   103,    98,    98,    98,    98,    98,    98,    98,
+      98,    98,   104,   104,   105,   106,   106,   108,   107,   107,
+     109,   109,   110,   110,   111,   111,   111,   112,   112,   112,
      112,   112,   112,   112,   112,   112,   112,   112,   112,   112,
      112,   112,   112,   112,   112,   112,   112,   112,   112,   112,
-     112,   112
+     112,   112,   112
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
@@ -899,13 +899,13 @@ static const yytype_uint8 yyr2[] =
        3,     3,     1,     2,     0,     5,     0,     5,     3,     0,
        2,     1,     1,     1,     1,     1,     3,     4,     4,     0,
        1,     1,     3,     1,     1,     1,     1,     3,     3,     1,
-       3,     3,     0,     0,    11,     0,     9,     3,     2,     0,
-       4,     0,     4,     3,     3,     3,     3,     3,     3,     1,
-       3,     3,     1,     5,     1,     3,     0,     4,     1,     1,
-       3,     1,     1,     1,     1,     1,     3,     1,     1,     4,
-       1,     1,     1,     1,     4,     1,     4,     1,     1,     2,
-       3,     3,     3,     3,     3,     3,     3,     3,     2,     3,
-       3,     1
+       3,     3,     3,     0,     0,    11,     0,     9,     3,     2,
+       0,     4,     0,     4,     3,     3,     3,     3,     3,     3,
+       1,     3,     3,     1,     5,     1,     3,     0,     4,     1,
+       1,     3,     1,     1,     1,     1,     1,     3,     1,     1,
+       4,     1,     1,     1,     1,     4,     1,     4,     1,     1,
+       2,     3,     3,     3,     3,     3,     3,     3,     3,     2,
+       3,     3,     1
 };
 
 
@@ -1333,55 +1333,55 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, void *yyscanner, Y
   switch (yytype)
     {
           case 10: /* _IDENTIFIER_  */
-#line 181 "grammar.y" /* yacc.c:1257  */
+#line 194 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1339 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 11: /* _STRING_IDENTIFIER_  */
-#line 185 "grammar.y" /* yacc.c:1257  */
+#line 198 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1345 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 12: /* _STRING_COUNT_  */
-#line 182 "grammar.y" /* yacc.c:1257  */
+#line 195 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1351 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 13: /* _STRING_OFFSET_  */
-#line 183 "grammar.y" /* yacc.c:1257  */
+#line 196 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1357 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 14: /* _STRING_LENGTH_  */
-#line 184 "grammar.y" /* yacc.c:1257  */
+#line 197 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1363 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 15: /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
-#line 186 "grammar.y" /* yacc.c:1257  */
+#line 199 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).c_string)); }
 #line 1369 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 19: /* _TEXT_STRING_  */
-#line 187 "grammar.y" /* yacc.c:1257  */
+#line 200 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1375 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 20: /* _HEX_STRING_  */
-#line 188 "grammar.y" /* yacc.c:1257  */
+#line 201 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1381 "grammar.c" /* yacc.c:1257  */
         break;
 
     case 21: /* _REGEXP_  */
-#line 189 "grammar.y" /* yacc.c:1257  */
+#line 202 "grammar.y" /* yacc.c:1257  */
       { yr_free(((*yyvaluep).sized_string)); }
 #line 1387 "grammar.c" /* yacc.c:1257  */
         break;
@@ -1649,7 +1649,7 @@ yyreduce:
   switch (yyn)
     {
         case 8:
-#line 217 "grammar.y" /* yacc.c:1646  */
+#line 230 "grammar.y" /* yacc.c:1646  */
     {
         int result = yr_parser_reduce_import(yyscanner, (yyvsp[0].sized_string));
 
@@ -1661,7 +1661,7 @@ yyreduce:
     break;
 
   case 9:
-#line 229 "grammar.y" /* yacc.c:1646  */
+#line 242 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = yr_parser_reduce_rule_declaration_phase_1(
             yyscanner, (int32_t) (yyvsp[-2].integer), (yyvsp[0].c_string));
@@ -1674,7 +1674,7 @@ yyreduce:
     break;
 
   case 10:
-#line 238 "grammar.y" /* yacc.c:1646  */
+#line 251 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = (yyvsp[-4].rule); // rule created in phase 1
 
@@ -1686,7 +1686,7 @@ yyreduce:
     break;
 
   case 11:
-#line 246 "grammar.y" /* yacc.c:1646  */
+#line 259 "grammar.y" /* yacc.c:1646  */
     {
         YR_RULE* rule = (yyvsp[-7].rule); // rule created in phase 1
 
@@ -1701,7 +1701,7 @@ yyreduce:
     break;
 
   case 12:
-#line 261 "grammar.y" /* yacc.c:1646  */
+#line 274 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = NULL;
       }
@@ -1709,7 +1709,7 @@ yyreduce:
     break;
 
   case 13:
-#line 265 "grammar.y" /* yacc.c:1646  */
+#line 278 "grammar.y" /* yacc.c:1646  */
     {
         // Each rule have a list of meta-data info, consisting in a
         // sequence of YR_META structures. The last YR_META structure does
@@ -1736,7 +1736,7 @@ yyreduce:
     break;
 
   case 14:
-#line 292 "grammar.y" /* yacc.c:1646  */
+#line 305 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = NULL;
       }
@@ -1744,7 +1744,7 @@ yyreduce:
     break;
 
   case 15:
-#line 296 "grammar.y" /* yacc.c:1646  */
+#line 309 "grammar.y" /* yacc.c:1646  */
     {
         // Each rule have a list of strings, consisting in a sequence
         // of YR_STRING structures. The last YR_STRING structure does not
@@ -1771,31 +1771,31 @@ yyreduce:
     break;
 
   case 17:
-#line 327 "grammar.y" /* yacc.c:1646  */
+#line 340 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = 0;  }
 #line 1777 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 328 "grammar.y" /* yacc.c:1646  */
+#line 341 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
 #line 1783 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 333 "grammar.y" /* yacc.c:1646  */
+#line 346 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = RULE_GFLAGS_PRIVATE; }
 #line 1789 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 334 "grammar.y" /* yacc.c:1646  */
+#line 347 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = RULE_GFLAGS_GLOBAL; }
 #line 1795 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 340 "grammar.y" /* yacc.c:1646  */
+#line 353 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.c_string) = NULL;
       }
@@ -1803,7 +1803,7 @@ yyreduce:
     break;
 
   case 22:
-#line 344 "grammar.y" /* yacc.c:1646  */
+#line 357 "grammar.y" /* yacc.c:1646  */
     {
         // Tags list is represented in the arena as a sequence
         // of null-terminated strings, the sequence ends with an
@@ -1821,7 +1821,7 @@ yyreduce:
     break;
 
   case 23:
-#line 362 "grammar.y" /* yacc.c:1646  */
+#line 375 "grammar.y" /* yacc.c:1646  */
     {
         char* identifier;
 
@@ -1838,7 +1838,7 @@ yyreduce:
     break;
 
   case 24:
-#line 375 "grammar.y" /* yacc.c:1646  */
+#line 388 "grammar.y" /* yacc.c:1646  */
     {
         char* tag_name = (yyvsp[-1].c_string);
         size_t tag_length = tag_name != NULL ? strlen(tag_name) : 0;
@@ -1874,19 +1874,19 @@ yyreduce:
     break;
 
   case 25:
-#line 411 "grammar.y" /* yacc.c:1646  */
+#line 424 "grammar.y" /* yacc.c:1646  */
     {  (yyval.meta) = (yyvsp[0].meta); }
 #line 1880 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 412 "grammar.y" /* yacc.c:1646  */
+#line 425 "grammar.y" /* yacc.c:1646  */
     {  (yyval.meta) = (yyvsp[-1].meta); }
 #line 1886 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 418 "grammar.y" /* yacc.c:1646  */
+#line 431 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string = (yyvsp[0].sized_string);
 
@@ -1906,7 +1906,7 @@ yyreduce:
     break;
 
   case 28:
-#line 434 "grammar.y" /* yacc.c:1646  */
+#line 447 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1923,7 +1923,7 @@ yyreduce:
     break;
 
   case 29:
-#line 447 "grammar.y" /* yacc.c:1646  */
+#line 460 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1940,7 +1940,7 @@ yyreduce:
     break;
 
   case 30:
-#line 460 "grammar.y" /* yacc.c:1646  */
+#line 473 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1957,7 +1957,7 @@ yyreduce:
     break;
 
   case 31:
-#line 473 "grammar.y" /* yacc.c:1646  */
+#line 486 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.meta) = yr_parser_reduce_meta_declaration(
             yyscanner,
@@ -1974,19 +1974,19 @@ yyreduce:
     break;
 
   case 32:
-#line 489 "grammar.y" /* yacc.c:1646  */
+#line 502 "grammar.y" /* yacc.c:1646  */
     { (yyval.string) = (yyvsp[0].string); }
 #line 1980 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 490 "grammar.y" /* yacc.c:1646  */
+#line 503 "grammar.y" /* yacc.c:1646  */
     { (yyval.string) = (yyvsp[-1].string); }
 #line 1986 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 496 "grammar.y" /* yacc.c:1646  */
+#line 509 "grammar.y" /* yacc.c:1646  */
     {
         compiler->error_line = yyget_lineno(yyscanner);
       }
@@ -1994,7 +1994,7 @@ yyreduce:
     break;
 
   case 35:
-#line 500 "grammar.y" /* yacc.c:1646  */
+#line 513 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, (int32_t) (yyvsp[0].integer), (yyvsp[-4].c_string), (yyvsp[-1].sized_string));
@@ -2009,7 +2009,7 @@ yyreduce:
     break;
 
   case 36:
-#line 511 "grammar.y" /* yacc.c:1646  */
+#line 524 "grammar.y" /* yacc.c:1646  */
     {
         compiler->error_line = yyget_lineno(yyscanner);
       }
@@ -2017,7 +2017,7 @@ yyreduce:
     break;
 
   case 37:
-#line 515 "grammar.y" /* yacc.c:1646  */
+#line 528 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, (int32_t) (yyvsp[0].integer) | STRING_GFLAGS_REGEXP, (yyvsp[-4].c_string), (yyvsp[-1].sized_string));
@@ -2033,7 +2033,7 @@ yyreduce:
     break;
 
   case 38:
-#line 527 "grammar.y" /* yacc.c:1646  */
+#line 540 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.string) = yr_parser_reduce_string_declaration(
             yyscanner, STRING_GFLAGS_HEXADECIMAL, (yyvsp[-2].c_string), (yyvsp[0].sized_string));
@@ -2047,43 +2047,43 @@ yyreduce:
     break;
 
   case 39:
-#line 540 "grammar.y" /* yacc.c:1646  */
+#line 553 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = 0; }
 #line 2053 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 541 "grammar.y" /* yacc.c:1646  */
+#line 554 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
 #line 2059 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 546 "grammar.y" /* yacc.c:1646  */
+#line 559 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_WIDE; }
 #line 2065 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 547 "grammar.y" /* yacc.c:1646  */
+#line 560 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_ASCII; }
 #line 2071 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 548 "grammar.y" /* yacc.c:1646  */
+#line 561 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_NO_CASE; }
 #line 2077 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 549 "grammar.y" /* yacc.c:1646  */
+#line 562 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = STRING_GFLAGS_FULL_WORD; }
 #line 2083 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 555 "grammar.y" /* yacc.c:1646  */
+#line 568 "grammar.y" /* yacc.c:1646  */
     {
         int var_index = yr_parser_lookup_loop_variable(yyscanner, (yyvsp[0].c_string));
 
@@ -2172,7 +2172,7 @@ yyreduce:
     break;
 
   case 46:
-#line 640 "grammar.y" /* yacc.c:1646  */
+#line 653 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT* field = NULL;
 
@@ -2222,7 +2222,7 @@ yyreduce:
     break;
 
   case 47:
-#line 686 "grammar.y" /* yacc.c:1646  */
+#line 699 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT_ARRAY* array;
         YR_OBJECT_DICTIONARY* dict;
@@ -2283,7 +2283,7 @@ yyreduce:
     break;
 
   case 48:
-#line 744 "grammar.y" /* yacc.c:1646  */
+#line 757 "grammar.y" /* yacc.c:1646  */
     {
         YR_OBJECT_FUNCTION* function;
         char* args_fmt;
@@ -2328,19 +2328,19 @@ yyreduce:
     break;
 
   case 49:
-#line 788 "grammar.y" /* yacc.c:1646  */
+#line 801 "grammar.y" /* yacc.c:1646  */
     { (yyval.c_string) = yr_strdup(""); }
 #line 2334 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 789 "grammar.y" /* yacc.c:1646  */
+#line 802 "grammar.y" /* yacc.c:1646  */
     { (yyval.c_string) = (yyvsp[0].c_string); }
 #line 2340 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 794 "grammar.y" /* yacc.c:1646  */
+#line 807 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.c_string) = (char*) yr_malloc(MAX_FUNCTION_ARGS + 1);
 
@@ -2369,7 +2369,7 @@ yyreduce:
     break;
 
   case 52:
-#line 819 "grammar.y" /* yacc.c:1646  */
+#line 832 "grammar.y" /* yacc.c:1646  */
     {
         if (strlen((yyvsp[-2].c_string)) == MAX_FUNCTION_ARGS)
         {
@@ -2405,7 +2405,7 @@ yyreduce:
     break;
 
   case 53:
-#line 855 "grammar.y" /* yacc.c:1646  */
+#line 868 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string = (yyvsp[0].sized_string);
         RE* re;
@@ -2451,7 +2451,7 @@ yyreduce:
     break;
 
   case 54:
-#line 901 "grammar.y" /* yacc.c:1646  */
+#line 914 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_STRING)
         {
@@ -2474,7 +2474,7 @@ yyreduce:
     break;
 
   case 55:
-#line 923 "grammar.y" /* yacc.c:1646  */
+#line 936 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -2487,7 +2487,7 @@ yyreduce:
     break;
 
   case 56:
-#line 932 "grammar.y" /* yacc.c:1646  */
+#line 945 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 0, NULL, NULL);
@@ -2500,7 +2500,7 @@ yyreduce:
     break;
 
   case 57:
-#line 941 "grammar.y" /* yacc.c:1646  */
+#line 954 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "matches");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_REGEXP, "matches");
@@ -2519,7 +2519,7 @@ yyreduce:
     break;
 
   case 58:
-#line 956 "grammar.y" /* yacc.c:1646  */
+#line 969 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "contains");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_STRING, "contains");
@@ -2535,7 +2535,7 @@ yyreduce:
     break;
 
   case 59:
-#line 968 "grammar.y" /* yacc.c:1646  */
+#line 981 "grammar.y" /* yacc.c:1646  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner,
@@ -2553,7 +2553,7 @@ yyreduce:
     break;
 
   case 60:
-#line 982 "grammar.y" /* yacc.c:1646  */
+#line 995 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "at");
 
@@ -2570,7 +2570,7 @@ yyreduce:
     break;
 
   case 61:
-#line 995 "grammar.y" /* yacc.c:1646  */
+#line 1008 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-2].c_string), OP_FOUND_IN, UNDEFINED);
@@ -2585,7 +2585,16 @@ yyreduce:
     break;
 
   case 62:
-#line 1006 "grammar.y" /* yacc.c:1646  */
+#line 1019 "grammar.y" /* yacc.c:1646  */
+    {
+        compiler->loop_depth--;
+        compiler->loop_identifier[compiler->loop_depth] = NULL;
+      }
+#line 2594 "grammar.c" /* yacc.c:1646  */
+    break;
+
+  case 63:
+#line 1024 "grammar.y" /* yacc.c:1646  */
     {
         int var_index;
 
@@ -2615,11 +2624,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 2619 "grammar.c" /* yacc.c:1646  */
+#line 2628 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 63:
-#line 1036 "grammar.y" /* yacc.c:1646  */
+  case 64:
+#line 1054 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2654,11 +2663,11 @@ yyreduce:
         compiler->loop_identifier[compiler->loop_depth] = (yyvsp[-4].c_string);
         compiler->loop_depth++;
       }
-#line 2658 "grammar.c" /* yacc.c:1646  */
+#line 2667 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 64:
-#line 1071 "grammar.y" /* yacc.c:1646  */
+  case 65:
+#line 1089 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2739,11 +2748,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2743 "grammar.c" /* yacc.c:1646  */
+#line 2752 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 65:
-#line 1152 "grammar.y" /* yacc.c:1646  */
+  case 66:
+#line 1170 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2773,11 +2782,11 @@ yyreduce:
         compiler->loop_identifier[compiler->loop_depth] = NULL;
         compiler->loop_depth++;
       }
-#line 2777 "grammar.c" /* yacc.c:1646  */
+#line 2786 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 66:
-#line 1182 "grammar.y" /* yacc.c:1646  */
+  case 67:
+#line 1200 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2827,31 +2836,31 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
 
       }
-#line 2831 "grammar.c" /* yacc.c:1646  */
+#line 2840 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 67:
-#line 1232 "grammar.y" /* yacc.c:1646  */
+  case 68:
+#line 1250 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_OF, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2841 "grammar.c" /* yacc.c:1646  */
+#line 2850 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 68:
-#line 1238 "grammar.y" /* yacc.c:1646  */
+  case 69:
+#line 1256 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_NOT, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2851 "grammar.c" /* yacc.c:1646  */
+#line 2860 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 69:
-#line 1244 "grammar.y" /* yacc.c:1646  */
+  case 70:
+#line 1262 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         int64_t* jmp_destination_addr;
@@ -2877,11 +2886,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2881 "grammar.c" /* yacc.c:1646  */
+#line 2890 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 70:
-#line 1270 "grammar.y" /* yacc.c:1646  */
+  case 71:
+#line 1288 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* and_addr;
@@ -2917,11 +2926,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2921 "grammar.c" /* yacc.c:1646  */
+#line 2930 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 71:
-#line 1306 "grammar.y" /* yacc.c:1646  */
+  case 72:
+#line 1324 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         int64_t* jmp_destination_addr;
@@ -2946,11 +2955,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2950 "grammar.c" /* yacc.c:1646  */
+#line 2959 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 72:
-#line 1331 "grammar.y" /* yacc.c:1646  */
+  case 73:
+#line 1349 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* or_addr;
@@ -2986,11 +2995,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2990 "grammar.c" /* yacc.c:1646  */
+#line 2999 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 73:
-#line 1367 "grammar.y" /* yacc.c:1646  */
+  case 74:
+#line 1385 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -2999,11 +3008,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3003 "grammar.c" /* yacc.c:1646  */
+#line 3012 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 74:
-#line 1376 "grammar.y" /* yacc.c:1646  */
+  case 75:
+#line 1394 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3012,11 +3021,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3016 "grammar.c" /* yacc.c:1646  */
+#line 3025 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 75:
-#line 1385 "grammar.y" /* yacc.c:1646  */
+  case 76:
+#line 1403 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3025,11 +3034,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3029 "grammar.c" /* yacc.c:1646  */
+#line 3038 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 76:
-#line 1394 "grammar.y" /* yacc.c:1646  */
+  case 77:
+#line 1412 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3038,11 +3047,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3042 "grammar.c" /* yacc.c:1646  */
+#line 3051 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 77:
-#line 1403 "grammar.y" /* yacc.c:1646  */
+  case 78:
+#line 1421 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "==", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3051,11 +3060,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3055 "grammar.c" /* yacc.c:1646  */
+#line 3064 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 78:
-#line 1412 "grammar.y" /* yacc.c:1646  */
+  case 79:
+#line 1430 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "!=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3064,39 +3073,39 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3068 "grammar.c" /* yacc.c:1646  */
-    break;
-
-  case 79:
-#line 1421 "grammar.y" /* yacc.c:1646  */
-    {
-        (yyval.expression) = (yyvsp[0].expression);
-      }
-#line 3076 "grammar.c" /* yacc.c:1646  */
+#line 3077 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 1425 "grammar.y" /* yacc.c:1646  */
+#line 1439 "grammar.y" /* yacc.c:1646  */
     {
-        (yyval.expression) = (yyvsp[-1].expression);
+        (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3084 "grammar.c" /* yacc.c:1646  */
+#line 3085 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 1432 "grammar.y" /* yacc.c:1646  */
-    { (yyval.integer) = INTEGER_SET_ENUMERATION; }
-#line 3090 "grammar.c" /* yacc.c:1646  */
+#line 1443 "grammar.y" /* yacc.c:1646  */
+    {
+        (yyval.expression) = (yyvsp[-1].expression);
+      }
+#line 3093 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 1433 "grammar.y" /* yacc.c:1646  */
-    { (yyval.integer) = INTEGER_SET_RANGE; }
-#line 3096 "grammar.c" /* yacc.c:1646  */
+#line 1450 "grammar.y" /* yacc.c:1646  */
+    { (yyval.integer) = INTEGER_SET_ENUMERATION; }
+#line 3099 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 1439 "grammar.y" /* yacc.c:1646  */
+#line 1451 "grammar.y" /* yacc.c:1646  */
+    { (yyval.integer) = INTEGER_SET_RANGE; }
+#line 3105 "grammar.c" /* yacc.c:1646  */
+    break;
+
+  case 84:
+#line 1457 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[-3].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3114,27 +3123,27 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3118 "grammar.c" /* yacc.c:1646  */
-    break;
-
-  case 84:
-#line 1461 "grammar.y" /* yacc.c:1646  */
-    {
-        if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
-        {
-          yr_compiler_set_error_extra_info(
-              compiler, "wrong type for enumeration item");
-          compiler->last_result = ERROR_WRONG_TYPE;
-
-        }
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3134 "grammar.c" /* yacc.c:1646  */
+#line 3127 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 1473 "grammar.y" /* yacc.c:1646  */
+#line 1479 "grammar.y" /* yacc.c:1646  */
+    {
+        if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
+        {
+          yr_compiler_set_error_extra_info(
+              compiler, "wrong type for enumeration item");
+          compiler->last_result = ERROR_WRONG_TYPE;
+
+        }
+
+        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+      }
+#line 3143 "grammar.c" /* yacc.c:1646  */
+    break;
+
+  case 86:
+#line 1491 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3144,78 +3153,78 @@ yyreduce:
         }
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3149 "grammar.c" /* yacc.c:1646  */
-    break;
-
-  case 86:
-#line 1488 "grammar.y" /* yacc.c:1646  */
-    {
-        // Push end-of-list marker
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
 #line 3158 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 88:
-#line 1494 "grammar.y" /* yacc.c:1646  */
+  case 87:
+#line 1506 "grammar.y" /* yacc.c:1646  */
+    {
+        // Push end-of-list marker
+        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
+      }
+#line 3167 "grammar.c" /* yacc.c:1646  */
+    break;
+
+  case 89:
+#line 1512 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
         yr_parser_emit_pushes_for_strings(yyscanner, "$*");
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3169 "grammar.c" /* yacc.c:1646  */
-    break;
-
-  case 91:
-#line 1511 "grammar.y" /* yacc.c:1646  */
-    {
-        yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3180 "grammar.c" /* yacc.c:1646  */
+#line 3178 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 1518 "grammar.y" /* yacc.c:1646  */
+#line 1529 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
         yr_free((yyvsp[0].c_string));
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3191 "grammar.c" /* yacc.c:1646  */
+#line 3189 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 94:
-#line 1530 "grammar.y" /* yacc.c:1646  */
+  case 93:
+#line 1536 "grammar.y" /* yacc.c:1646  */
     {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
+        yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
+        yr_free((yyvsp[0].c_string));
+
+        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3199 "grammar.c" /* yacc.c:1646  */
+#line 3200 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 1534 "grammar.y" /* yacc.c:1646  */
+#line 1548 "grammar.y" /* yacc.c:1646  */
     {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL, NULL);
+        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
-#line 3207 "grammar.c" /* yacc.c:1646  */
+#line 3208 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 1542 "grammar.y" /* yacc.c:1646  */
+#line 1552 "grammar.y" /* yacc.c:1646  */
     {
-        (yyval.expression) = (yyvsp[-1].expression);
+        yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL, NULL);
       }
-#line 3215 "grammar.c" /* yacc.c:1646  */
+#line 3216 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 1546 "grammar.y" /* yacc.c:1646  */
+#line 1560 "grammar.y" /* yacc.c:1646  */
+    {
+        (yyval.expression) = (yyvsp[-1].expression);
+      }
+#line 3224 "grammar.c" /* yacc.c:1646  */
+    break;
+
+  case 98:
+#line 1564 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit(
             yyscanner, OP_FILESIZE, NULL);
@@ -3225,11 +3234,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3229 "grammar.c" /* yacc.c:1646  */
+#line 3238 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 98:
-#line 1556 "grammar.y" /* yacc.c:1646  */
+  case 99:
+#line 1574 "grammar.y" /* yacc.c:1646  */
     {
         yywarning(yyscanner,
             "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" "
@@ -3243,11 +3252,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3247 "grammar.c" /* yacc.c:1646  */
+#line 3256 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 99:
-#line 1570 "grammar.y" /* yacc.c:1646  */
+  case 100:
+#line 1588 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-1].expression), EXPRESSION_TYPE_INTEGER, "intXXXX or uintXXXX");
 
@@ -3263,11 +3272,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3267 "grammar.c" /* yacc.c:1646  */
+#line 3276 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 100:
-#line 1586 "grammar.y" /* yacc.c:1646  */
+  case 101:
+#line 1604 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, (yyvsp[0].integer), NULL, NULL);
@@ -3277,11 +3286,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = (yyvsp[0].integer);
       }
-#line 3281 "grammar.c" /* yacc.c:1646  */
+#line 3290 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 101:
-#line 1596 "grammar.y" /* yacc.c:1646  */
+  case 102:
+#line 1614 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg_double(
             yyscanner, OP_PUSH, (yyvsp[0].double_), NULL, NULL);
@@ -3290,11 +3299,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
       }
-#line 3294 "grammar.c" /* yacc.c:1646  */
+#line 3303 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 102:
-#line 1605 "grammar.y" /* yacc.c:1646  */
+  case 103:
+#line 1623 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string;
 
@@ -3319,11 +3328,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_STRING;
         (yyval.expression).value.sized_string = sized_string;
       }
-#line 3323 "grammar.c" /* yacc.c:1646  */
+#line 3332 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 103:
-#line 1630 "grammar.y" /* yacc.c:1646  */
+  case 104:
+#line 1648 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[0].c_string), OP_COUNT, UNDEFINED);
@@ -3335,11 +3344,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3339 "grammar.c" /* yacc.c:1646  */
+#line 3348 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 104:
-#line 1642 "grammar.y" /* yacc.c:1646  */
+  case 105:
+#line 1660 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_OFFSET, UNDEFINED);
@@ -3351,11 +3360,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3355 "grammar.c" /* yacc.c:1646  */
+#line 3364 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 105:
-#line 1654 "grammar.y" /* yacc.c:1646  */
+  case 106:
+#line 1672 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3371,11 +3380,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3375 "grammar.c" /* yacc.c:1646  */
+#line 3384 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 106:
-#line 1670 "grammar.y" /* yacc.c:1646  */
+  case 107:
+#line 1688 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_LENGTH, UNDEFINED);
@@ -3387,11 +3396,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3391 "grammar.c" /* yacc.c:1646  */
+#line 3400 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 107:
-#line 1682 "grammar.y" /* yacc.c:1646  */
+  case 108:
+#line 1700 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3407,11 +3416,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3411 "grammar.c" /* yacc.c:1646  */
+#line 3420 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 108:
-#line 1698 "grammar.y" /* yacc.c:1646  */
+  case 109:
+#line 1716 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_INTEGER)  // loop identifier
         {
@@ -3456,11 +3465,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3460 "grammar.c" /* yacc.c:1646  */
+#line 3469 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 109:
-#line 1743 "grammar.y" /* yacc.c:1646  */
+  case 110:
+#line 1761 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER | EXPRESSION_TYPE_FLOAT, "-");
 
@@ -3479,11 +3488,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3483 "grammar.c" /* yacc.c:1646  */
+#line 3492 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 110:
-#line 1762 "grammar.y" /* yacc.c:1646  */
+  case 111:
+#line 1780 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "+", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3501,11 +3510,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3505 "grammar.c" /* yacc.c:1646  */
+#line 3514 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 111:
-#line 1780 "grammar.y" /* yacc.c:1646  */
+  case 112:
+#line 1798 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "-", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3523,11 +3532,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3527 "grammar.c" /* yacc.c:1646  */
+#line 3536 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 112:
-#line 1798 "grammar.y" /* yacc.c:1646  */
+  case 113:
+#line 1816 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "*", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3545,11 +3554,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3549 "grammar.c" /* yacc.c:1646  */
+#line 3558 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 113:
-#line 1816 "grammar.y" /* yacc.c:1646  */
+  case 114:
+#line 1834 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "\\", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3575,11 +3584,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3579 "grammar.c" /* yacc.c:1646  */
+#line 3588 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 114:
-#line 1842 "grammar.y" /* yacc.c:1646  */
+  case 115:
+#line 1860 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "%");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "%");
@@ -3597,11 +3606,11 @@ yyreduce:
           ERROR_IF(compiler->last_result != ERROR_SUCCESS);
         }
       }
-#line 3601 "grammar.c" /* yacc.c:1646  */
+#line 3610 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 115:
-#line 1860 "grammar.y" /* yacc.c:1646  */
+  case 116:
+#line 1878 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3611,11 +3620,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(^, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3615 "grammar.c" /* yacc.c:1646  */
+#line 3624 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 116:
-#line 1870 "grammar.y" /* yacc.c:1646  */
+  case 117:
+#line 1888 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3625,11 +3634,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(&, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3629 "grammar.c" /* yacc.c:1646  */
+#line 3638 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 117:
-#line 1880 "grammar.y" /* yacc.c:1646  */
+  case 118:
+#line 1898 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "|");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "|");
@@ -3639,11 +3648,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(|, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3643 "grammar.c" /* yacc.c:1646  */
+#line 3652 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 118:
-#line 1890 "grammar.y" /* yacc.c:1646  */
+  case 119:
+#line 1908 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "~");
 
@@ -3653,11 +3662,11 @@ yyreduce:
         (yyval.expression).value.integer = ((yyvsp[0].expression).value.integer == UNDEFINED) ?
             UNDEFINED : ~((yyvsp[0].expression).value.integer);
       }
-#line 3657 "grammar.c" /* yacc.c:1646  */
+#line 3666 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 119:
-#line 1900 "grammar.y" /* yacc.c:1646  */
+  case 120:
+#line 1918 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "<<");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "<<");
@@ -3667,11 +3676,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(<<, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3671 "grammar.c" /* yacc.c:1646  */
+#line 3680 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 120:
-#line 1910 "grammar.y" /* yacc.c:1646  */
+  case 121:
+#line 1928 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, ">>");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, ">>");
@@ -3681,19 +3690,19 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(>>, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3685 "grammar.c" /* yacc.c:1646  */
+#line 3694 "grammar.c" /* yacc.c:1646  */
     break;
 
-  case 121:
-#line 1920 "grammar.y" /* yacc.c:1646  */
+  case 122:
+#line 1938 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3693 "grammar.c" /* yacc.c:1646  */
+#line 3702 "grammar.c" /* yacc.c:1646  */
     break;
 
 
-#line 3697 "grammar.c" /* yacc.c:1646  */
+#line 3706 "grammar.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3921,5 +3930,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1925 "grammar.y" /* yacc.c:1906  */
+#line 1943 "grammar.y" /* yacc.c:1906  */
 

--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -611,14 +611,14 @@ static const yytype_uint16 yyrline[] =
      347,   353,   356,   374,   387,   424,   425,   430,   446,   459,
      472,   485,   502,   503,   509,   508,   524,   523,   539,   553,
      554,   559,   560,   561,   562,   567,   652,   698,   756,   801,
-     802,   806,   831,   867,   913,   935,   944,   953,   968,   980,
-     994,  1007,  1018,  1024,  1054,  1023,  1170,  1169,  1249,  1255,
-    1262,  1261,  1324,  1323,  1384,  1393,  1402,  1411,  1420,  1429,
-    1438,  1442,  1450,  1451,  1456,  1478,  1490,  1506,  1505,  1511,
-    1522,  1523,  1528,  1535,  1546,  1547,  1551,  1559,  1563,  1573,
-    1587,  1603,  1613,  1622,  1647,  1659,  1671,  1687,  1699,  1715,
-    1760,  1779,  1797,  1815,  1833,  1859,  1877,  1887,  1897,  1907,
-    1917,  1927,  1937
+     802,   806,   833,   871,   917,   939,   948,   957,   972,   984,
+     998,  1011,  1022,  1033,  1063,  1032,  1179,  1178,  1258,  1264,
+    1271,  1270,  1333,  1332,  1393,  1402,  1411,  1420,  1429,  1438,
+    1447,  1451,  1459,  1460,  1465,  1487,  1499,  1515,  1514,  1520,
+    1531,  1532,  1537,  1544,  1555,  1556,  1560,  1568,  1572,  1582,
+    1596,  1612,  1622,  1631,  1656,  1668,  1680,  1696,  1708,  1724,
+    1769,  1788,  1806,  1824,  1842,  1868,  1886,  1896,  1906,  1916,
+    1926,  1936,  1946
 };
 #endif
 
@@ -2361,15 +2361,17 @@ yyreduce:
           case EXPRESSION_TYPE_REGEXP:
             strlcpy((yyval.c_string), "r", MAX_FUNCTION_ARGS);
             break;
+          default:
+            assert(FALSE);
         }
 
         ERROR_IF((yyval.c_string) == NULL);
       }
-#line 2369 "grammar.c" /* yacc.c:1646  */
+#line 2371 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 832 "grammar.y" /* yacc.c:1646  */
+#line 834 "grammar.y" /* yacc.c:1646  */
     {
         if (strlen((yyvsp[-2].c_string)) == MAX_FUNCTION_ARGS)
         {
@@ -2394,6 +2396,8 @@ yyreduce:
             case EXPRESSION_TYPE_REGEXP:
               strlcat((yyvsp[-2].c_string), "r", MAX_FUNCTION_ARGS);
               break;
+            default:
+              assert(FALSE);
           }
         }
 
@@ -2401,11 +2405,11 @@ yyreduce:
 
         (yyval.c_string) = (yyvsp[-2].c_string);
       }
-#line 2405 "grammar.c" /* yacc.c:1646  */
+#line 2409 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 868 "grammar.y" /* yacc.c:1646  */
+#line 872 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string = (yyvsp[0].sized_string);
         RE* re;
@@ -2447,11 +2451,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_REGEXP;
       }
-#line 2451 "grammar.c" /* yacc.c:1646  */
+#line 2455 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 914 "grammar.y" /* yacc.c:1646  */
+#line 918 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_STRING)
         {
@@ -2470,11 +2474,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2474 "grammar.c" /* yacc.c:1646  */
+#line 2478 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 936 "grammar.y" /* yacc.c:1646  */
+#line 940 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -2483,11 +2487,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2487 "grammar.c" /* yacc.c:1646  */
+#line 2491 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 945 "grammar.y" /* yacc.c:1646  */
+#line 949 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 0, NULL, NULL);
@@ -2496,11 +2500,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2500 "grammar.c" /* yacc.c:1646  */
+#line 2504 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 954 "grammar.y" /* yacc.c:1646  */
+#line 958 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "matches");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_REGEXP, "matches");
@@ -2515,11 +2519,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2519 "grammar.c" /* yacc.c:1646  */
+#line 2523 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 969 "grammar.y" /* yacc.c:1646  */
+#line 973 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_STRING, "contains");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_STRING, "contains");
@@ -2531,11 +2535,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2535 "grammar.c" /* yacc.c:1646  */
+#line 2539 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 981 "grammar.y" /* yacc.c:1646  */
+#line 985 "grammar.y" /* yacc.c:1646  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner,
@@ -2549,11 +2553,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2553 "grammar.c" /* yacc.c:1646  */
+#line 2557 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 995 "grammar.y" /* yacc.c:1646  */
+#line 999 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "at");
 
@@ -2566,11 +2570,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2570 "grammar.c" /* yacc.c:1646  */
+#line 2574 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 1008 "grammar.y" /* yacc.c:1646  */
+#line 1012 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-2].c_string), OP_FOUND_IN, UNDEFINED);
@@ -2581,20 +2585,25 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2585 "grammar.c" /* yacc.c:1646  */
+#line 2589 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 1019 "grammar.y" /* yacc.c:1646  */
+#line 1023 "grammar.y" /* yacc.c:1646  */
     {
-        compiler->loop_depth--;
-        compiler->loop_identifier[compiler->loop_depth] = NULL;
+        if (compiler->loop_depth > 0)
+        {
+          compiler->loop_depth--;
+          compiler->loop_identifier[compiler->loop_depth] = NULL;
+        }
+
+        YYERROR;
       }
-#line 2594 "grammar.c" /* yacc.c:1646  */
+#line 2603 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 1024 "grammar.y" /* yacc.c:1646  */
+#line 1033 "grammar.y" /* yacc.c:1646  */
     {
         int var_index;
 
@@ -2624,11 +2633,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 2628 "grammar.c" /* yacc.c:1646  */
+#line 2637 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 1054 "grammar.y" /* yacc.c:1646  */
+#line 1063 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2663,11 +2672,11 @@ yyreduce:
         compiler->loop_identifier[compiler->loop_depth] = (yyvsp[-4].c_string);
         compiler->loop_depth++;
       }
-#line 2667 "grammar.c" /* yacc.c:1646  */
+#line 2676 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 1089 "grammar.y" /* yacc.c:1646  */
+#line 1098 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2748,11 +2757,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2752 "grammar.c" /* yacc.c:1646  */
+#line 2761 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 1170 "grammar.y" /* yacc.c:1646  */
+#line 1179 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
         uint8_t* addr;
@@ -2782,11 +2791,11 @@ yyreduce:
         compiler->loop_identifier[compiler->loop_depth] = NULL;
         compiler->loop_depth++;
       }
-#line 2786 "grammar.c" /* yacc.c:1646  */
+#line 2795 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 1200 "grammar.y" /* yacc.c:1646  */
+#line 1209 "grammar.y" /* yacc.c:1646  */
     {
         int mem_offset;
 
@@ -2836,31 +2845,31 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
 
       }
-#line 2840 "grammar.c" /* yacc.c:1646  */
+#line 2849 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 1250 "grammar.y" /* yacc.c:1646  */
+#line 1259 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_OF, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2850 "grammar.c" /* yacc.c:1646  */
+#line 2859 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 1256 "grammar.y" /* yacc.c:1646  */
+#line 1265 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit(yyscanner, OP_NOT, NULL);
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2860 "grammar.c" /* yacc.c:1646  */
+#line 2869 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 1262 "grammar.y" /* yacc.c:1646  */
+#line 1271 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         int64_t* jmp_destination_addr;
@@ -2886,11 +2895,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2890 "grammar.c" /* yacc.c:1646  */
+#line 2899 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 1288 "grammar.y" /* yacc.c:1646  */
+#line 1297 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* and_addr;
@@ -2926,11 +2935,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2930 "grammar.c" /* yacc.c:1646  */
+#line 2939 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 1324 "grammar.y" /* yacc.c:1646  */
+#line 1333 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         int64_t* jmp_destination_addr;
@@ -2955,11 +2964,11 @@ yyreduce:
         fixup->next = compiler->fixup_stack_head;
         compiler->fixup_stack_head = fixup;
       }
-#line 2959 "grammar.c" /* yacc.c:1646  */
+#line 2968 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 1349 "grammar.y" /* yacc.c:1646  */
+#line 1358 "grammar.y" /* yacc.c:1646  */
     {
         YR_FIXUP* fixup;
         uint8_t* or_addr;
@@ -2995,11 +3004,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 2999 "grammar.c" /* yacc.c:1646  */
+#line 3008 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 1385 "grammar.y" /* yacc.c:1646  */
+#line 1394 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3008,11 +3017,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3012 "grammar.c" /* yacc.c:1646  */
+#line 3021 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 1394 "grammar.y" /* yacc.c:1646  */
+#line 1403 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3021,11 +3030,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3025 "grammar.c" /* yacc.c:1646  */
+#line 3034 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 1403 "grammar.y" /* yacc.c:1646  */
+#line 1412 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "<=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3034,11 +3043,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3038 "grammar.c" /* yacc.c:1646  */
+#line 3047 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 1412 "grammar.y" /* yacc.c:1646  */
+#line 1421 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, ">=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3047,11 +3056,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3051 "grammar.c" /* yacc.c:1646  */
+#line 3060 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 1421 "grammar.y" /* yacc.c:1646  */
+#line 1430 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "==", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3060,11 +3069,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3064 "grammar.c" /* yacc.c:1646  */
+#line 3073 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 1430 "grammar.y" /* yacc.c:1646  */
+#line 1439 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "!=", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3073,39 +3082,39 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_BOOLEAN;
       }
-#line 3077 "grammar.c" /* yacc.c:1646  */
+#line 3086 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 1439 "grammar.y" /* yacc.c:1646  */
+#line 1448 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3085 "grammar.c" /* yacc.c:1646  */
+#line 3094 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 1443 "grammar.y" /* yacc.c:1646  */
+#line 1452 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[-1].expression);
       }
-#line 3093 "grammar.c" /* yacc.c:1646  */
+#line 3102 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 1450 "grammar.y" /* yacc.c:1646  */
+#line 1459 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = INTEGER_SET_ENUMERATION; }
-#line 3099 "grammar.c" /* yacc.c:1646  */
+#line 3108 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 1451 "grammar.y" /* yacc.c:1646  */
+#line 1460 "grammar.y" /* yacc.c:1646  */
     { (yyval.integer) = INTEGER_SET_RANGE; }
-#line 3105 "grammar.c" /* yacc.c:1646  */
+#line 3114 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 1457 "grammar.y" /* yacc.c:1646  */
+#line 1466 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[-3].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3123,11 +3132,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3127 "grammar.c" /* yacc.c:1646  */
+#line 3136 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 1479 "grammar.y" /* yacc.c:1646  */
+#line 1488 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3139,11 +3148,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3143 "grammar.c" /* yacc.c:1646  */
+#line 3152 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 1491 "grammar.y" /* yacc.c:1646  */
+#line 1500 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type != EXPRESSION_TYPE_INTEGER)
         {
@@ -3153,78 +3162,78 @@ yyreduce:
         }
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3158 "grammar.c" /* yacc.c:1646  */
-    break;
-
-  case 87:
-#line 1506 "grammar.y" /* yacc.c:1646  */
-    {
-        // Push end-of-list marker
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
 #line 3167 "grammar.c" /* yacc.c:1646  */
     break;
 
+  case 87:
+#line 1515 "grammar.y" /* yacc.c:1646  */
+    {
+        // Push end-of-list marker
+        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
+      }
+#line 3176 "grammar.c" /* yacc.c:1646  */
+    break;
+
   case 89:
-#line 1512 "grammar.y" /* yacc.c:1646  */
+#line 1521 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
         yr_parser_emit_pushes_for_strings(yyscanner, "$*");
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3178 "grammar.c" /* yacc.c:1646  */
+#line 3187 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 1529 "grammar.y" /* yacc.c:1646  */
+#line 1538 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
         yr_free((yyvsp[0].c_string));
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3189 "grammar.c" /* yacc.c:1646  */
+#line 3198 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 1536 "grammar.y" /* yacc.c:1646  */
+#line 1545 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
         yr_free((yyvsp[0].c_string));
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3200 "grammar.c" /* yacc.c:1646  */
+#line 3209 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 1548 "grammar.y" /* yacc.c:1646  */
+#line 1557 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL, NULL);
       }
-#line 3208 "grammar.c" /* yacc.c:1646  */
+#line 3217 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 1552 "grammar.y" /* yacc.c:1646  */
+#line 1561 "grammar.y" /* yacc.c:1646  */
     {
         yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL, NULL);
       }
-#line 3216 "grammar.c" /* yacc.c:1646  */
+#line 3225 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 1560 "grammar.y" /* yacc.c:1646  */
+#line 1569 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[-1].expression);
       }
-#line 3224 "grammar.c" /* yacc.c:1646  */
+#line 3233 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 1564 "grammar.y" /* yacc.c:1646  */
+#line 1573 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit(
             yyscanner, OP_FILESIZE, NULL);
@@ -3234,11 +3243,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3238 "grammar.c" /* yacc.c:1646  */
+#line 3247 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 1574 "grammar.y" /* yacc.c:1646  */
+#line 1583 "grammar.y" /* yacc.c:1646  */
     {
         yywarning(yyscanner,
             "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" "
@@ -3252,11 +3261,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3256 "grammar.c" /* yacc.c:1646  */
+#line 3265 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 1588 "grammar.y" /* yacc.c:1646  */
+#line 1597 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-1].expression), EXPRESSION_TYPE_INTEGER, "intXXXX or uintXXXX");
 
@@ -3272,11 +3281,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3276 "grammar.c" /* yacc.c:1646  */
+#line 3285 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 1604 "grammar.y" /* yacc.c:1646  */
+#line 1613 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, (yyvsp[0].integer), NULL, NULL);
@@ -3286,11 +3295,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = (yyvsp[0].integer);
       }
-#line 3290 "grammar.c" /* yacc.c:1646  */
+#line 3299 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 1614 "grammar.y" /* yacc.c:1646  */
+#line 1623 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg_double(
             yyscanner, OP_PUSH, (yyvsp[0].double_), NULL, NULL);
@@ -3299,11 +3308,11 @@ yyreduce:
 
         (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
       }
-#line 3303 "grammar.c" /* yacc.c:1646  */
+#line 3312 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 1623 "grammar.y" /* yacc.c:1646  */
+#line 1632 "grammar.y" /* yacc.c:1646  */
     {
         SIZED_STRING* sized_string;
 
@@ -3328,11 +3337,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_STRING;
         (yyval.expression).value.sized_string = sized_string;
       }
-#line 3332 "grammar.c" /* yacc.c:1646  */
+#line 3341 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 1648 "grammar.y" /* yacc.c:1646  */
+#line 1657 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[0].c_string), OP_COUNT, UNDEFINED);
@@ -3344,11 +3353,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3348 "grammar.c" /* yacc.c:1646  */
+#line 3357 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 1660 "grammar.y" /* yacc.c:1646  */
+#line 1669 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_OFFSET, UNDEFINED);
@@ -3360,11 +3369,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3364 "grammar.c" /* yacc.c:1646  */
+#line 3373 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 1672 "grammar.y" /* yacc.c:1646  */
+#line 1681 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3380,11 +3389,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3384 "grammar.c" /* yacc.c:1646  */
+#line 3393 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 1688 "grammar.y" /* yacc.c:1646  */
+#line 1697 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_LENGTH, UNDEFINED);
@@ -3396,11 +3405,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3400 "grammar.c" /* yacc.c:1646  */
+#line 3409 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 1700 "grammar.y" /* yacc.c:1646  */
+#line 1709 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -3416,11 +3425,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = UNDEFINED;
       }
-#line 3420 "grammar.c" /* yacc.c:1646  */
+#line 3429 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 1716 "grammar.y" /* yacc.c:1646  */
+#line 1725 "grammar.y" /* yacc.c:1646  */
     {
         if ((yyvsp[0].expression).type == EXPRESSION_TYPE_INTEGER)  // loop identifier
         {
@@ -3465,11 +3474,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3469 "grammar.c" /* yacc.c:1646  */
+#line 3478 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 1761 "grammar.y" /* yacc.c:1646  */
+#line 1770 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER | EXPRESSION_TYPE_FLOAT, "-");
 
@@ -3488,11 +3497,11 @@ yyreduce:
 
         ERROR_IF(compiler->last_result != ERROR_SUCCESS);
       }
-#line 3492 "grammar.c" /* yacc.c:1646  */
+#line 3501 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 1780 "grammar.y" /* yacc.c:1646  */
+#line 1789 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "+", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3510,11 +3519,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3514 "grammar.c" /* yacc.c:1646  */
+#line 3523 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 1798 "grammar.y" /* yacc.c:1646  */
+#line 1807 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "-", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3532,11 +3541,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3536 "grammar.c" /* yacc.c:1646  */
+#line 3545 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 1816 "grammar.y" /* yacc.c:1646  */
+#line 1825 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "*", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3554,11 +3563,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3558 "grammar.c" /* yacc.c:1646  */
+#line 3567 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 1834 "grammar.y" /* yacc.c:1646  */
+#line 1843 "grammar.y" /* yacc.c:1646  */
     {
         compiler->last_result = yr_parser_reduce_operation(
             yyscanner, "\\", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -3584,11 +3593,11 @@ yyreduce:
           (yyval.expression).type = EXPRESSION_TYPE_FLOAT;
         }
       }
-#line 3588 "grammar.c" /* yacc.c:1646  */
+#line 3597 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 1860 "grammar.y" /* yacc.c:1646  */
+#line 1869 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "%");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "%");
@@ -3606,11 +3615,11 @@ yyreduce:
           ERROR_IF(compiler->last_result != ERROR_SUCCESS);
         }
       }
-#line 3610 "grammar.c" /* yacc.c:1646  */
+#line 3619 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 1878 "grammar.y" /* yacc.c:1646  */
+#line 1887 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3620,11 +3629,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(^, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3624 "grammar.c" /* yacc.c:1646  */
+#line 3633 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1888 "grammar.y" /* yacc.c:1646  */
+#line 1897 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -3634,11 +3643,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(&, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3638 "grammar.c" /* yacc.c:1646  */
+#line 3647 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 1898 "grammar.y" /* yacc.c:1646  */
+#line 1907 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "|");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "|");
@@ -3648,11 +3657,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(|, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3652 "grammar.c" /* yacc.c:1646  */
+#line 3661 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1908 "grammar.y" /* yacc.c:1646  */
+#line 1917 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "~");
 
@@ -3662,11 +3671,11 @@ yyreduce:
         (yyval.expression).value.integer = ((yyvsp[0].expression).value.integer == UNDEFINED) ?
             UNDEFINED : ~((yyvsp[0].expression).value.integer);
       }
-#line 3666 "grammar.c" /* yacc.c:1646  */
+#line 3675 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1918 "grammar.y" /* yacc.c:1646  */
+#line 1927 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "<<");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "<<");
@@ -3676,11 +3685,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(<<, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3680 "grammar.c" /* yacc.c:1646  */
+#line 3689 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1928 "grammar.y" /* yacc.c:1646  */
+#line 1937 "grammar.y" /* yacc.c:1646  */
     {
         CHECK_TYPE((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, ">>");
         CHECK_TYPE((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, ">>");
@@ -3690,19 +3699,19 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(>>, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 3694 "grammar.c" /* yacc.c:1646  */
+#line 3703 "grammar.c" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 1938 "grammar.y" /* yacc.c:1646  */
+#line 1947 "grammar.y" /* yacc.c:1646  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 3702 "grammar.c" /* yacc.c:1646  */
+#line 3711 "grammar.c" /* yacc.c:1646  */
     break;
 
 
-#line 3706 "grammar.c" /* yacc.c:1646  */
+#line 3715 "grammar.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3930,5 +3939,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1943 "grammar.y" /* yacc.c:1906  */
+#line 1952 "grammar.y" /* yacc.c:1906  */
 

--- a/libyara/grammar.h
+++ b/libyara/grammar.h
@@ -152,7 +152,7 @@ extern int yara_yydebug;
 
 union YYSTYPE
 {
-#line 191 "grammar.y" /* yacc.c:1909  */
+#line 204 "grammar.y" /* yacc.c:1909  */
 
   EXPRESSION      expression;
   SIZED_STRING*   sized_string;

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -1017,8 +1017,11 @@ expression
       }
     | _FOR_ for_expression error
       {
-        compiler->loop_depth--;
-        compiler->loop_identifier[compiler->loop_depth] = NULL;
+        if (compiler->loop_depth > 0)
+        {
+          compiler->loop_depth--;
+          compiler->loop_identifier[compiler->loop_depth] = NULL;
+        }
       }
     | _FOR_ for_expression _IDENTIFIER_ _IN_
       {

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -824,6 +824,8 @@ arguments_list
           case EXPRESSION_TYPE_REGEXP:
             strlcpy($$, "r", MAX_FUNCTION_ARGS);
             break;
+          default:
+            assert(FALSE);
         }
 
         ERROR_IF($$ == NULL);
@@ -853,6 +855,8 @@ arguments_list
             case EXPRESSION_TYPE_REGEXP:
               strlcat($1, "r", MAX_FUNCTION_ARGS);
               break;
+            default:
+              assert(FALSE);
           }
         }
 
@@ -1022,6 +1026,8 @@ expression
           compiler->loop_depth--;
           compiler->loop_identifier[compiler->loop_depth] = NULL;
         }
+
+        YYERROR;
       }
     | _FOR_ for_expression _IDENTIFIER_ _IN_
       {

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -1015,6 +1015,11 @@ expression
 
         $$.type = EXPRESSION_TYPE_BOOLEAN;
       }
+    | _FOR_ for_expression error
+      {
+        compiler->loop_depth--;
+        compiler->loop_identifier[compiler->loop_depth] = NULL;
+      }
     | _FOR_ for_expression _IDENTIFIER_ _IN_
       {
         int var_index;

--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -243,7 +243,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -736,7 +736,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /* Lexical analyzer for YARA */
-#line 20 "lexer.l"
+#line 33 "lexer.l"
 
 /* Disable warnings for unused functions in this file.
 
@@ -754,11 +754,10 @@ with noyywrap then we can remove this pragma.
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <setjmp.h>
 
-
+#include <yara/integers.h>
 #include <yara/lexer.h>
 #include <yara/sizedstr.h>
 #include <yara/error.h>
@@ -810,7 +809,7 @@ with noyywrap then we can remove this pragma.
 
 
 
-#line 801 "lexer.c"
+#line 813 "lexer.c"
 
 #define INITIAL 0
 #define str 1
@@ -843,7 +842,7 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
+    int yy_n_chars;
     yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
@@ -1087,10 +1086,10 @@ YY_DECL
 		}
 
 	{
-#line 111 "lexer.l"
+#line 123 "lexer.l"
 
 
-#line 1081 "lexer.c"
+#line 1093 "lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1157,208 +1156,208 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 113 "lexer.l"
+#line 125 "lexer.l"
 { return _DOT_DOT_;     }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 114 "lexer.l"
+#line 126 "lexer.l"
 { return _LT_;          }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 115 "lexer.l"
+#line 127 "lexer.l"
 { return _GT_;          }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 116 "lexer.l"
+#line 128 "lexer.l"
 { return _LE_;          }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 117 "lexer.l"
+#line 129 "lexer.l"
 { return _GE_;          }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 118 "lexer.l"
+#line 130 "lexer.l"
 { return _EQ_;          }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 119 "lexer.l"
+#line 131 "lexer.l"
 { return _NEQ_;         }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 120 "lexer.l"
+#line 132 "lexer.l"
 { return _SHIFT_LEFT_;  }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 121 "lexer.l"
+#line 133 "lexer.l"
 { return _SHIFT_RIGHT_; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 122 "lexer.l"
+#line 134 "lexer.l"
 { return _PRIVATE_;     }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 123 "lexer.l"
+#line 135 "lexer.l"
 { return _GLOBAL_;      }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 124 "lexer.l"
+#line 136 "lexer.l"
 { return _RULE_;        }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 125 "lexer.l"
+#line 137 "lexer.l"
 { return _META_;        }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 126 "lexer.l"
+#line 138 "lexer.l"
 { return _STRINGS_;     }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 127 "lexer.l"
+#line 139 "lexer.l"
 { return _ASCII_;       }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 128 "lexer.l"
+#line 140 "lexer.l"
 { return _WIDE_;        }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 129 "lexer.l"
+#line 141 "lexer.l"
 { return _FULLWORD_;    }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 130 "lexer.l"
+#line 142 "lexer.l"
 { return _NOCASE_;      }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 131 "lexer.l"
+#line 143 "lexer.l"
 { return _CONDITION_;   }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 132 "lexer.l"
+#line 144 "lexer.l"
 { return _TRUE_;        }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 133 "lexer.l"
+#line 145 "lexer.l"
 { return _FALSE_;       }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 134 "lexer.l"
+#line 146 "lexer.l"
 { return _NOT_;         }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 135 "lexer.l"
+#line 147 "lexer.l"
 { return _AND_;         }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 136 "lexer.l"
+#line 148 "lexer.l"
 { return _OR_;          }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 137 "lexer.l"
+#line 149 "lexer.l"
 { return _AT_;          }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 138 "lexer.l"
+#line 150 "lexer.l"
 { return _IN_;          }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 139 "lexer.l"
+#line 151 "lexer.l"
 { return _OF_;          }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 140 "lexer.l"
+#line 152 "lexer.l"
 { return _THEM_;        }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 141 "lexer.l"
+#line 153 "lexer.l"
 { return _FOR_;         }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 142 "lexer.l"
+#line 154 "lexer.l"
 { return _ALL_;         }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 143 "lexer.l"
+#line 155 "lexer.l"
 { return _ANY_;         }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 144 "lexer.l"
+#line 156 "lexer.l"
 { return _ENTRYPOINT_;  }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 145 "lexer.l"
+#line 157 "lexer.l"
 { return _FILESIZE_;    }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 146 "lexer.l"
+#line 158 "lexer.l"
 { return _MATCHES_;     }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 147 "lexer.l"
+#line 159 "lexer.l"
 { return _CONTAINS_;    }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 148 "lexer.l"
+#line 160 "lexer.l"
 { return _IMPORT_;      }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 151 "lexer.l"
+#line 163 "lexer.l"
 { BEGIN(comment);       }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 152 "lexer.l"
+#line 164 "lexer.l"
 { BEGIN(INITIAL);       }
 	YY_BREAK
 case 39:
 /* rule 39 can match eol */
 YY_RULE_SETUP
-#line 153 "lexer.l"
+#line 165 "lexer.l"
 { /* skip comments */   }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 156 "lexer.l"
+#line 168 "lexer.l"
 { /* skip single-line comments */ }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 159 "lexer.l"
+#line 171 "lexer.l"
 {
                           yyextra->lex_buf_ptr = yyextra->lex_buf;
                           yyextra->lex_buf_len = 0;
@@ -1368,12 +1367,12 @@ YY_RULE_SETUP
 case 42:
 /* rule 42 can match eol */
 YY_RULE_SETUP
-#line 166 "lexer.l"
+#line 178 "lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 169 "lexer.l"
+#line 181 "lexer.l"
 {
 
   char            buffer[1024];
@@ -1489,7 +1488,7 @@ case YY_STATE_EOF(str):
 case YY_STATE_EOF(regexp):
 case YY_STATE_EOF(include):
 case YY_STATE_EOF(comment):
-#line 281 "lexer.l"
+#line 293 "lexer.l"
 {
 
   YR_COMPILER* compiler = yara_yyget_extra(yyscanner);
@@ -1511,7 +1510,7 @@ case YY_STATE_EOF(comment):
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 301 "lexer.l"
+#line 313 "lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1527,7 +1526,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 315 "lexer.l"
+#line 327 "lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1543,7 +1542,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 329 "lexer.l"
+#line 341 "lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1560,7 +1559,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 344 "lexer.l"
+#line 356 "lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1577,7 +1576,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 359 "lexer.l"
+#line 371 "lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1594,7 +1593,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 374 "lexer.l"
+#line 386 "lexer.l"
 {
 
   char* text = yytext;
@@ -1635,7 +1634,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 413 "lexer.l"
+#line 425 "lexer.l"
 {
 
   if (strlen(yytext) > 128)
@@ -1656,7 +1655,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 432 "lexer.l"
+#line 444 "lexer.l"
 {
 
   #ifdef _MSC_VER
@@ -1678,7 +1677,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 451 "lexer.l"
+#line 463 "lexer.l"
 {
   yylval->double_ = atof(yytext);
   return _DOUBLE_;
@@ -1686,7 +1685,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 456 "lexer.l"
+#line 468 "lexer.l"
 {
 
   yylval->integer = xtoi(yytext + 2);
@@ -1695,7 +1694,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 463 "lexer.l"
+#line 475 "lexer.l"
 {     /* saw closing quote - all done */
 
   ALLOC_SIZED_STRING(s, yyextra->lex_buf_len);
@@ -1711,7 +1710,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 477 "lexer.l"
+#line 489 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\t", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1721,7 +1720,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 485 "lexer.l"
+#line 497 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\n", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1731,7 +1730,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 493 "lexer.l"
+#line 505 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\"", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1741,7 +1740,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 501 "lexer.l"
+#line 513 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\\", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1751,7 +1750,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 509 "lexer.l"
+#line 521 "lexer.l"
 {
 
    int result;
@@ -1764,13 +1763,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 520 "lexer.l"
+#line 532 "lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
 case 61:
 /* rule 61 can match eol */
 YY_RULE_SETUP
-#line 523 "lexer.l"
+#line 535 "lexer.l"
 {
 
   yyerror(yyscanner, compiler, "unterminated string");
@@ -1780,7 +1779,7 @@ YY_RULE_SETUP
 case 62:
 /* rule 62 can match eol */
 YY_RULE_SETUP
-#line 529 "lexer.l"
+#line 541 "lexer.l"
 {
 
   yyerror(yyscanner, compiler, "illegal escape sequence");
@@ -1788,7 +1787,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 535 "lexer.l"
+#line 547 "lexer.l"
 {
 
   if (yyextra->lex_buf_len > 0)
@@ -1816,7 +1815,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 561 "lexer.l"
+#line 573 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("/", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1826,10 +1825,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 569 "lexer.l"
+#line 581 "lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\\.", yyextra->lex_buf_len, LEX_BUF_SIZE);
+
+  if (yytext[1] == 0)
+  {
+    yyerror(yyscanner, compiler, "malformed regular expression");
+    yyterminate();
+  }
+
   *yyextra->lex_buf_ptr++ = yytext[0];
   *yyextra->lex_buf_ptr++ = yytext[1];
   yyextra->lex_buf_len += 2;
@@ -1837,13 +1843,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 578 "lexer.l"
+#line 597 "lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
 case 67:
 /* rule 67 can match eol */
 YY_RULE_SETUP
-#line 581 "lexer.l"
+#line 600 "lexer.l"
 {
 
   yyerror(yyscanner, compiler, "unterminated regular expression");
@@ -1852,7 +1858,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 588 "lexer.l"
+#line 607 "lexer.l"
 {
 
   yyextra->lex_buf_ptr = yyextra->lex_buf;
@@ -1862,7 +1868,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 596 "lexer.l"
+#line 615 "lexer.l"
 {
 
   yyextra->lex_buf_ptr = yyextra->lex_buf;
@@ -1873,7 +1879,7 @@ YY_RULE_SETUP
 case 70:
 /* rule 70 can match eol */
 YY_RULE_SETUP
-#line 604 "lexer.l"
+#line 623 "lexer.l"
 {
   // Match hex-digits with whitespace or comments. The latter are stripped
   // out by hex_lexer.l
@@ -1889,12 +1895,12 @@ YY_RULE_SETUP
 case 71:
 /* rule 71 can match eol */
 YY_RULE_SETUP
-#line 617 "lexer.l"
+#line 636 "lexer.l"
 /* skip whitespace */
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 619 "lexer.l"
+#line 638 "lexer.l"
 {
 
   if (yytext[0] >= 32 && yytext[0] < 127)
@@ -1910,10 +1916,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 632 "lexer.l"
+#line 651 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1904 "lexer.c"
+#line 1923 "lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2169,9 +2175,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yara_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
@@ -2571,7 +2577,7 @@ static void yara_yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; // After all that talk, this was set to 1 anyways...
+		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)yara_yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
@@ -3062,7 +3068,7 @@ void yara_yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 632 "lexer.l"
+#line 651 "lexer.l"
 
 
 

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -581,6 +581,13 @@ u?int(8|16|32)(be)? {
 <regexp>\\. {
 
   LEX_CHECK_SPACE_OK("\\.", yyextra->lex_buf_len, LEX_BUF_SIZE);
+
+  if (yytext[1] == 0)
+  {
+    yyerror(yyscanner, compiler, "malformed regular expression");
+    yyterminate();
+  }
+
   *yyextra->lex_buf_ptr++ = yytext[0];
   *yyextra->lex_buf_ptr++ = yytext[1];
   yyextra->lex_buf_len += 2;


### PR DESCRIPTION
While reviewing #627 may be a lot of work for a minor release, here are a few easy commits (also part of #627) that by themselves should warrant a 3.5.1 release because they fix bugs that had CVE numbers assigned to them:
- [CVE-2016-10210](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10210)
- [CVE-2016-1021](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10211)
- [CVE-2017-5923](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5923)
- [CVE-2017-5924](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5924)
