### PR TITLE
libyara.c: Fix openssl #include

### DIFF
--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/threading.h>
 
-#ifdef HAVE_LIBCRYPTO
+#ifdef HAVE_LIBCRYPTO && OPENSSL_VERSION_NUMBER < 0x10100000L
 #include <openssl/crypto.h>
 #endif
 


### PR DESCRIPTION
openssl/crypto.h is only used for locking which is not needed after OpenSSL 1.1