### PR TITLE
Fix undefined behavior in hash

### DIFF
--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -35,9 +35,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/error.h>
 
-#define ROTATE_INT32(x, shift) \
-    ((x << (shift % 32)) | (x >> (32 - (shift % 32))))
+// Constant-time left rotate that does not invoke undefined behavior.
+// http://blog.regehr.org/archives/1063
+uint32_t rotl32(uint32_t x, uint32_t shift) {
+  assert(shift < 32);
+  return (x << shift) | (x >> (-shift & 31));
+}
 
+#define ROTATE_INT32(x, shift) \
+    rotl32(x, shift % 32)
 
 uint32_t byte_to_int32[]  =
 {


### PR DESCRIPTION
The previous rotation implementation invoked undefined behavior for
every index in the target string where i % 32 == 0. Found via ASan.

Fixes #641