### PR TITLE
Handle malformed streams better.

### DIFF
--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -1557,7 +1557,9 @@ void dotnet_parse_com(
     dotnet_parse_guid(pe, metadata_root, headers.guid);
 
   // Parse the #~ stream, which includes various tables of interest.
-  if (headers.tilde != NULL)
+  // These tables reference the blob and string streams, so we need to ensure
+  // those are not NULL also.
+  if (headers.tilde != NULL && headers.string != NULL && headers.blob != NULL)
     dotnet_parse_tilde(pe, metadata_root, cli_header, &headers);
 
   if (headers.us != NULL)


### PR DESCRIPTION
When parsing the #~ stream it will require references to the #US and #Blob
streams, so we need to make sure those are not NULL before attempting to parse
the stream. It is possible to only do these checks in the place we need them but
I'd rather declare the whole thing as malformed once and early.

Fixes part of #650.