### PR TITLE
Increase RE_MAX_SPLIT_ID to allow complex rules.

### DIFF
--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -68,7 +68,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Maximum allowed split ID, also limiting the number of split instructions
 // allowed in a regular expression. This number can't be increased
 // over 255 without changing RE_SPLIT_ID_TYPE.
-#define RE_MAX_SPLIT_ID                 128
+#define RE_MAX_SPLIT_ID                 255
 
 // Maximum stack size for regexp evaluation
 #define RE_MAX_STACK                    1024


### PR DESCRIPTION
Some of our internal rules are rather complex and don't work with the default setting of 128.