### PR TITLE
Improve handling of intermediate files generated by lex, yacc.

### DIFF
--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -84,6 +84,14 @@ lib_LTLIBRARIES = libyara.la
 
 libyara_la_LDFLAGS = -version-number 3:6:0
 
+BUILT_SOURCES = \
+  lexer.c \
+  hex_lexer.c \
+  re_lexer.c \
+  grammar.c \
+  hex_grammar.c \
+  re_grammar.c
+
 libyara_la_SOURCES = \
   $(MODULES) \
   grammar.y \
@@ -100,9 +108,7 @@ libyara_la_SOURCES = \
   hash.c \
   hash.h \
   hex_grammar.y \
-  hex_lexer.h \
   hex_lexer.l \
-  lexer.h \
   lexer.l \
   libyara.c \
   mem.c \
@@ -119,7 +125,6 @@ libyara_la_SOURCES = \
   re.c \
   re.h \
   re_grammar.y \
-  re_lexer.h \
   re_lexer.l \
   rules.c \
   scan.c \


### PR DESCRIPTION
The Automake manual recommends not to put intermediate files into
SOURCES. The *.c files go into BUILT_SOURCES to ensure that those
files get built before everything else.