### PR TITLE
Crash due to memory uninitialized

### DIFF
--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -963,6 +963,10 @@ int yr_arena_load_stream(
     yr_arena_destroy(new_arena);
     return ERROR_CORRUPT_FILE;
   }
+  if (reloc_offset) {
+    yr_arena_destroy(new_arena);
+    return ERROR_CORRUPT_FILE;
+  }
 
   while (reloc_offset != 0xFFFFFFFF)
   {


### PR DESCRIPTION
The fix might be wrong since I am not familiar with the code so point me out in the right direction. I think the first `reloc_offset` should starts at zero but again not familiar with the format

The issue resides in the function `yr_arena_load_stream` specifically in the following lines

```
961   if (yr_stream_read(&reloc_offset, sizeof(reloc_offset), 1, stream) != 1)
962   {
963     yr_arena_destroy(new_arena);
964     return ERROR_CORRUPT_FILE;
965   }
966
967   while (reloc_offset != 0xFFFFFFFF)
968   {
969     if (reloc_offset > header.size - sizeof(uint8_t*))
970     {
971       yr_arena_destroy(new_arena);
972       return ERROR_CORRUPT_FILE;
973     }
974
975     yr_arena_make_relocatable(new_arena, page->address, reloc_offset, EOL);
976
977     reloc_address = (uint8_t**) (page->address + reloc_offset);
978     reloc_target = *reloc_address;
979
980     if (reloc_target != (uint8_t*) (size_t) 0xFFFABADA)
981       *reloc_address += (size_t) page->address;
982     else
983       *reloc_address = 0;
984
985     if (yr_stream_read(&reloc_offset, sizeof(reloc_offset), 1, stream) != 1)
986     {
987       yr_arena_destroy(new_arena);
988       return ERROR_CORRUPT_FILE;
989     }
990   }
```

`reloc_offset` is read from the file which is under the control of the user. In the first iteration it holds a value of 32, which will make the first 32 bytes of `page->address` to be uninitialized. However, later on the first 32 bytes of `page->address` will be dereferenced at line 401 within `rules.c` file.

```
399   external = rules->externals_list_head;
400
401 while (!EXTERNAL_VARIABLE_IS_NULL(external))
```

Here is the file that produces the issue (just remove .png extension)

![yara-crash](https://user-images.githubusercontent.com/3474042/28139797-e46b13f6-6755-11e7-90f1-af218f0f1fdc.png)


```
==2194==ERROR: AddressSanitizer: SEGV on unknown address 0x000000001aa0 (pc 0x000000545baf bp 0x74b15eab3c10 sp 0x74b15eab2f40 T0)
==2194==The signal is caused by a READ memory access.
    #0 0x545bae in yr_rules_scan_mem_blocks /home/alvaro/fuzzers/yara/yara/libyara/rules.c:401:11
    #1 0x54771a in yr_rules_scan_mem /home/alvaro/fuzzers/yara/yara/libyara/rules.c:586:10
    #2 0x54771a in yr_rules_scan_file /home/alvaro/fuzzers/yara/yara/libyara/rules.c:610
    #3 0x50ffb7 in main /home/alvaro/fuzzers/yara/yara/yara.c:1227:14
    #4 0x65a326cbc439 in __libc_start_main (/usr/lib/libc.so.6+0x20439)
    #5 0x41a179 in _start (/home/alvaro/fuzzers/yara/yara/yara+0x41a179)
```
