### PR TITLE
Fix read out of bound due to uncheck pop macro

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -65,7 +65,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     } \
 
 
-#define pop(x)  x = stack[--sp]
+#define pop(x)  \
+    if (sp > 0) \
+    { \
+       x = stack[--sp]; \
+    } \
+    else \
+    { \
+      result = ERROR_EXEC_STACK_OVERFLOW; \
+      stop = TRUE; \
+      break; \
+    } \
 
 #define is_undef(x) IS_UNDEFINED((x).i)
 


### PR DESCRIPTION
Found while fuzzing. 

```
=================================================================
==26138==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7647b09437f8 at pc 0x0000004beaf4 bp 0x7a3b878882f0 sp 0x7a3b87887a
a0
READ of size 8 at 0x7647b09437f8 thread T0
    #0 0x4beaf3 in __asan_memcpy /home/alvaro/tools/llvm/llvm/projects/compiler-rt/lib/asan/asan_interceptors.cc:462
    #1 0x5d8775 in yr_execute_code /home/alvaro/fuzzers/yara/yara/libyara/exec.c:327:9
    #2 0x559061 in yr_rules_scan_mem_blocks /home/alvaro/fuzzers/yara/yara/libyara/rules.c:472:3
    #3 0x559ce1 in yr_rules_scan_mem /home/alvaro/fuzzers/yara/yara/libyara/rules.c:586:10
    #4 0x55a03e in yr_rules_scan_file /home/alvaro/fuzzers/yara/yara/libyara/rules.c:610:14
    #5 0x511d7c in main /home/alvaro/fuzzers/yara/yara/yara.c:1227:14
    #6 0x7647af56d439 in __libc_start_main (/usr/lib/libc.so.6+0x20439)
    #7 0x41a209 in _start (/home/alvaro/fuzzers/yara/yara/yara+0x41a209)
```

Here the file

![yara-crash-pop-macro](https://user-images.githubusercontent.com/3474042/28309862-f6b1981a-6baa-11e7-80e7-1c3ae8936a08.png)
