### PR TITLE
fix issue #699: address overflow in _yr_get_next_block which may cause yara scan hangs.

### DIFF
--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -144,8 +144,9 @@ YR_MEMORY_BLOCK* _yr_get_next_block(
   PVOID address = (PVOID) (context->current_block.base + \
 	                       context->current_block.size);
 
-  while (address < context->si.lpMaximumApplicationAddress &&
-    VirtualQueryEx(context->hProcess, address, &mbi, sizeof(mbi)) != 0)
+  while (address >= (PVOID) context->current_block.base &&
+    address < context->si.lpMaximumApplicationAddress &&
+    VirtualQueryEx(context->hProcess, address, &mbi, sizeof(mbi)) == sizeof(mbi))
   {
     if (mbi.State == MEM_COMMIT && ((mbi.Protect & PAGE_NOACCESS) == 0))
     {
@@ -155,7 +156,17 @@ YR_MEMORY_BLOCK* _yr_get_next_block(
       return &context->current_block;
     }
 
-    address = (uint8_t*) address + mbi.RegionSize;
+    {
+      PVOID new_address = (uint8_t*) address + mbi.RegionSize;
+      if (new_address > address)
+      {
+        address = new_address;
+      }
+      else
+      {
+        break;
+      }
+    }
   }
 
   return NULL;


### PR DESCRIPTION
please refer to #699 