### PR TITLE
Fix modules callback return.

### DIFF
--- a/libyara/modules.c
+++ b/libyara/modules.c
@@ -183,12 +183,10 @@ int yr_modules_load(
     }
   }
 
-  result = context->callback(
+  return context->callback(
       CALLBACK_MSG_MODULE_IMPORTED,
       module_structure,
       context->user_data);
-
-  return ERROR_SUCCESS;
 }
 
 


### PR DESCRIPTION
When a modules callback returns we should return that status, not always return
ERROR_SUCCESS, because if the module callback failed for whatever reason we
should honor that.

I've been using the modules_callback as a nice way to get access to the parsed structures in python, which is really useful for building unpackers/deobfuscators for things like .NET binaries. If the callback ever throws an exception it is ignored without this change.

NOTE: There is a corresponding pull request in yara-python I will be opening right after this.