### PR TITLE
Fix dotnet version string and docs.

### DIFF
--- a/docs/modules/dotnet.rst
+++ b/docs/modules/dotnet.rst
@@ -62,7 +62,7 @@ Reference
 
         Stream size.
 
-    *Example: pe.streams[0].name == "#~"*
+    *Example: dotnet.streams[0].name == "#~"*
 
 .. c:type:: number_of_guids
 
@@ -73,7 +73,7 @@ Reference
     A zero-based array of strings, one for each GUID. Individual guids can be
     accessed by using the [] operator.
 
-    *Example: pe.guids[0].name == "99c08ffd-f378-a891-10ab-c02fe11be6ef"*
+    *Example: dotnet.guids[0] == "99c08ffd-f378-a891-10ab-c02fe11be6ef"*
 
 .. c:type:: number_of_resources
 

--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -1520,6 +1520,7 @@ void dotnet_parse_com(
   PCLI_HEADER cli_header;
   PNET_METADATA metadata;
   int64_t metadata_root, offset;
+  char* end;
   STREAMS headers;
   WORD num_streams;
 
@@ -1552,7 +1553,15 @@ void dotnet_parse_com(
     return;
   }
 
-  set_sized_string(metadata->Version, metadata->Length, pe->object, "version");
+  // The length includes the NULL terminator and is rounded up to a multiple of
+  // 4. We need to exclude the terminator and the padding, so search for the
+  // first NULL byte.
+  end = (char*) memmem((void*) metadata->Version, metadata->Length, "\0", 1);
+  if (end != NULL)
+      set_sized_string(metadata->Version,
+          (end - metadata->Version),
+          pe->object,
+          "version");
 
   // The metadata structure has some variable length records after the version.
   // We must manually parse things from here on out.


### PR DESCRIPTION
After c1280bd185ec9154e329a921acebf15461fe977d, the dotnet version string
includes the NULL terminator and any padding bytes. So you would see things like
"v2.0.50727\x00\x00". Deal with this by searching for the first NULL byte
instead of grabbing the entire length of it.

While here, fix a couple of copy/paste mistakes in the documentation.