### PR TITLE
Fix the build on 10.13. Missing LDFLAGS for OpenSSL from brew.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,8 @@ case $host_os in
     darwin*) CFLAGS="$CFLAGS -I/opt/local/include"
              # Starting with Mac OS X 10.11 (El Capitan) the OpenSSL headers
              # are in /usr/local/opt/openssl/include
-             CFLAGS="$CFLAGS -I/usr/local/opt/openssl/include" ;;
+             CFLAGS="$CFLAGS -I/usr/local/opt/openssl/include"
+             LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib" ;;
 esac
 
 AC_C_BIGENDIAN


### PR DESCRIPTION
The build is broken on OS X 10.13 because they finally removed the OpenSSL libraries they had been shipping. They stopped shipping the headers back in 10.11 but have now stopped shipping the libraries. This diff adds the libraries from brew to LDFLAGS. We were already adding the headers from brew to CFLAGS for a while now.