### PR TITLE
Do not depend on mkgmtime being available on Win32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ ACX_PTHREAD(
 
 AC_CHECK_LIB(m, isnan)
 AC_CHECK_LIB(m, log2)
-AC_CHECK_FUNCS([strlcpy strlcat memmem timegm])
+AC_CHECK_FUNCS([strlcpy strlcat memmem timegm _mkgmtime])
 
 AC_ARG_ENABLE([debug],
   [AS_HELP_STRING([--enable-debug], [compiles with -g option])],

--- a/libyara/modules/pe_utils.c
+++ b/libyara/modules/pe_utils.c
@@ -29,10 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 
-#if defined(_WIN32)
-#define timegm _mkgmtime
-#endif
-
 #include <string.h>
 
 #include <yara/endian.h>
@@ -219,7 +215,10 @@ int64_t pe_rva_to_offset(
 }
 
 
-#if !HAVE_TIMEGM && !defined(WIN32)
+#if !HAVE_TIMEGM
+#if HAVE__MKGMTIME
+#define timegm _mkgmtime
+#else
 
 #include <time.h>
 
@@ -258,7 +257,8 @@ time_t timegm(
   return res;
 }
 
-#endif
+#endif // HAVE__MKGMTIME
+#endif // !HAVE_TIMEGM
 
 #if HAVE_LIBCRYPTO
 


### PR DESCRIPTION
This fixes (cross-)building with OpenSSL support for MinGW.