### PR TITLE
yara.pc: Generate in configure script, add Requires.private

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,7 @@ AS_IF([test "x$have_crypto" = "xno"],
   [
     build_hash_module=true
     CFLAGS="$CFLAGS -DHASH_MODULE"
+    PC_REQUIRES_PRIVATE=libcrypto
   ])
 
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
@@ -165,8 +166,10 @@ AM_CONDITIONAL([MAGIC_MODULE], [test x$build_magic_module = xtrue])
 AM_CONDITIONAL([HASH_MODULE], [test x$build_hash_module = xtrue])
 AM_CONDITIONAL([DOTNET_MODULE], [test x$build_dotnet_module = xtrue])
 AM_CONDITIONAL([GCC], [test "x$GCC" = xyes])
+AC_SUBST([PC_REQUIRES_PRIVATE])
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([libyara/Makefile])
+AC_CONFIG_FILES([libyara/yara.pc])
 
 AC_OUTPUT

--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -141,11 +141,3 @@ libyara_la_SOURCES = \
 
 pkgconfigdir = $(libdir)/pkgconfig
 nodist_pkgconfig_DATA = yara.pc
-
-yara.pc: yara.pc.in
-		sed -e 's![@]prefix[@]!$(prefix)!g' \
-		    -e 's![@]exec_prefix[@]!$(exec_prefix)!g' \
-		    -e 's![@]includedir[@]!$(includedir)!g' \
-		    -e 's![@]libdir[@]!$(libdir)!g' \
-		    -e 's![@]PACKAGE_VERSION[@]!$(PACKAGE_VERSION)!g' \
-		    $(srcdir)/yara.pc.in > $@

--- a/libyara/yara.pc.in
+++ b/libyara/yara.pc.in
@@ -7,5 +7,6 @@ Name: yara
 Description: YARA library
 URL: https://virustotal.github.io/yara/
 Version: @PACKAGE_VERSION@
+Requires.private: @PC_REQUIRES_PRIVATE@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lyara


### PR DESCRIPTION
Requires.private is useful to indicate to a build script that
statically links libyara that libcrypto must also be linked.