### PR TITLE
Implement a faster time measurement method for profiling purposes.

### DIFF
--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -132,6 +132,8 @@ libyara_la_SOURCES = \
   scan.c \
   sizedstr.c \
   sizedstr.h \
+  stopwatch.c \
+  stopwatch.h \
   strutils.c \
   strutils.h \
   stream.c \

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -45,6 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/strutils.h>
 #include <yara/utils.h>
 #include <yara/mem.h>
+#include <yara/stopwatch.h>
 
 #include <yara.h>
 
@@ -193,7 +194,8 @@ int yr_execute_code(
   uint8_t opcode;
 
   #ifdef PROFILING_ENABLED
-  clock_t start = clock();
+  YR_STOPWATCH stopwatch;
+  yr_stopwatch_start(&stopwatch);
   #endif
 
   yr_get_configuration(YR_CONFIG_STACK_SIZE, (void*) &stack_size);
@@ -450,8 +452,7 @@ int yr_execute_code(
           rule->ns->t_flags[tidx] |= NAMESPACE_TFLAGS_UNSATISFIED_GLOBAL;
 
         #ifdef PROFILING_ENABLED
-        rule->clock_ticks += clock() - start;
-        start = clock();
+        rule->clock_ticks = yr_stopwatch_elapsed_microseconds(&stopwatch);
         #endif
 
         assert(sp == 0); // at this point the stack should be empty.
@@ -1159,7 +1160,7 @@ int yr_execute_code(
         {
           #ifdef PROFILING_ENABLED
           assert(current_rule != NULL);
-          current_rule->clock_ticks += clock() - start;
+          current_rule->clock_ticks += yr_stopwatch_elapsed_microseconds(&stopwatch);
           #endif
           result = ERROR_SCAN_TIMEOUT;
           stop = TRUE;

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2017. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#include <yara/integers.h>
+
+typedef struct _YR_STOPWATCH
+{
+  struct timespec ts_start;
+
+} YR_STOPWATCH;
+
+
+void yr_stopwatch_start(
+    YR_STOPWATCH* stopwatch);
+
+uint64_t yr_stopwatch_elapsed_microseconds(
+    YR_STOPWATCH* stopwatch);

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -233,7 +233,7 @@ typedef struct _YR_STRING
   YR_MATCHES unconfirmed_matches[MAX_THREADS];
 
   // Used only when PROFILING_ENABLED is defined
-  clock_t clock_ticks;
+  uint64_t clock_ticks;
 
 } YR_STRING;
 

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/error.h>
 #include <yara/libyara.h>
 #include <yara/scan.h>
+#include <yara/stopwatch.h>
 
 
 typedef struct _CALLBACK_ARGS
@@ -740,7 +741,8 @@ int yr_scan_verify_match(
     return ERROR_SUCCESS;
 
   #ifdef PROFILING_ENABLED
-  clock_t start = clock();
+  YR_STOPWATCH stopwatch;
+  yr_stopwatch_start(&stopwatch);
   #endif
 
   if (STRING_IS_LITERAL(string))
@@ -755,7 +757,7 @@ int yr_scan_verify_match(
   }
 
   #ifdef PROFILING_ENABLED
-  string->clock_ticks += clock() - start;
+  string->clock_ticks += yr_stopwatch_elapsed_microseconds(&stopwatch);
   #endif
 
   return ERROR_SUCCESS;

--- a/libyara/stopwatch.c
+++ b/libyara/stopwatch.c
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2017. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <time.h>
+
+#include <yara/stopwatch.h>
+
+
+#define	timespecsub(tsp, usp, vsp)					\
+do {								\
+  (vsp)->tv_sec = (tsp)->tv_sec - (usp)->tv_sec;		\
+  (vsp)->tv_nsec = (tsp)->tv_nsec - (usp)->tv_nsec;	\
+  if ((vsp)->tv_nsec < 0) {				\
+    (vsp)->tv_sec--;				\
+    (vsp)->tv_nsec += 1000000000L;			\
+  }							\
+} while (0)
+
+
+void yr_stopwatch_start(YR_STOPWATCH* stopwatch)
+{
+  clock_gettime(CLOCK_MONOTONIC, &stopwatch->ts_start);
+}
+
+
+uint64_t yr_stopwatch_elapsed_microseconds(YR_STOPWATCH* stopwatch)
+{
+  struct timespec ts_stop;
+  struct timespec ts_elapsed;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts_stop);
+  timespecsub(&ts_stop, &stopwatch->ts_start, &ts_elapsed);
+
+  return ts_elapsed.tv_sec + ts_elapsed.tv_nsec;
+}


### PR DESCRIPTION
The clock() function used until now is very slow. For more information read: https://upvoid.com/devblog/2014/05/linux-timers/