### PR TITLE
Consider native hash APIs on Windows, MacOSX if OpenSSL is unavailable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,7 @@ AS_IF([test "x$with_crypto" != "xno"],
     have_crypto=no
   ])
 
+
 AS_IF([test "x$have_crypto" = "xno"],
   [
     AS_IF([test "x$with_crypto" = "xyes"],
@@ -147,18 +148,47 @@ AS_IF([test "x$have_crypto" = "xno"],
       [
         AC_MSG_WARN([
 *******************************************************************************
-  Could not find OpenSSL library. The "hash" module and some features in "pe"
-  module have been disabled. If you want to enable all features please install
-  it and run this script again.
+  Could not find OpenSSL library. Some features in "pe" module have been
+  disabled. If you want to enable all features please install it and run this
+  script again.
 *******************************************************************************
         ])
+	AC_MSG_CHECKING([for MS Crypto API])
+        AC_CHECK_HEADERS([wincrypt.h],
+          [
+	    AC_MSG_RESULT([The "hash" module functions will be provided through the MS Crypto API])
+            # FIXME: Add PC_LIBS_PRIVATE entries?
+            build_hash_module=true
+          ],
+          [],
+          [#include <windows.h>])
+	AC_MSG_CHECKING([for MacOSX Common Crypto API])
+        AC_CHECK_HEADERS([CommonCrypto/CommonCrypto.h],
+          [
+	    AC_MSG_RESULT([The "hash" module functions will be provided through the MacOSX Common Crypto API])
+            # FIXME: Add PC_LIBS_PRIVATE entries?
+            build_hash_module=true
+          ])
+        AS_IF([test x$build_hash_module = xtrue],
+          [
+            build_hash_module=true
+            CFLAGS="$CFLAGS -DHASH_MODULE"
+          ],
+          [
+            AC_MSG_WARN([
+*******************************************************************************
+  Could not find alternative APIs for hash functions. The "hash" module has
+  been disabled.
+*******************************************************************************
+            ])
+          ])
+        ])
+      ],
+      [
+        build_hash_module=true
+        CFLAGS="$CFLAGS -DHASH_MODULE"
+        PC_REQUIRES_PRIVATE="$PC_REQUIRES_PRIVATE libcrypto"
       ])
-  ],
-  [
-    build_hash_module=true
-    CFLAGS="$CFLAGS -DHASH_MODULE"
-    PC_REQUIRES_PRIVATE="$PC_REQUIRES_PRIVATE libcrypto"
-  ])
 
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 AM_CONDITIONAL([OPTIMIZATION], [test x$optimization = xtrue])

--- a/libyara/crypto.h
+++ b/libyara/crypto.h
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2017. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef YR_CRYPTO_H
+#define YR_CRYPTO_H
+
+#define YR_MD5_LEN    16
+#define YR_SHA1_LEN   20
+#define YR_SHA256_LEN 32
+
+#if defined(HAVE_LIBCRYPTO)
+#include <openssl/crypto.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+
+typedef MD5_CTX yr_md5_ctx;
+typedef SHA_CTX yr_sha1_ctx;
+typedef SHA256_CTX yr_sha256_ctx;
+
+#define yr_md5_init(ctx) \
+ MD5_Init(ctx)
+#define yr_md5_update(ctx,data,len) \
+ MD5_Update(ctx,data,len)
+#define yr_md5_final(digest,ctx) \
+ MD5_Final(digest,ctx)
+
+#define yr_sha1_init(ctx) \
+ SHA1_Init(ctx)
+#define yr_sha1_update(ctx,data,len) \
+ SHA1_Update(ctx,data,len)
+#define yr_sha1_final(digest,ctx) \
+ SHA1_Final(digest,ctx)
+
+#define yr_sha256_init(ctx) \
+ SHA256_Init(ctx)
+#define yr_sha256_update(ctx,data,len) \
+ SHA256_Update(ctx,data,len)
+#define yr_sha256_final(digest,ctx) \
+ SHA256_Final(digest,ctx)
+
+#elif defined(HAVE_WINCRYPT_H)
+#include <windows.h>
+#include <wincrypt.h>
+
+HCRYPTPROV yr_cryptprov;
+
+typedef HCRYPTHASH yr_md5_ctx;
+typedef HCRYPTHASH yr_sha1_ctx;
+typedef HCRYPTHASH yr_sha256_ctx;
+
+#define yr_md5_init(ctx) \
+  CryptCreateHash(yr_cryptprov, CALG_MD5, 0, 0, ctx)
+#define yr_md5_update(ctx,data,len) \
+  CryptHashData(*ctx, (const BYTE*)data, len, 0)
+#define yr_md5_final(digest,ctx) {                      \
+  DWORD len = YR_MD5_LEN;                               \
+  CryptGetHashParam(*ctx, HP_HASHVAL, digest, &len, 0); \
+  CryptDestroyHash(*ctx);                               \
+}
+
+#define yr_sha1_init(ctx) \
+  CryptCreateHash(yr_cryptprov, CALG_SHA1, 0, 0, ctx)
+#define yr_sha1_update(ctx,data,len) \
+  CryptHashData(*ctx, (const BYTE*)data, len, 0)
+#define yr_sha1_final(digest,ctx) {                     \
+  DWORD len = YR_SHA1_LEN;                              \
+  CryptGetHashParam(*ctx, HP_HASHVAL, digest, &len, 0); \
+  CryptDestroyHash(*ctx);                               \
+}
+
+#define yr_sha256_init(ctx) \
+  CryptCreateHash(yr_cryptprov, CALG_SHA_256, 0, 0, ctx)
+#define yr_sha256_update(ctx,data,len) \
+  CryptHashData(*ctx, (const BYTE*)data, len, 0)
+#define yr_sha256_final(digest,ctx) {                   \
+  DWORD len = YR_SHA256_LEN;                            \
+  CryptGetHashParam(*ctx, HP_HASHVAL, digest, &len, 0); \
+  CryptDestroyHash(*ctx);                               \
+}
+
+#elif defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
+#include <CommonCrypto/CommonDigest.h>
+
+typedef CC_MD5_CTX yr_md5_ctx;
+typedef CC_SHA1_CTX yr_sha1_ctx;
+typedef CC_SHA256_CTX yr_sha256_ctx;
+
+#define yr_md5_init(ctx) \
+  CC_MD5_Init(ctx)
+#define yr_md5_update(ctx,data,len) \
+  CC_MD5_Update(ctx, data, len)
+#define yr_md5_final(digest,ctx) \
+  CC_MD5_Final(digest, ctx)
+
+#define yr_sha1_init(ctx) \
+  CC_SHA1_Init(ctx)
+#define yr_sha1_update(ctx,data,len) \
+  CC_SHA1_Update(ctx, data, len)
+#define yr_sha1_final(digest,ctx) \
+  CC_SHA1_Final(digest, ctx)
+
+#define yr_sha256_init(ctx) \
+  CC_SHA256_Init(ctx)
+#define yr_sha256_update(ctx,data,len) \
+  CC_SHA256_Update(ctx, data, len)
+#define yr_sha256_final(digest,ctx) \
+  CC_SHA256_Final(digest, ctx)
+
+#endif
+
+#endif

--- a/libyara/modules/hash.c
+++ b/libyara/modules/hash.c
@@ -27,8 +27,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <openssl/md5.h>
-#include <openssl/sha.h>
+#include "../crypto.h"
 
 #if _WIN32 || __CYGWIN__
 
@@ -122,17 +121,17 @@ int add_to_cache(
 
 define_function(string_md5)
 {
-  unsigned char digest[MD5_DIGEST_LENGTH];
-  char digest_ascii[MD5_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_MD5_LEN];
+  char digest_ascii[YR_MD5_LEN * 2 + 1];
 
-  MD5_CTX md5_context;
+  yr_md5_ctx md5_context;
   SIZED_STRING* s = sized_string_argument(1);
 
-  MD5_Init(&md5_context);
-  MD5_Update(&md5_context, s->c_string, s->length);
-  MD5_Final(digest, &md5_context);
+  yr_md5_init(&md5_context);
+  yr_md5_update(&md5_context, s->c_string, s->length);
+  yr_md5_final(digest, &md5_context);
 
-  digest_to_ascii(digest, digest_ascii, MD5_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_MD5_LEN);
 
   return_string(digest_ascii);
 }
@@ -140,17 +139,17 @@ define_function(string_md5)
 
 define_function(string_sha256)
 {
-  unsigned char digest[SHA256_DIGEST_LENGTH];
-  char digest_ascii[SHA256_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_SHA256_LEN];
+  char digest_ascii[YR_SHA256_LEN * 2 + 1];
 
-  SHA256_CTX sha256_context;
+  yr_sha256_ctx sha256_context;
   SIZED_STRING* s = sized_string_argument(1);
 
-  SHA256_Init(&sha256_context);
-  SHA256_Update(&sha256_context, s->c_string, s->length);
-  SHA256_Final(digest, &sha256_context);
+  yr_sha256_init(&sha256_context);
+  yr_sha256_update(&sha256_context, s->c_string, s->length);
+  yr_sha256_final(digest, &sha256_context);
 
-  digest_to_ascii(digest, digest_ascii, SHA256_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_SHA256_LEN);
 
   return_string(digest_ascii);
 }
@@ -158,17 +157,17 @@ define_function(string_sha256)
 
 define_function(string_sha1)
 {
-  unsigned char digest[SHA_DIGEST_LENGTH];
-  char digest_ascii[SHA_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_SHA1_LEN];
+  char digest_ascii[YR_SHA1_LEN * 2 + 1];
 
-  SHA_CTX sha_context;
+  yr_sha1_ctx sha_context;
   SIZED_STRING* s = sized_string_argument(1);
 
-  SHA1_Init(&sha_context);
-  SHA1_Update(&sha_context, s->c_string, s->length);
-  SHA1_Final(digest, &sha_context);
+  yr_sha1_init(&sha_context);
+  yr_sha1_update(&sha_context, s->c_string, s->length);
+  yr_sha1_final(digest, &sha_context);
 
-  digest_to_ascii(digest, digest_ascii, SHA_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_SHA1_LEN);
 
   return_string(digest_ascii);
 }
@@ -190,10 +189,10 @@ define_function(string_checksum32)
 
 define_function(data_md5)
 {
-  MD5_CTX md5_context;
+  yr_md5_ctx md5_context;
 
-  unsigned char digest[MD5_DIGEST_LENGTH];
-  char digest_ascii[MD5_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_MD5_LEN];
+  char digest_ascii[YR_MD5_LEN * 2 + 1];
   char* cached_ascii_digest;
 
   int past_first_block = FALSE;
@@ -208,7 +207,7 @@ define_function(data_md5)
   int64_t offset = arg_offset;
   int64_t length = arg_length;
 
-  MD5_Init(&md5_context);
+  yr_md5_init(&md5_context);
 
   if (offset < 0 || length < 0 || offset < block->base)
   {
@@ -239,7 +238,7 @@ define_function(data_md5)
         offset += data_len;
         length -= data_len;
 
-        MD5_Update(&md5_context, block_data + data_offset, data_len);
+        yr_md5_update(&md5_context, block_data + data_offset, data_len);
       }
 
       past_first_block = TRUE;
@@ -262,9 +261,9 @@ define_function(data_md5)
   if (!past_first_block)
     return_string(UNDEFINED);
 
-  MD5_Final(digest, &md5_context);
+  yr_md5_final(digest, &md5_context);
 
-  digest_to_ascii(digest, digest_ascii, MD5_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_MD5_LEN);
 
   FAIL_ON_ERROR(
       add_to_cache(module(), "md5", arg_offset, arg_length, digest_ascii));
@@ -275,10 +274,10 @@ define_function(data_md5)
 
 define_function(data_sha1)
 {
-  SHA_CTX sha_context;
+  yr_sha1_ctx sha_context;
 
-  unsigned char digest[SHA_DIGEST_LENGTH];
-  char digest_ascii[SHA_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_SHA1_LEN];
+  char digest_ascii[YR_SHA1_LEN * 2 + 1];
   char* cached_ascii_digest;
 
   int past_first_block = FALSE;
@@ -293,7 +292,7 @@ define_function(data_sha1)
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
-  SHA1_Init(&sha_context);
+  yr_sha1_init(&sha_context);
 
   if (offset < 0 || length < 0 || offset < block->base)
   {
@@ -323,7 +322,7 @@ define_function(data_sha1)
         offset += data_len;
         length -= data_len;
 
-        SHA1_Update(&sha_context, block_data + data_offset, data_len);
+        yr_sha1_update(&sha_context, block_data + data_offset, data_len);
       }
 
       past_first_block = TRUE;
@@ -346,9 +345,9 @@ define_function(data_sha1)
   if (!past_first_block)
     return_string(UNDEFINED);
 
-  SHA1_Final(digest, &sha_context);
+  yr_sha1_final(digest, &sha_context);
 
-  digest_to_ascii(digest, digest_ascii, SHA_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_SHA1_LEN);
 
   FAIL_ON_ERROR(
       add_to_cache(module(), "sha1", arg_offset, arg_length, digest_ascii));
@@ -359,10 +358,10 @@ define_function(data_sha1)
 
 define_function(data_sha256)
 {
-  SHA256_CTX sha256_context;
+  yr_sha256_ctx sha256_context;
 
-  unsigned char digest[SHA256_DIGEST_LENGTH];
-  char digest_ascii[SHA256_DIGEST_LENGTH * 2 + 1];
+  unsigned char digest[YR_SHA256_LEN];
+  char digest_ascii[YR_SHA256_LEN * 2 + 1];
   char* cached_ascii_digest;
 
   int past_first_block = FALSE;
@@ -377,7 +376,7 @@ define_function(data_sha256)
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
-  SHA256_Init(&sha256_context);
+  yr_sha256_init(&sha256_context);
 
   if (offset < 0 || length < 0 || offset < block->base)
   {
@@ -406,7 +405,7 @@ define_function(data_sha256)
         offset += data_len;
         length -= data_len;
 
-        SHA256_Update(&sha256_context, block_data + data_offset, data_len);
+        yr_sha256_update(&sha256_context, block_data + data_offset, data_len);
       }
 
       past_first_block = TRUE;
@@ -429,9 +428,9 @@ define_function(data_sha256)
   if (!past_first_block)
     return_string(UNDEFINED);
 
-  SHA256_Final(digest, &sha256_context);
+  yr_sha256_final(digest, &sha256_context);
 
-  digest_to_ascii(digest, digest_ascii, SHA256_DIGEST_LENGTH);
+  digest_to_ascii(digest, digest_ascii, YR_SHA256_LEN);
 
   FAIL_ON_ERROR(
       add_to_cache(module(), "sha256", arg_offset, arg_length, digest_ascii));

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
       }",
       "tests/data/tiny");
 
-  #if defined(HAVE_LIBCRYPTO)
+  #if defined(HAVE_LIBCRYPTO) || defined(HAVE_WINCRYPT_H) || defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \


### PR DESCRIPTION
Those APIs are the Microsoft Crypto API and the Apple Common Crypto
library, respectively.