### PR TITLE
pkg-config: Add pthreads-related libraries to Link.private

### DIFF
--- a/libyara/yara.pc.in
+++ b/libyara/yara.pc.in
@@ -10,4 +10,4 @@ Version: @PACKAGE_VERSION@
 Requires.private: @PC_REQUIRES_PRIVATE@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lyara
-Libs.private: @PC_LIBS_PRIVATE@
+Libs.private: @PC_LIBS_PRIVATE@ @PTHREAD_LIBS@


### PR DESCRIPTION
This makes a difference on systems where a library has to be linked to use pthreads.

Such as ... you guessed it ... AIX.