### PR TITLE
Add explicit support for DragonFly BSD, kFreeBSD to Linux process scan module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ case $host_os in
              proc_interface=mach ;;
     mingw*) CFLAGS="$CFLAGS -DUSE_WINDOWS_PROC"
             proc_interface=windows ;;
-    linux*|netbsd*)
+    linux*|netbsd*|dragonfly*|kfreebsd*)
             CFLAGS="$CFLAGS -DUSE_LINUX_PROC"
             proc_interface=linux ;;
     freebsd*)
@@ -48,7 +48,9 @@ case $host_os in
     openbsd*)
             CFLAGS="$CFLAGS -DUSE_OPENBSD_PROC"
             proc_interface=openbsd ;;
-    *)      proc_interface=none ;;
+    *)
+            CFLAGS="$CFLAGS -DUSE_NO_PROC"
+            proc_interface=none ;;
 esac
 
 AC_C_BIGENDIAN

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/wait.h>
 #include <errno.h>
 
-#if defined(__NetBSD__)
+#if defined(__NetBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
 #define PTRACE_ATTACH PT_ATTACH
 #define PTRACE_DETACH PT_DETACH
 #define _XOPEN_SOURCE 500


### PR DESCRIPTION
I have successfully tested this on a default install of DragonFly BSD 5.0.1. The Debian GNU/kFreeBSD userland lacks the definition of `struct ptrace_vm_entry` but by default still has the /proc filesystem mounted.