### PR TITLE
Don't access directory entries past SizeOfOptionalHeader.

### DIFF
--- a/libyara/include/yara/pe_utils.h
+++ b/libyara/include/yara/pe_utils.h
@@ -90,11 +90,6 @@ PIMAGE_DATA_DIRECTORY pe_get_directory_entry(
     int entry);
 
 
-PIMAGE_DATA_DIRECTORY pe_get_directory_entry(
-    PE* pe,
-    int entry);
-
-
 int64_t pe_rva_to_offset(
     PE* pe,
     uint64_t rva);

--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -1527,6 +1527,9 @@ void dotnet_parse_com(
   WORD num_streams;
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR);
+  if (directory == NULL)
+    return;
+
   offset = pe_rva_to_offset(pe, directory->VirtualAddress);
 
   if (offset < 0 || !struct_fits_in_pe(pe, pe->data + offset, CLI_HEADER))

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -437,6 +437,9 @@ int pe_iterate_resources(
   PIMAGE_DATA_DIRECTORY directory = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_RESOURCE);
 
+  if (directory == NULL)
+     return 0;
+
   if (yr_le32toh(directory->VirtualAddress) != 0)
   {
     PIMAGE_RESOURCE_DIRECTORY rsrc_dir;
@@ -882,6 +885,9 @@ IMPORTED_DLL* pe_parse_imports(
   PIMAGE_DATA_DIRECTORY directory = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_IMPORT);
 
+  if (directory == NULL)
+    return NULL;
+
   if (yr_le32toh(directory->VirtualAddress) == 0)
     return NULL;
 
@@ -973,6 +979,9 @@ IMPORT_EXPORT_FUNCTION* pe_parse_exports(
 
   directory = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_EXPORT);
+
+  if (directory == NULL)
+    return NULL;
 
   if (yr_le32toh(directory->VirtualAddress) == 0)
     return NULL;
@@ -1076,6 +1085,9 @@ void pe_parse_certificates(
 
   PIMAGE_DATA_DIRECTORY directory = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_SECURITY);
+
+  if (directory == NULL)
+    return;
 
   // Default to 0 signatures until we know otherwise.
   set_integer(0, pe->object, "number_of_signatures");
@@ -1336,6 +1348,12 @@ void pe_parse_header(
       yr_le64toh(OptionalHeader(pe, ImageBase)) :
       yr_le32toh(OptionalHeader(pe, ImageBase)),
       pe->object, "image_base");
+
+  set_integer(
+      IS_64BITS_PE(pe) ?
+      yr_le64toh(OptionalHeader(pe, NumberOfRvaAndSizes)) :
+      yr_le32toh(OptionalHeader(pe, NumberOfRvaAndSizes)),
+      pe->object, "number_of_rva_and_sizes");
 
   set_integer(
       OptionalHeader(pe, MajorLinkerVersion),
@@ -2195,6 +2213,7 @@ begin_declarations;
 
   declare_integer("entry_point");
   declare_integer("image_base");
+  declare_integer("number_of_rva_and_sizes");
 
   declare_string_dictionary("version_info");
 

--- a/libyara/modules/pe_utils.c
+++ b/libyara/modules/pe_utils.c
@@ -120,14 +120,47 @@ PIMAGE_DATA_DIRECTORY pe_get_directory_entry(
     PE* pe,
     int entry)
 {
-  PIMAGE_DATA_DIRECTORY result;
+  PIMAGE_DATA_DIRECTORY directory_start;
+  uint8_t* optional_header_start;
+  uint16_t optional_header_size;
+
+  // We are specifically NOT checking NumberOfRvaAndSizes here because it can
+  // lie. 7ff1bf680c80fd73c0b35084904848b3705480ddeb6d0eff62180bd14cd18570 has
+  // NumberOfRvaAndSizes set to 11 when in fact there is a valid
+  // IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR entry (which is more than 11). If we
+  // are overly strict here and only parse entries which are less than
+  // NumberOfRvaAndSizes we run the risk of missing otherwise perfectly valid
+  // files. Instead of being strict we check to make sure the entry is within
+  // the OptionalHeader, since SizeOfOptionalHeader includes the DataDirectory
+  // array.
+
+  // In case someone requests an entry which is, by definition, invalid.
+  if (entry >= IMAGE_NUMBEROF_DIRECTORY_ENTRIES)
+    return NULL;
 
   if (IS_64BITS_PE(pe))
-    result = &pe->header64->OptionalHeader.DataDirectory[entry];
+  {
+    optional_header_start = (uint8_t*) &pe->header64->OptionalHeader;
+    optional_header_size = pe->header64->FileHeader.SizeOfOptionalHeader;
+    directory_start = pe->header64->OptionalHeader.DataDirectory;
+  }
   else
-    result = &pe->header->OptionalHeader.DataDirectory[entry];
+  {
+    optional_header_start = (uint8_t*) &pe->header->OptionalHeader;
+    optional_header_size = pe->header->FileHeader.SizeOfOptionalHeader;
+    directory_start = pe->header->OptionalHeader.DataDirectory;
+  }
 
-  return result;
+  // Make sure the entry doesn't point outside of the OptionalHeader.
+  if ((uint8_t*) (directory_start + entry) <= optional_header_start + optional_header_size)
+  {
+    if (IS_64BITS_PE(pe))
+      return &pe->header64->OptionalHeader.DataDirectory[entry];
+    else
+      return &pe->header->OptionalHeader.DataDirectory[entry];
+  }
+
+  return NULL;
 }
 
 


### PR DESCRIPTION
Attempt to make pe_get_directory_entry() a little more resilent to malformed PE
files.

As discussed in a comment in the code,
7ff1bf680c80fd73c0b35084904848b3705480ddeb6d0eff62180bd14cd18570 is an
interesting sample which has NumberOfRvaAndSizes set to 11 but does in fact have
more than 11 entries in the DataDirectory array. We happened to work for this
sample because we were not checking NumberOfRvaAndSizes before accessing the
DataDirectory array. While the docs say the NumberOfRvaAndSizes is to be
checked. If we were to enforce this strict check to ensure safety we would be
incorrectly parsing what is an otherwise valid .NET binary.

Instead of being overly strict here I'm attempting to make sure the entry in the
DataDirectory array is at least within the bounds of the OptionalHeader. If it
isn't the function now returns NULL, instead of whatever happened to be in
memory at that address. Since the function now returns NULL I have to fix every
caller to check for it and return accordingly.

While I'm here, I might as well remove a redundant prototype for
pe_get_directory_entry in pe_utils.h and add in NumberOfRvaAndSizes because it's
useful to catch packers which alter this value.