### PR TITLE
modules/pe: Fixed possible invalid memory read when parsing certificates

### DIFF
--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -472,6 +472,8 @@ typedef struct _VERSION_INFO {
 #define WIN_CERT_TYPE_RESERVED_1       0x0003
 #define WIN_CERT_TYPE_TS_STACK_SIGNED  0x0004
 
+#define WIN_CERTIFICATE_HEADER_SIZE    8
+
 typedef struct _WIN_CERTIFICATE {
     DWORD Length;
     WORD  Revision;

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1134,14 +1134,14 @@ void pe_parse_certificates(
         yr_le16toh(win_cert->CertificateType) != WIN_CERT_TYPE_PKCS_SIGNED_DATA)
     {
       uintptr_t end = (uintptr_t)
-          ((uint8_t *) win_cert) + yr_le32toh(win_cert->Length);
+          ((uint8_t *) win_cert) + yr_le32toh(win_cert->Length) - WIN_CERTIFICATE_HEADER_SIZE;
 
       win_cert = (PWIN_CERTIFICATE) (end + (end % 8));
       continue;
     }
 
     cert_bio = BIO_new_mem_buf(
-        win_cert->Certificate, yr_le32toh(win_cert->Length));
+        win_cert->Certificate, yr_le32toh(win_cert->Length) - WIN_CERTIFICATE_HEADER_SIZE);
 
     if (!cert_bio)
       break;

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1134,7 +1134,7 @@ void pe_parse_certificates(
         yr_le16toh(win_cert->CertificateType) != WIN_CERT_TYPE_PKCS_SIGNED_DATA)
     {
       uintptr_t end = (uintptr_t)
-          ((uint8_t *) win_cert) + yr_le32toh(win_cert->Length) - WIN_CERTIFICATE_HEADER_SIZE;
+          ((uint8_t *) win_cert) + yr_le32toh(win_cert->Length);
 
       win_cert = (PWIN_CERTIFICATE) (end + (end % 8));
       continue;


### PR DESCRIPTION
Attribute Length in `WIN_CERTIFICATE` structure is length of `bCertificate` buffer,
not the length of the whole structure. Every time we want to work with the `bCertificate` buffer,
we need to subtract size of the header. If the security directory is the
very last thing in the PE file, we can possibly end up with invalid pointer.