### PR TITLE
Add Avast to "Who's using YARA"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ helpful extension to YARA developed and open-sourced by Bayshore Networks.
 * [ActiveCanopy](https://activecanopy.com/)
 * [Adlice](http://www.adlice.com/)
 * [AlienVault](https://otx.alienvault.com/)
+* [Avast](https://www.avast.com/)
 * [BAE Systems](http://www.baesystems.com/home?r=ai)
 * [Bayshore Networks, Inc.](http://www.bayshorenetworks.com)
 * [BinaryAlert](https://github.com/airbnb/binaryalert)


### PR DESCRIPTION
Avast is using YARA e.g. in [retdec](https://github.com/avast-tl/retdec) via [fnc-patterns](https://github.com/avast-tl/fnc-patterns).
