### PR TITLE
Open files in default include callback with binary mode on Windows

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -84,7 +84,7 @@ const char* _yr_compiler_default_include_callback(
   int fd = -1;
 
   #ifdef _MSC_VER
-  _sopen_s(&fd, include_name, _O_RDONLY, _SH_DENYRW, _S_IREAD);
+  _sopen_s(&fd, include_name, _O_RDONLY | _O_BINARY, _SH_DENYRW, _S_IREAD);
   #else
   fd = open(include_name, O_RDONLY);
   #endif


### PR DESCRIPTION
Default include callback obtains the file size of included file in order to allocate sufficiently large buffer. It then compares the file size from `_filelength()` with the return value of `read()` call. However, `_filelength()` most probably just read the metadata of the file and returns the amount of bytes in the file. In contrary, `read()` on Windows transforms CRLF line endings to LF line endings when file is open in text mode and thus `read()` returns different value than the actual file size. Opening the file in binary mode should solve this problem.

This fixes bug #809.