### PR TITLE
Do not use thread local storage for storing fiber pools in regexp eng…

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -883,6 +883,7 @@ int yr_execute_code(
         }
 
         result = yr_re_exec(
+          context,
           (uint8_t*) r2.re->code,
           (uint8_t*) r1.ss->c_string,
           r1.ss->length,

--- a/libyara/include/yara/libyara.h
+++ b/libyara/include/yara/libyara.h
@@ -70,7 +70,7 @@ YR_API int yr_initialize(void);
 YR_API int yr_finalize(void);
 
 
-YR_API void yr_finalize_thread(void);
+YR_DEPRECATED_API void yr_finalize_thread(void);
 
 
 YR_API int yr_get_tidx(void);

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -292,8 +292,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define parent()        (__function_obj->parent)
 #define scan_context()  (__context)
 
-#define re_match(...)   yr_re_match(__context, __VA_ARGS__)
-
 
 #define foreach_memory_block(iterator, block) \
   for (block = iterator->first(iterator); \

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/error.h>
 #include <yara/exec.h>
 #include <yara/types.h>
+#include <yara/re.h>
 #include <yara/object.h>
 #include <yara/libyara.h>
 
@@ -290,6 +291,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define module()        yr_object_get_root((YR_OBJECT*) __function_obj)
 #define parent()        (__function_obj->parent)
 #define scan_context()  (__context)
+
+#define re_match(...)   yr_re_match(__context, __VA_ARGS__)
 
 
 #define foreach_memory_block(iterator, block) \

--- a/libyara/include/yara/object.h
+++ b/libyara/include/yara/object.h
@@ -47,8 +47,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 
-#include <yara/types.h>
 
+#include <yara/types.h>
+#include <yara/sizedstr.h>
 
 #define OBJECT_CREATE           1
 

--- a/libyara/include/yara/re.h
+++ b/libyara/include/yara/re.h
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ctype.h>
 
+#include <yara/types.h>
 #include <yara/arena.h>
 #include <yara/sizedstr.h>
 
@@ -98,81 +99,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RE_FLAGS_UNGREEDY              0x800
 
 
-typedef struct RE RE;
-typedef struct RE_AST RE_AST;
-typedef struct RE_NODE RE_NODE;
-typedef struct RE_CLASS RE_CLASS;
-typedef struct RE_ERROR RE_ERROR;
-
-typedef uint8_t RE_SPLIT_ID_TYPE;
-
-
-struct RE_NODE
-{
-  int type;
-
-  union {
-    int value;
-    int count;
-    int start;
-  };
-
-  union {
-    int mask;
-    int end;
-  };
-
-  int greedy;
-
-  RE_CLASS* re_class;
-
-  RE_NODE* left;
-  RE_NODE* right;
-
-  uint8_t* forward_code;
-  uint8_t* backward_code;
-};
-
-
-struct RE_CLASS
-{
-  uint8_t negated;
-  uint8_t bitmap[32];
-};
-
-
-struct RE_AST
-{
-  uint32_t flags;
-  uint16_t levels;
-  RE_NODE* root_node;
-};
-
-
-// Disable warning due to zero length array in Microsoft's compiler
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4200)
-#endif
-
-struct RE
-{
-  uint32_t flags;
-  uint8_t code[0];
-};
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
-
-struct RE_ERROR
-{
-  char message[384];
-};
-
-
 typedef int RE_MATCH_CALLBACK_FUNC(
     const uint8_t* match,
     int match_length,
@@ -222,6 +148,7 @@ void yr_re_node_destroy(
 
 
 int yr_re_exec(
+    YR_SCAN_CONTEXT* context,
     const uint8_t* code,
     const uint8_t* input_data,
     size_t input_forwards_size,
@@ -233,6 +160,7 @@ int yr_re_exec(
 
 
 int yr_re_fast_exec(
+    YR_SCAN_CONTEXT* context,
     const uint8_t* code,
     const uint8_t* input_data,
     size_t input_forwards_size,
@@ -264,16 +192,9 @@ int yr_re_compile(
 
 
 int yr_re_match(
+    YR_SCAN_CONTEXT* context,
     RE* re,
     const char* target);
 
-
-int yr_re_initialize(void);
-
-
-int yr_re_finalize(void);
-
-
-int yr_re_finalize_thread(void);
 
 #endif

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -60,6 +60,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if defined(__GNUC__)
+#define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
+#else
+#define YR_DEPRECATED_API EXTERNC
+#endif
+
+#if defined(__GNUC__)
 #define YR_ALIGN(n) __attribute__((aligned(n)))
 #elif defined(_MSC_VER)
 #define YR_ALIGN(n) __declspec(align(n))

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -160,7 +160,6 @@ YR_API int yr_initialize(void)
 
   #endif
 
-  FAIL_ON_ERROR(yr_re_initialize());
   FAIL_ON_ERROR(yr_modules_initialize());
 
   // Initialize default configuration options
@@ -176,21 +175,19 @@ YR_API int yr_initialize(void)
 //
 // yr_finalize_thread
 //
-// Should be called by ALL threads using libyara before exiting.
-//
+// This function is deprecated, it's maintained only for backward compatibility
+// with programs that already use it. Calling yr_finalize_thread from each
+// thread using libyara is not required anymore.
 
-YR_API void yr_finalize_thread(void)
+YR_DEPRECATED_API void yr_finalize_thread(void)
 {
-  yr_re_finalize_thread();
 }
 
 
 //
 // yr_finalize
 //
-// Should be called by main thread before exiting. Main thread doesn't
-// need to explicitly call yr_finalize_thread because yr_finalize already
-// calls it.
+// Should be called by main thread before exiting.
 //
 
 YR_API int yr_finalize(void)
@@ -203,8 +200,6 @@ YR_API int yr_finalize(void)
 
   if (init_count == 0)
     return ERROR_INTERNAL_FATAL_ERROR;
-
-  yr_re_finalize_thread();
 
   init_count--;
 
@@ -228,7 +223,6 @@ YR_API int yr_finalize(void)
 
   FAIL_ON_ERROR(yr_thread_storage_destroy(&yr_tidx_key));
   FAIL_ON_ERROR(yr_thread_storage_destroy(&yr_recovery_state_key));
-  FAIL_ON_ERROR(yr_re_finalize());
   FAIL_ON_ERROR(yr_modules_finalize());
   FAIL_ON_ERROR(yr_heap_free());
 

--- a/libyara/modules/cuckoo.c
+++ b/libyara/modules/cuckoo.c
@@ -90,7 +90,7 @@ define_function(network_dns_lookup)
   {
     if (json_unpack(value, "{s:s, s:s}", "ip", &ip, field_name, &hostname) == 0)
     {
-      if (yr_re_match(regexp_argument(1), hostname) > 0)
+      if (re_match(regexp_argument(1), hostname) > 0)
       {
         result = 1;
         break;
@@ -127,7 +127,7 @@ uint64_t http_request(
     {
       if (((methods & METHOD_GET && strcasecmp(method, "get") == 0) ||
            (methods & METHOD_POST && strcasecmp(method, "post") == 0)) &&
-           yr_re_match(uri_regexp, uri) > 0)
+           re_match(uri_regexp, uri) > 0)
       {
         result = 1;
         break;
@@ -181,7 +181,7 @@ define_function(registry_key_access)
 
   json_array_foreach(keys_json, index, value)
   {
-    if (yr_re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;
@@ -204,7 +204,7 @@ define_function(filesystem_file_access)
 
   json_array_foreach(files_json, index, value)
   {
-    if (yr_re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;
@@ -228,7 +228,7 @@ define_function(sync_mutex)
 
   json_array_foreach(mutexes_json, index, value)
   {
-    if (yr_re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;

--- a/libyara/modules/cuckoo.c
+++ b/libyara/modules/cuckoo.c
@@ -43,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define_function(network_dns_lookup)
 {
+  YR_SCAN_CONTEXT* context = scan_context();
   YR_OBJECT* network_obj = parent();
 
   json_t* network_json = (json_t*) network_obj->data;
@@ -90,7 +91,7 @@ define_function(network_dns_lookup)
   {
     if (json_unpack(value, "{s:s, s:s}", "ip", &ip, field_name, &hostname) == 0)
     {
-      if (re_match(regexp_argument(1), hostname) > 0)
+      if (yr_re_match(context, regexp_argument(1), hostname) > 0)
       {
         result = 1;
         break;
@@ -107,6 +108,7 @@ define_function(network_dns_lookup)
 
 
 uint64_t http_request(
+    YR_SCAN_CONTEXT* context,
     YR_OBJECT* network_obj,
     RE* uri_regexp,
     int methods)
@@ -127,7 +129,7 @@ uint64_t http_request(
     {
       if (((methods & METHOD_GET && strcasecmp(method, "get") == 0) ||
            (methods & METHOD_POST && strcasecmp(method, "post") == 0)) &&
-           re_match(uri_regexp, uri) > 0)
+           yr_re_match(context, uri_regexp, uri) > 0)
       {
         result = 1;
         break;
@@ -143,6 +145,7 @@ define_function(network_http_request)
 {
   return_integer(
       http_request(
+          scan_context(),
           parent(),
           regexp_argument(1),
           METHOD_GET | METHOD_POST));
@@ -153,6 +156,7 @@ define_function(network_http_get)
 {
   return_integer(
       http_request(
+          scan_context(),
           parent(),
           regexp_argument(1),
           METHOD_GET));
@@ -163,6 +167,7 @@ define_function(network_http_post)
 {
   return_integer(
       http_request(
+          scan_context(),
           parent(),
           regexp_argument(1),
           METHOD_POST));
@@ -171,6 +176,7 @@ define_function(network_http_post)
 
 define_function(registry_key_access)
 {
+  YR_SCAN_CONTEXT* context = scan_context();
   YR_OBJECT* registry_obj = parent();
 
   json_t* keys_json = (json_t*) registry_obj->data;
@@ -181,7 +187,7 @@ define_function(registry_key_access)
 
   json_array_foreach(keys_json, index, value)
   {
-    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (yr_re_match(context, regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;
@@ -194,6 +200,7 @@ define_function(registry_key_access)
 
 define_function(filesystem_file_access)
 {
+  YR_SCAN_CONTEXT* context = scan_context();
   YR_OBJECT* filesystem_obj = parent();
 
   json_t* files_json = (json_t*) filesystem_obj->data;
@@ -204,7 +211,7 @@ define_function(filesystem_file_access)
 
   json_array_foreach(files_json, index, value)
   {
-    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (yr_re_match(context, regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;
@@ -218,6 +225,7 @@ define_function(filesystem_file_access)
 
 define_function(sync_mutex)
 {
+  YR_SCAN_CONTEXT* context = scan_context();
   YR_OBJECT* sync_obj = parent();
 
   json_t* mutexes_json = (json_t*) sync_obj->data;
@@ -228,7 +236,7 @@ define_function(sync_mutex)
 
   json_array_foreach(mutexes_json, index, value)
   {
-    if (re_match(regexp_argument(1), json_string_value(value)) > 0)
+    if (yr_re_match(context, regexp_argument(1), json_string_value(value)) > 0)
     {
       result = 1;
       break;

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1597,7 +1597,7 @@ define_function(exports_regexp)
 
   while (exported_func != NULL)
   {
-    if (yr_re_match(regex, exported_func->name) != -1)
+    if (re_match(regex, exported_func->name) != -1)
       return_integer(1);
 
     exported_func = exported_func->next;

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1597,7 +1597,7 @@ define_function(exports_regexp)
 
   while (exported_func != NULL)
   {
-    if (re_match(regex, exported_func->name) != -1)
+    if (yr_re_match(scan_context(), regex, exported_func->name) != -1)
       return_integer(1);
 
     exported_func = exported_func->next;

--- a/libyara/modules/tests.c
+++ b/libyara/modules/tests.c
@@ -84,7 +84,7 @@ define_function(empty)
 
 define_function(match)
 {
-  return_integer(yr_re_match(regexp_argument(1), string_argument(2)));
+  return_integer(re_match(regexp_argument(1), string_argument(2)));
 }
 
 

--- a/libyara/modules/tests.c
+++ b/libyara/modules/tests.c
@@ -84,7 +84,11 @@ define_function(empty)
 
 define_function(match)
 {
-  return_integer(re_match(regexp_argument(1), string_argument(2)));
+  return_integer(
+      yr_re_match(
+          scan_context(),
+          regexp_argument(1),
+          string_argument(2)));
 }
 
 

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <assert.h>
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -531,6 +531,7 @@ static int _yr_scan_match_callback(
 
 
 typedef int (*RE_EXEC_FUNC)(
+    YR_SCAN_CONTEXT* context,
     const uint8_t* code,
     const uint8_t* input,
     size_t input_forwards_size,
@@ -573,6 +574,7 @@ static int _yr_scan_verify_re_match(
   if (STRING_IS_ASCII(ac_match->string))
   {
     FAIL_ON_ERROR(exec(
+        context,
         ac_match->forward_code,
         data + offset,
         data_size - offset,
@@ -587,6 +589,7 @@ static int _yr_scan_verify_re_match(
   {
     flags |= RE_FLAGS_WIDE;
     FAIL_ON_ERROR(exec(
+        context,
         ac_match->forward_code,
         data + offset,
         data_size - offset,
@@ -614,6 +617,7 @@ static int _yr_scan_verify_re_match(
   if (ac_match->backward_code != NULL)
   {
     FAIL_ON_ERROR(exec(
+        context,
         ac_match->backward_code,
         data + offset,
         data_size - offset,

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -214,6 +214,18 @@ YR_API int yr_scanner_create(
 YR_API void yr_scanner_destroy(
     YR_SCANNER* scanner)
 {
+  RE_FIBER* fiber;
+  RE_FIBER* next_fiber;
+
+  fiber = scanner->re_fiber_pool.fibers.head;
+
+  while (fiber != NULL)
+  {
+    next_fiber = fiber->next;
+    yr_free(fiber);
+    fiber = next_fiber;
+  }
+
   if (scanner->objects_table != NULL)
   {
     yr_hash_table_destroy(

--- a/yara.c
+++ b/yara.c
@@ -836,8 +836,6 @@ static void* scanning_thread(void* param)
     }
   }
 
-  yr_finalize_thread();
-
   return 0;
 }
 


### PR DESCRIPTION
…ine.

The regexp engine maintains a fiber pool for each thread that executes the yr_re_exec function. The fiber pool was stored using thread local storage (TLS), but this design as proven to be a bad decision, as each thread was responsible for freeing its own fiber pool and this was problematic in languages like Go, where the runtime can create multiple threads but the programmer don't have full control of such threads. Now the fiber pool is stored in the YR_SCAN_CONTEXT structure.