### PR TITLE
Fix wide string matching.

### DIFF
--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -114,7 +114,7 @@ static int _yr_scan_wcompare(
   if (data_size < string_length * 2)
     return 0;
 
-  while (i < string_length && *s1 == *s2)
+  while (i < string_length && *s1 == *s2 && *(s1 + 1) == 0x00)
   {
     s1+=2;
     s2++;
@@ -791,7 +791,7 @@ int yr_scan_verify_match(
 
   if (result != ERROR_SUCCESS)
     context->last_error_string = string;
- 
+
   #ifdef PROFILING_ENABLED
   string->clock_ticks += yr_stopwatch_elapsed_ns(&stopwatch, FALSE);
   #endif


### PR DESCRIPTION
While working on the xor modifier I noticed that the 'wide' bytes are not being compared. The docs say that the wide modifier interleaves the string with zeros, but the below snippet shows that only the initial atom needs to have zeros, the rest don't matter.

```
wxs@mbp yara % cat wide.yara
rule a {
  strings:
    $a = "This program cannot" wide
  condition:
    $a
}
wxs@mbp yara % echo "T\x00h\x00i\x01s\x01 \x01p\x01r\x01o\x01g\x01r\x01a\x01m\x01 \x01c\x01a\x01n\x01n\x01o\x01t\x01" > test
wxs@mbp yara % ./yara -s wide.yara test
a test
0x0:$a: T\x00h\x00i\x01s\x01 \x01p\x01r\x01o\x01g\x01r\x01a\x01m\x01 \x01c\x01a\x01n\x01n\x01o\x01t\x01
wxs@mbp yara %
```

This pull request fixes it by checking that the string is interleaved with zeros. After this fix is applied the original string above doesn't match, but one with zeros will:

```
wxs@mbp yara % echo "T\x00h\x00i\x00s\x00 \x00p\x00r\x00o\x00g\x00r\x00a\x00m\x00 \x00c\x00a\x00n\x00n\x00o\x00t\x00" > test
wxs@mbp yara % ./yara -s wide.yara test
a test
0x0:$a: T\x00h\x00i\x00s\x00 \x00p\x00r\x00o\x00g\x00r\x00a\x00m\x00 \x00c\x00a\x00n\x00n\x00o\x00t\x00
wxs@mbp yara %