### PR TITLE
Update home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@ to YARA developed and open-sourced by Bayshore Networks.</p>
 <li><a href="https://github.com/airbnb/binaryalert">BinaryAlert</a></li>
 <li><a href="http://www.bluecoat.com/products/malware-analysis-appliance">Blue Coat</a></li>
 <li><a href="http://www.blueliv.com">Blueliv</a></li>
+<li><a href="https://cofense.com">Cofense</a></li>
 <li><a href="http://www.conix.fr">Conix</a></li>
 <li><a href="https://github.com/CrowdStrike/CrowdFMS">CrowdStrike FMS</a></li>
 <li><a href="https://www.eset.com">ESET</a></li>
@@ -104,7 +105,6 @@ to YARA developed and open-sourced by Bayshore Networks.</p>
 <li><a href="http://www.nozominetworks.com">Nozomi Networks</a></li>
 <li><a href="http://www.osquery.io">osquery</a></li>
 <li><a href="https://www.payload-security.com">Payload Security</a></li>
-<li><a href="http://phishme.com">PhishMe</a></li>
 <li><a href="http://www.picussecurity.com">Picus Security</a></li>
 <li><a href="http://rada.re">Radare2</a></li>
 <li><a href="http://www.raytheoncyber.com/capabilities/products/sureview-threatprotection/">Raytheon Cyber Products, Inc.</a></li>


### PR DESCRIPTION
As of this week, PhishMe has changed their name to Cofense.