### PR TITLE
Set AC_CONFIG_AUX_DIR in configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ stamp-h1
 /aclocal.m4
 /ar-lib
 /autom4te.cache/
+/build-aux
 /compile
 /config.guess
 /config.h

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,8 @@ AC_INIT([yara], [3.7.0], [vmalvarez@virustotal.com])
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([yara.c])
 
+AC_CONFIG_AUX_DIR([build-aux])
+
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
First execution of ./bootstrap.sh fails on CentOS 7 because of libtool (v2.4.2, most recent version available in package repo) when AC_CONFIG_AUX_DIR is not set.