### PR TITLE
Add mach_absolute_time()-based stopwatch for macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ case $host_os in
              # are in /usr/local/opt/openssl/include
              CFLAGS="$CFLAGS -DUSE_MACH_PROC -I/usr/local/opt/openssl/include"
              LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
+             mach=yes
              proc_interface=mach
              jemalloc_prefix=je_ ;;
     mingw*) CFLAGS="$CFLAGS -DUSE_WINDOWS_PROC"
@@ -268,8 +269,11 @@ AS_IF([test "x$have_crypto" = "xno"],
     PC_REQUIRES_PRIVATE="$PC_REQUIRES_PRIVATE libcrypto"
   ])
 
-AC_CHECK_FUNCS([clock_gettime],,
-  AC_MSG_ERROR([clock_gettime not supported in your OS.]))
+AS_IF([test "x$mach" != "xyes"],
+  [
+    AC_CHECK_FUNCS([clock_gettime],,
+      AC_MSG_ERROR([clock_gettime not supported in your OS.]))
+  ],)
 
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 AM_CONDITIONAL([PROFILING_ENABLED], [test x$profiling_enabled = xtrue])

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -44,6 +44,17 @@ typedef struct _YR_STOPWATCH
 
 } YR_STOPWATCH;
 
+#elif defined(__MACH__)
+
+#include <mach/mach_time.h>
+
+typedef struct _YR_STOPWATCH
+{
+  mach_timebase_info_data_t timebase;
+  uint64_t start;
+
+} YR_STOPWATCH;
+
 #else
 
 typedef struct _YR_STOPWATCH

--- a/libyara/stopwatch.c
+++ b/libyara/stopwatch.c
@@ -51,6 +51,27 @@ uint64_t yr_stopwatch_elapsed_us(
   return (li.QuadPart - sw->start.QuadPart) * 1000000L / sw->frequency.QuadPart;
 }
 
+
+#elif defined(__MACH__)
+
+void yr_stopwatch_start(
+    YR_STOPWATCH* sw)
+{
+  mach_timebase_info(&sw->timebase);
+  sw->start = mach_absolute_time();
+}
+
+
+uint64_t yr_stopwatch_elapsed_us(
+    YR_STOPWATCH* sw)
+{
+  uint64_t now;
+
+  now = mach_absolute_time();
+  return (now - sw->start) * 1000ULL * sw->timebase.numer / sw->timebase.denom;
+}
+
+
 #else
 
 #define timespecsub(tsp, usp, vsp)                      \

--- a/libyara/stopwatch.c
+++ b/libyara/stopwatch.c
@@ -68,7 +68,8 @@ uint64_t yr_stopwatch_elapsed_us(
   uint64_t now;
 
   now = mach_absolute_time();
-  return (now - sw->start) * 1000ULL * sw->timebase.numer / sw->timebase.denom;
+  return (now - sw->start) * sw->timebase.numer /
+         (sw->timebase.denom * 1000ULL);
 }
 
 


### PR DESCRIPTION
Unbreak on macOS releases before 10.12 Sierra, lacking clock_gettime(),
by adding an mach_absolute_time()-based implementation of stopwatch.
Prefer the mach_absolute_time()-based implementation to clock_gettime()
for now.  Only check for clock_gettime() in ./configure on non-Mach
platforms.