### PR TITLE
Improve documentation of read/write functions for yr_rules_load_stream() and yr_rules_save_stream() 

### DIFF
--- a/docs/capi.rst
+++ b/docs/capi.rst
@@ -165,8 +165,9 @@ The ``ptr`` argument is a pointer to the buffer where the ``read`` function
 should put the read data, or where the ``write`` function will find the data
 that needs to be written to the stream. In both cases ``size`` is the size of
 each element being read or written and ``count`` the number of elements. The
-total size of the data being read or written is ``size`` * ``count``. Both
-functions must return the total number of elements read or written.
+total size of the data being read or written is ``size`` * ``count``. The 
+``read`` function must return the number of elements read, the ``write`` function
+must return the total size of the data written.
 
 The ``user_data`` pointer is the same you specified in the
 :c:type:`YR_STREAM` structure. You can use it to pass arbitrary data to your


### PR DESCRIPTION
Although the description is technically not wrong as yr_rules_save_stream never returns an error anyway, fwrite would not adhere to this rule.