### PR TITLE
Fixed https://github.com/VirusTotal/yara/issues/867

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1445,7 +1445,9 @@ void pe_parse_header(
 
     // This will catch the section with the highest raw offset to help checking
     // if overlay data is present
-    if (yr_le32toh(section->PointerToRawData) > highest_sec_ofs)
+    // ladislav_zezula: Fix for files that have multiple sections - same raw offset, different size
+    // Sample: cf62bf1815a93e68e6c5189f689286b66c4088b9507cf3ecf835e4ac3f9ededa
+    if ((yr_le32toh(section->PointerToRawData) + yr_le32toh(section->SizeOfRawData)) > (highest_sec_ofs + highest_sec_siz))
     {
       highest_sec_ofs = yr_le32toh(section->PointerToRawData);
       highest_sec_siz = yr_le32toh(section->SizeOfRawData);


### PR DESCRIPTION
The code which checks for position of `pe.overlay` in (file: pe.c, line: 1450) fails in the case when there is more sections having the same raw data offset, but different sizes. This is unusual, but not invalid and Windows loader will load the file just fine.

Sample: `cf62bf1815a93e68e6c5189f689286b66c4088b9507cf3ecf835e4ac3f9ededa`
The sample above does not have overlay, yet YARA thinks it does:
```
        overlay
                size = 18744
                offset = 63488
```