### PR TITLE
Use unsigned integers for math.min() and math.max().

### DIFF
--- a/docs/modules/math.rst
+++ b/docs/modules/math.rst
@@ -103,10 +103,10 @@ file and create signatures based on those results.
 
     .. versionadded:: 3.8.0
 
-    Returns the maximum of two integer values.
+    Returns the maximum of two unsigned integer values.
 
 .. c:function:: min(int, int)
 
     .. versionadded:: 3.8.0
 
-    Returns the minimum of two integer values.
+    Returns the minimum of two unsigned integer values.

--- a/libyara/modules/math.c
+++ b/libyara/modules/math.c
@@ -599,8 +599,8 @@ define_function(in_range)
 
 define_function(min)
 {
-  int i = integer_argument(1);
-  int j = integer_argument(2);
+  uint64_t i = integer_argument(1);
+  uint64_t j = integer_argument(2);
 
   return_integer(i < j ? i : j);
 }
@@ -608,8 +608,8 @@ define_function(min)
 
 define_function(max)
 {
-  int i = integer_argument(1);
-  int j = integer_argument(2);
+  uint64_t i = integer_argument(1);
+  uint64_t j = integer_argument(2);
 
   return_integer(i > j ? i : j);
 }


### PR DESCRIPTION
Apologies for not noticing this sooner, but I think we should be using unsigned integers for the comparison. This enables us to use things like `math.min(uint32(0), 10)` and if the high bit is set for whatever uint32(0) returns it won't be treated as a negative number.