### PR TITLE
Corrected early stoppage of Imported DLLs parsing.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -911,8 +911,10 @@ IMPORTED_DLL* pe_parse_imports(
 
       char* dll_name = (char *) (pe->data + offset);
 
-      if (!pe_valid_dll_name(dll_name, pe->data_size - (size_t) offset))
-        break;
+      if (!pe_valid_dll_name(dll_name, pe->data_size - (size_t) offset)){
+          imports++;
+          continue;
+      }
 
       imported_dll = (IMPORTED_DLL*) yr_calloc(1, sizeof(IMPORTED_DLL));
 


### PR DESCRIPTION
When the program encounters an IMAGE_IMPORT_DESCRIPTOR whose DLL name is not valid, it stops parsing the current descriptor and the subsequent ones. It should be important to prosecute the parsing, at least of the next descriptors, in order not to miss any imported DLL. A malware author could "obfuscate" the entire set of Imported DLLs by putting, as first DLL, one with an invalid Name.