### PR TITLE
Add thumbprint to pe.signatures[]

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -116,8 +116,8 @@ Reference
 
 .. c:type:: characteristics
 
-    Bitmap with PE FileHeader characteristics. Individual characteristics 
-    can be inspected by performing a bitwise AND operation with the 
+    Bitmap with PE FileHeader characteristics. Individual characteristics
+    can be inspected by performing a bitwise AND operation with the
     following constants:
 
     .. c:type:: RELOCS_STRIPPED
@@ -193,8 +193,8 @@ Reference
 .. c:type:: dll_characteristics
 
     Bitmap with PE OptionalHeader DllCharacteristics.  Do not confuse these
-    flags with the PE FileHeader Characteristics. Individual 
-    characteristics can be inspected by performing a bitwise AND 
+    flags with the PE FileHeader Characteristics. Individual
+    characteristics can be inspected by performing a bitwise AND
     operation with the following constants:
 
     .. c:type:: DYNAMIC_BASE
@@ -209,7 +209,7 @@ Reference
     .. c:type:: NO_ISOLATION
     .. c:type:: NO_SEH
 
-        The file does not contain structured exception handlers, this must be 
+        The file does not contain structured exception handlers, this must be
         set to use SafeSEH
 
     .. c:type:: NO_BIND
@@ -420,6 +420,12 @@ Reference
 
     A zero-based array of signature objects, one for each authenticode
     signature in the PE file. Usually PE files have a single signature.
+
+    .. c:member:: thumbprint
+
+        A string containing the thumbprint of the signature.
+
+    .. versionadded:: 3.8.0
 
     .. c:member:: issuer
 

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1189,10 +1189,25 @@ void pe_parse_certificates(
       const char* sig_alg;
       char buffer[256];
       int bytes;
+      const EVP_MD* sha1_digest = EVP_sha1();
+      unsigned char thumbprint[YR_SHA1_LEN];
+      char thumbprint_ascii[YR_SHA1_LEN * 2];
 
       ASN1_INTEGER* serial;
 
       X509* cert = sk_X509_value(certs, i);
+
+      X509_digest(cert, sha1_digest, thumbprint, NULL);
+      for (i = 0; i < YR_SHA1_LEN; i++)
+      {
+        sprintf(thumbprint_ascii + (i * 2), "%02x", thumbprint[i]);
+      }
+      set_sized_string(
+          (char*) thumbprint_ascii,
+          sizeof(thumbprint_ascii),
+          pe->object,
+          "signatures[%i].thumbprint",
+          counter);
 
       X509_NAME_oneline(
           X509_get_issuer_name(cert), buffer, sizeof(buffer));
@@ -2329,6 +2344,7 @@ begin_declarations;
 
   #if defined(HAVE_LIBCRYPTO)
   begin_struct_array("signatures");
+    declare_string("thumbprint");
     declare_string("issuer");
     declare_string("subject");
     declare_integer("version");


### PR DESCRIPTION
This adds the thumbprint of the certificate to the PE metadata.

We probably should include tests for these but I'm not sure if I have a small, signed, binary. If anyone has one I'll happily write up tests for the various signature pieces in it.

```
wxs@mbp yara % cat thumbprint.yara
/*
Sample Thumbprint
6a5e69726622e6aa9a589b2e45df0cf68d6724d8c60bf162a055e314ccde4d53 7E2D60266B6DB4AC7AA6D8DC8E6EC5FA4CD6A108
72062ab54807d258f3f639ccbdf94bccda06b07a07bd8efab73cfa105482e099 07E45E18706C1771A8A224CF8EA5BC0444A6F958
*/

import "pe"

rule six_a_five_e {
  condition:
    for any i in (0..pe.number_of_signatures):
      (pe.signatures[i].thumbprint == "7e2d60266b6db4ac7aa6d8dc8e6ec5fa4cd6a108")
}

rule seven_two_oh_six {
  condition:
    for any i in (0..pe.number_of_signatures):
      (pe.signatures[i].thumbprint == "07e45e18706c1771a8a224cf8ea5bc0444a6f958")
}
wxs@mbp yara % ./yara thumbprint.yara ~/Desktop/thumbprint
seven_two_oh_six /Users/wxs/Desktop/thumbprint/72062ab54807d258f3f639ccbdf94bccda06b07a07bd8efab73cfa105482e099
six_a_five_e /Users/wxs/Desktop/thumbprint/6a5e69726622e6aa9a589b2e45df0cf68d6724d8c60bf162a055e314ccde4d53
wxs@mbp yara %
```