### PR TITLE
Add gcc printf format attribute to yara_yywarning

### DIFF
--- a/libyara/include/yara/lexer.h
+++ b/libyara/include/yara/lexer.h
@@ -127,7 +127,7 @@ void yyerror(
 void yywarning(
     yyscan_t yyscanner,
     const char *message_fmt,
-    ...);
+    ...) YR_PRINTF_LIKE(2, 3);
 
 void yyfatal(
     yyscan_t yyscanner,

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -69,6 +69,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_ALIGN(n)
 #endif
 
+#if defined(__GNUC__)
+#define YR_PRINTF_LIKE(x, y) __attribute__((format(printf, x, y)))
+#else
+#define YR_PRINTF_LIKE(x, y)
+#endif
+
 #define yr_min(x, y) ((x < y) ? (x) : (y))
 #define yr_max(x, y) ((x > y) ? (x) : (y))
 


### PR DESCRIPTION
This attribute helps catching issues related to printf-like format string when `yara_yywarning` is called. As it only exists in gcc and clang (not MSVC), add a suitable macro in `utils.h`.

Fixes: https://github.com/VirusTotal/yara/issues/913