### PR TITLE
Add parentheses to yr_min and yr_max parameters

### DIFF
--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -75,8 +75,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_PRINTF_LIKE(x, y)
 #endif
 
-#define yr_min(x, y) ((x < y) ? (x) : (y))
-#define yr_max(x, y) ((x > y) ? (x) : (y))
+#define yr_min(x, y) (((x) < (y)) ? (x) : (y))
+#define yr_max(x, y) (((x) > (y)) ? (x) : (y))
 
 #define yr_swap(x, y, T) do { T temp = x; x = y; y = temp; } while (0)
 


### PR DESCRIPTION
If the parameters given to `yr_min` and `yr_max` macros use operations which priority is lower than the one of `<`, the current definitions may cause unexpected results. Adding parentheses makes sure this can never happen.

For information, the current implementations of `yr_min` and `yr_max` evaluate twice their parameters. This could be an issue when a parameter is a function call. Nevertheless MSVC does not provide a way to perform something similar this gcc-specific code:
```c
#define yr_min(x, y) ({ \
    typeof(x) _min1 = (x); \
    typeof(y) _min2 = (y); \
    _min1 < _min2 ? _min1 : _min2; \
    })
```
Therefore, do not change the implementation of `yr_min` and `yr_max` this way.