### PR TITLE
Use YR_BUILDING_DLL and YR_IMPORTING_DLL for controlling the semantics of YR_API

### DIFF
--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -54,21 +54,39 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define EXTERNC
 #endif
 
-#if defined(__GNUC__)
-#define YR_API EXTERNC __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
-#define YR_API EXTERNC __declspec(dllexport)
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef YR_BUILDING_DLL
+    #ifdef __GNUC__
+      #define YR_API EXTERNC __attribute_((dllexport))
+      #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
+    #else
+      #define YR_API EXTERNC __declspec(dllexport)
+      #define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
+    #endif
+  #elif defined(YR_BUILDING_STATIC_LIB)
+    #define YR_API EXTERNC
+    #define YR_DEPRECATED_API EXTERNC
+  #else
+    #ifdef __GNUC__
+      #define YR_API EXTERNC __attribute__((dllimport))
+      #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
+    #else
+      #define YR_API EXTERNC __declspec(dllimport)
+      #define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
+    #endif
+  #endif
+  #define DLL_LOCAL
 #else
-#define YR_API EXTERNC
+  #if __GNUC__ >= 4
+    #define YR_API EXTERNC __attribute__((visibility ("default")))
+    #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
+  #else
+    #define YR_API EXTERNC
+    #define YR_DEPRECATED_API EXTERNC
+  #endif
 #endif
 
-#if defined(__GNUC__)
-#define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
-#else
-#define YR_DEPRECATED_API EXTERNC
-#endif
 
 #if defined(__GNUC__)
 #define YR_ALIGN(n) __attribute__((aligned(n)))

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -64,10 +64,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       #define YR_API EXTERNC __declspec(dllexport)
       #define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
     #endif
-  #elif defined(YR_BUILDING_STATIC_LIB)
-    #define YR_API EXTERNC
-    #define YR_DEPRECATED_API EXTERNC
-  #else
+  #elif defined(YR_IMPORTING_DLL)
     #ifdef __GNUC__
       #define YR_API EXTERNC __attribute__((dllimport))
       #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
@@ -75,8 +72,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       #define YR_API EXTERNC __declspec(dllimport)
       #define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
     #endif
+  #else
+    #define YR_API EXTERNC
+    #define YR_DEPRECATED_API EXTERNC
   #endif
-  #define DLL_LOCAL
 #else
   #if __GNUC__ >= 4
     #define YR_API EXTERNC __attribute__((visibility ("default")))

--- a/windows/vs2015/libyara/libyara.vcxproj
+++ b/windows/vs2015/libyara/libyara.vcxproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -105,7 +105,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PRO;YR_BUILDING_STATIC_LIBC</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -132,7 +132,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -157,7 +157,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsCpp</CompileAs>


### PR DESCRIPTION
For compiling YARA in Windows as a DLL you must define YR_BUILDING_DLL. For using it that DLL in your project you must define YR_IMPORTING_DLL. This allows to use the same header files in both cases. If YR_BUILDING_DLL is defined, YR_API translates to __declspec(dllexport), if  YR_IMPORTING_DLL is defined  YR_API translates to __declspec(dllimport).