### PR TITLE
Keep ABI compatibility by keeping deprecated functions visible

### DIFF
--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -79,7 +79,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
   #if __GNUC__ >= 4
     #define YR_API EXTERNC __attribute__((visibility ("default")))
-    #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
+    #define YR_DEPRECATED_API YR_API __attribute__((deprecated))
   #else
     #define YR_API EXTERNC
     #define YR_DEPRECATED_API EXTERNC


### PR DESCRIPTION
When preparing the Debian package for 3.8.0, I noticed that `yr_finalize_thread` had disappeared from the symbols exported by `ibyara.so.3` because it no longer gets compiled with default visibility. This breaks ABI compatibility, i.e. programs that still call `yr_finalize_thread` cannot be linked with the library like this.