### PR TITLE
Fix argument size when setting booleans.

### DIFF
--- a/args.c
+++ b/args.c
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdlib.h>
 
+#include <yara.h>
+
 #include "args.h"
 
 #define args_is_long_arg(arg)  \
@@ -99,7 +101,7 @@ args_error_type_t args_parse_option(
   switch (opt->type)
   {
     case ARGS_OPT_BOOLEAN:
-      *(int*) opt->value = 1;
+      *(bool*) opt->value = true;
       break;
 
     case ARGS_OPT_INTEGER:


### PR DESCRIPTION
There's a bug in argument parsing in YARA 3.8.0 which is causing two boolean arguments to be broken. This doesn't work with every combination of arguments but here's one that does trigger it. First, the setup is a recursive directory structure with a file in it and a rule which should match:

```
wxs@mbp yara % mkdir -p /tmp/foo/bar
wxs@mbp yara % echo "hi" > /tmp/foo/bar/baz
wxs@mbp yara % cat test.yara
rule test : foo { condition: true }
wxs@mbp yara %
```

Now if we use ```yara -r -g``` the ```-r``` argument is seemingly ignored, but if we use ```yara -g -r``` neither argument is ignored.

```
wxs@mbp yara % ./yara -r -g test.yara /tmp/foo
wxs@mbp yara % ./yara -g -r test.yara /tmp/foo
test [foo] /tmp/foo/bar/baz
wxs@mbp yara %
```

What's happening is that &recursive_search and &show_tags are 1 byte difference.

```
(lldb) p &recursive_search
(bool *) $4 = 0x000000010006e851
(lldb) p & show_tags
(bool *) $5 = 0x000000010006e850
(lldb)
```

So when we write an integer for booleans we are writing 4 bytes when we should be writing one - sizeof(bool) is 1 and sizeof(int) is 4. Because the difference in address between the two is 1 byte we end up overwriting recursive_search with the zero bytes for show_tags.

This fix makes it so we write a single byte in this case (and uses true instead of 1 to be accurate).
