### PR TITLE
Fix macho module on 32bit architectures

### DIFF
--- a/libyara/modules/macho.c
+++ b/libyara/modules/macho.c
@@ -262,7 +262,7 @@ MACHO_HANDLE_MAIN(be)
 #define MACHO_HANDLE_SEGMENT(bits,bo)                                          \
 void macho_handle_segment_##bits##_##bo(                                       \
     const uint8_t* command,                                                    \
-    const uint64_t i,                                                          \
+    const unsigned i,                                                          \
     YR_OBJECT* object)                                                         \
 {                                                                              \
   yr_segment_command_##bits##_t* sg = (yr_segment_command_##bits##_t*)command; \


### PR DESCRIPTION
printf(3)-style expressions such as "segments[%i].sections[%i].segname"
expect int-size values. With the first value being defined as an
uint64_t, this holds true on 64bit architectures only.