### PR TITLE
Use __attribute__((format(...))) for GCC, fix warnings

### DIFF
--- a/libyara/include/yara/object.h
+++ b/libyara/include/yara/object.h
@@ -101,38 +101,38 @@ YR_OBJECT* yr_object_lookup(
     YR_OBJECT* root,
     int flags,
     const char* pattern,
-    ...);
+    ...) YR_PRINTF_LIKE(3, 4);
 
 
 bool yr_object_has_undefined_value(
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(2, 3);
 
 int64_t yr_object_get_integer(
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(2, 3);
 
 
 SIZED_STRING* yr_object_get_string(
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(2, 3);
 
 
 int yr_object_set_integer(
     int64_t value,
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(3, 4);
 
 
 int yr_object_set_float(
     double value,
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(3, 4);
 
 
 int yr_object_set_string(
@@ -140,7 +140,7 @@ int yr_object_set_string(
     size_t len,
     YR_OBJECT* object,
     const char* field,
-    ...);
+    ...) YR_PRINTF_LIKE(4, 5);
 
 
 YR_OBJECT* yr_object_array_get_item(

--- a/libyara/modules/dex.c
+++ b/libyara/modules/dex.c
@@ -405,7 +405,7 @@ uint32_t load_encoded_field(
       encoded_field.access_flags);
   #endif
 
-  uint64_t name_idx = get_integer(
+  int name_idx = (int)get_integer(
       dex->object, "field_ids[%i].name_idx", *previous_field_idx);
 
   #ifdef DEBUG_DEX_MODULE
@@ -431,10 +431,10 @@ uint32_t load_encoded_field(
         index_encoded_field);
   }
 
-  uint64_t class_idx = get_integer(
+  int class_idx = (int)get_integer(
       dex->object, "field_ids[%i].class_idx", *previous_field_idx);
 
-  uint64_t descriptor_idx = get_integer(
+  int descriptor_idx = (int)get_integer(
       dex->object, "type_ids[%i].descriptor_idx", class_idx);
 
   SIZED_STRING* class_name = get_string(
@@ -457,10 +457,10 @@ uint32_t load_encoded_field(
         index_encoded_field);
   }
 
-  uint64_t type_idx = get_integer(dex->object,
+  int type_idx = (int)get_integer(dex->object,
       "field_ids[%i].type_idx", *previous_field_idx);
 
-  uint64_t shorty_idx = get_integer(dex->object,
+  int shorty_idx = (int)get_integer(dex->object,
       "type_ids[%i].descriptor_idx", type_idx);
 
   SIZED_STRING* proto_name = get_string(dex->object,
@@ -553,7 +553,7 @@ uint32_t load_encoded_method(
       encoded_method.code_off);
   #endif
 
-  uint64_t name_idx = get_integer(
+  int name_idx = (int)get_integer(
       dex->object, "method_ids[%i].name_idx", *previous_method_idx);
 
   #ifdef DEBUG_DEX_MODULE
@@ -579,10 +579,10 @@ uint32_t load_encoded_method(
         index_encoded_method);
   }
 
-  uint64_t class_idx = get_integer(
+  int class_idx = (int)get_integer(
       dex->object, "method_ids[%i].class_idx", *previous_method_idx);
 
-  uint64_t descriptor_idx = get_integer(
+  int descriptor_idx = (int)get_integer(
       dex->object, "type_ids[%i].descriptor_idx", class_idx);
 
   SIZED_STRING* class_name = get_string(
@@ -605,10 +605,10 @@ uint32_t load_encoded_method(
         index_encoded_method);
   }
 
-  uint64_t proto_idx = get_integer(
+  int proto_idx = (int)get_integer(
       dex->object, "method_ids[%i].proto_idx", *previous_method_idx);
 
-  uint64_t shorty_idx = get_integer(
+  int shorty_idx = (int)get_integer(
       dex->object, "proto_ids[%i].shorty_idx", proto_idx);
 
   SIZED_STRING* proto_name = get_string(

--- a/libyara/modules/macho.c
+++ b/libyara/modules/macho.c
@@ -97,7 +97,7 @@ bool macho_rva_to_offset(
     YR_OBJECT* object)
 {
   uint64_t segment_count = get_integer(object, "number_of_segments");
-  for (uint64_t i = 0; i < segment_count; i++)
+  for (int i = 0; i < segment_count; i++)
   {
     uint64_t start = get_integer(object, "segments[%i].vmaddr", i);
     uint64_t end = start + get_integer(object, "segments[%i].vmsize", i);
@@ -121,7 +121,7 @@ int macho_offset_to_rva(
     YR_OBJECT* object)
 {
   uint64_t segment_count = get_integer(object, "number_of_segments");
-  for (uint64_t i = 0; i < segment_count; i++)
+  for (int i = 0; i < segment_count; i++)
   {
     uint64_t start = get_integer(object, "segments[%i].fileoff", i);
     uint64_t end = start + get_integer(object, "segments[%i].filesize", i);
@@ -722,7 +722,7 @@ define_function(file_index_type)
   if (is_undefined(module, "nfat_arch"))
     return_integer(UNDEFINED);
 
-  for (uint64_t i = 0; i < nfat; i++)
+  for (int i = 0; i < nfat; i++)
   {
     int64_t type = get_integer(module, "file[%i].cputype", i);
     if (type == type_arg)
@@ -746,7 +746,7 @@ define_function(file_index_subtype)
   if (is_undefined(module, "nfat_arch"))
     return_integer(UNDEFINED);
 
-  for (uint64_t i = 0; i < nfat; i++)
+  for (int i = 0; i < nfat; i++)
   {
     int64_t type = get_integer(module, "file[%i].cputype", i);
     int64_t subtype = get_integer(module, "file[%i].cpusubtype", i);
@@ -771,7 +771,7 @@ define_function(ep_for_arch_type)
   if (is_undefined(module, "nfat_arch"))
     return_integer(UNDEFINED);
 
-  for (uint64_t i = 0; i < nfat; i++)
+  for (int i = 0; i < nfat; i++)
   {
     int64_t type = get_integer(module, "fat_arch[%i].cputype", i);
     if (type == type_arg)
@@ -797,7 +797,7 @@ define_function(ep_for_arch_subtype)
   if (is_undefined(module, "nfat_arch"))
     return_integer(UNDEFINED);
 
-  for (uint64_t i = 0; i < nfat; i++)
+  for (int i = 0; i < nfat; i++)
   {
     int64_t type = get_integer(module, "fat_arch[%i].cputype", i);
     int64_t subtype = get_integer(module, "fat_arch[%i].cpusubtype", i);

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1672,7 +1672,7 @@ define_function(section_index_addr)
   YR_OBJECT* module = module();
   YR_SCAN_CONTEXT* context = scan_context();
 
-  int64_t i;
+  int i;
   int64_t offset;
   int64_t size;
 
@@ -1710,7 +1710,7 @@ define_function(section_index_name)
   char* name = string_argument(1);
 
   int64_t n = get_integer(module, "number_of_sections");
-  int64_t i;
+  int i;
 
   if (is_undefined(module, "number_of_sections"))
     return_integer(UNDEFINED);
@@ -2067,7 +2067,7 @@ define_function(locale)
   PE* pe = (PE*) module->data;
 
   uint64_t locale = integer_argument(1);
-  int64_t n, i;
+  int n, i;
 
   if (is_undefined(module, "number_of_resources"))
     return_integer(UNDEFINED);
@@ -2097,7 +2097,7 @@ define_function(language)
   PE* pe = (PE*) module->data;
 
   uint64_t language = integer_argument(1);
-  int64_t n, i;
+  int n, i;
 
   if (is_undefined(module, "number_of_resources"))
     return_integer(UNDEFINED);
@@ -2165,7 +2165,7 @@ static uint64_t rich_internal(
 {
   int64_t rich_length;
   int64_t rich_count;
-  int64_t i;
+  int i;
 
   PRICH_SIGNATURE clear_rich_signature;
   SIZED_STRING* rich_string;


### PR DESCRIPTION
GCC has had a feature `__attribute__((format(...)))` for some time that lets us annotate functions that behave similarly to `printf()` and relatives. GCC will then generate warnings for mismatches between the format string literal and the arguments referenced by the format string. It turns out that there are quite a few of these mismatches and fixing those eliminates some test failures (`dex`, `macho`) on linux-powerpc and linux-mips, both 32bit big-endian architectures.

I am not sure if the `__GNUC__ >= 4` condition is accurate. Also, Clang has support for the same syntax and apparently newer versions of the Microsoft C have a similar feature.