### PR TITLE
Fix bool macro redefinition warning in VS 2013 and higher and a typo

### DIFF
--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -58,7 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if defined(_WIN32) || defined(__CYGWIN__)
   #ifdef YR_BUILDING_DLL
     #ifdef __GNUC__
-      #define YR_API EXTERNC __attribute_((dllexport))
+      #define YR_API EXTERNC __attribute__((dllexport))
       #define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
     #else
       #define YR_API EXTERNC __declspec(dllexport)

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -38,7 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NULL 0
 #endif
 
-#if defined(HAVE_STDBOOL_H)
+#if defined(HAVE_STDBOOL_H) || (defined(_MSC_VER) && _MSC_VER >= 1800)
 #include <stdbool.h>
 #else
 #ifndef __cplusplus


### PR DESCRIPTION
When including the yara headers in a C program or library that has already included `stdbool.h`, you get this compiler warning in Visual Studio 2013 and up, because it does not define `HAVE_STDBOOL_H`:
```
yara\utils.h(45): warning C4005: 'bool': macro redefinition
```

I fixed it by adding a secondary check for `_MSC_VER >= 1800`, which is the earliest version that supports C99's `stdbool.h`.