### PR TITLE
is_integer(): Reject empty strings

### DIFF
--- a/common.h
+++ b/common.h
@@ -90,6 +90,9 @@ bool is_integer(const char *str)
   if (*str == '-')
     str++;
 
+  if (*str == '\0')
+    return false;
+
   while(*str)
   {
     if (!isdigit(*str))


### PR DESCRIPTION
As reported by Florian Roth: Using -d:str= to compile

   rule t { condition: str = "xyz" }

fails with

    error: type mismatch