### PR TITLE
Fixed internal error when running multiple instances of YARA

### DIFF
--- a/threading.c
+++ b/threading.c
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
 #include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
 #endif
 
 #if defined(__FreeBSD__)
@@ -103,12 +105,18 @@ int semaphore_init(
   // from the name. More info at:
   //
   // http://stackoverflow.com/questions/1413785/sem-init-on-os-x
-  *semaphore = sem_open("/semaphore", O_CREAT, S_IRUSR, value);
+  //
+  // Also create name for semaphore from PID because running multiple instances
+  // of YARA at the same time can cause that sem_open() was called in two processes
+  // simultaneously while neither of them had chance to call sem_unlink() yet.
+  char name[20];
+  snprintf(name, sizeof(name), "/yara.sem.%i", (int)getpid());
+  *semaphore = sem_open(name, O_CREAT, S_IRUSR, value);
 
   if (*semaphore == SEM_FAILED)
     return errno;
 
-  if (sem_unlink("/semaphore") != 0)
+  if (sem_unlink(name) != 0)
     return errno;
   #endif
 


### PR DESCRIPTION
When running multiple instances of YARA simultaneously, I occasionally ran into `internal error 31`. I found out that this is caused by the creation of semaphores. Because of Mac OS X, we need to create semaphore as named and then unlink it. The name of the semaphore is set to static name `/semaphore`. I personally thought that this couldn't be a problem since `O_EXCL` is not used, however when I try to compile this small program and run it twice (before the first one calls `sem_unlink`), the second process does not get access to the semaphore.

```c
#include <fcntl.h>
#include <semaphore.h>
#include <stdio.h>

int main()
{
	sem_t* sem = sem_open("/semaphore", O_CREAT, S_IRUSR, 0);
	perror("sem_open");
	printf("%p\n", sem);
	puts("Waiting for enter...");
	getchar();
	sem_unlink("/semaphore");
	perror("sem_unlink");
	puts("Waiting for enter...");
	getchar();
	sem_close(sem);
}
```

This PR puts PID of the process into name of the semaphore so no 2 processes can get into this kind of conflict.