### PR TITLE
Add `icons` array to PE module

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@
 Anthony Desnos <adesnos@google.com>
 Christian Blichmann <cblichmann@google.com>
 Hilko Bengen <bengen@hilluzination.de>
+Jason Garman <jason.garman@gmail.com>
 Joachim Metz <joachim.metz@gmail.com>
 Karl Hiramoto <karl.hiramoto@virustotal.com>
 Mike Wiacek <mjwiacek@google.com>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ awesome list of [YARA-related stuff](https://github.com/InQuest/awesome-yara).
 * [BinaryAlert](https://github.com/airbnb/binaryalert)
 * [Blue Coat](http://www.bluecoat.com/products/malware-analysis-appliance)
 * [Blueliv](http://www.blueliv.com)
+* [Carbon Black](https://www.carbonblack.com)
 * [Conix](http://www.conix.fr)
 * [CrowdStrike FMS](https://github.com/CrowdStrike/CrowdFMS)
 * [Cuckoo Sandbox](https://github.com/cuckoosandbox/cuckoo)

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -484,6 +484,49 @@ Reference
 
     *Example:  pe.data_directories[pe.IMAGE_DIRECTORY_ENTRY_EXPORT].virtual_address != 0*
 
+.. c:type:: number_of_icons
+
+    Number of "displayable" icons in the PE. This only counts icons that are considered
+    by Windows Explorer when viewing the directory containing the PE file or displaying 
+    file properties on the PE file.
+
+.. c:type:: icons
+
+    A zero-based array of icon objects, one for each "displayable" icon in the PE.
+    Individual icons can be accessed by using the [] operator. Each icon object has
+    the following attributes:
+
+    .. c:member:: width
+
+        Width of the icon image in pixels (1-256).
+
+    .. c:member:: height
+
+        Height of the icon image in pixels (1-256).
+
+    .. c:member:: color_bit_count
+
+        Number of bits in the color channel for this icon image (for example,
+        8 bit == 256 colors)
+
+    .. c:member:: color_planes
+
+        Number of color planes in the icon image.
+
+    .. c:member:: ordinal
+
+        The icon ordinal where the image can be found in the PE file.
+
+    .. c:member:: data
+
+        The icon image data as a string. Note that BMP formatted images do not
+        include the BITMAPINFOHEADER structure, and this structure has to be
+        recreated using the above metadata before the image can be displayed
+        properly. See the `description of the icon file format
+        <https://en.wikipedia.org/wiki/ICO_(file_format)>`_ for more information.
+        PNG formatted images are included in their entirety.
+
+
 .. c:type:: number_of_sections
 
     Number of sections in the PE.

--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -506,6 +506,28 @@ typedef struct _RICH_SIGNATURE {
 #define RICH_DANS 0x536e6144 // "DanS"
 #define RICH_RICH 0x68636952 // "Rich"
 
+//
+// Group Icon directory
+// https://blogs.msdn.microsoft.com/oldnewthing/20120720-00/?p=7083
+//
+
+typedef struct _PE_GROUP_ICON_DIRECTORY_ENTRY {
+    BYTE bWidth;          // this will be \x00 for 256 byte wide icons
+    BYTE bHeight;         // this will be \x00 for 256 byte high icons
+    BYTE bColorCount;
+    BYTE bReserved;
+    WORD wPlanes;
+    WORD wBitCount;
+    DWORD dwBytesInRes;
+    WORD nId;
+} PE_GROUP_ICON_DIRECTORY_ENTRY, *PPE_GROUP_ICON_DIRECTORY_ENTRY;
+
+typedef struct _PE_GROUP_ICON_DIRECTORY {
+    WORD idReserved;
+    WORD idType;
+    WORD idCount;
+    PE_GROUP_ICON_DIRECTORY_ENTRY idEntries[0];
+} PE_GROUP_ICON_DIRECTORY, *PPE_GROUP_ICON_DIRECTORY;
 
 #pragma pack(pop)
 #endif

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -1150,7 +1150,11 @@ YR_API void yr_object_print_data(
         {
           char c = object->value.ss->c_string[l];
 
-          if (isprint((unsigned char) c))
+          if ((unsigned char) c == '\\')
+            printf("\\\\");
+          else if ((unsigned char) c == '\"')
+            printf("\\\"");
+          else if (isprint((unsigned char) c))
             printf("%c", c);
           else
             printf("\\x%02x", (unsigned char) c);


### PR DESCRIPTION
Add a new `icons` field to the PE module to retrieve "displayable" icons in the PE file for hashing, matching, or another analysis. Icons are included in this list if they are considered as an 'application icon' by Windows Explorer (for example, when viewing the directory containing the file or displaying the file's properties page).

Also:
* slight fix to the `yr_object_print_data` function to properly escape output of arbitrary binary strings
* add Carbon Black as a company using Yara and myself as a contributor