### PR TITLE
Add a note about pe.rva_to_offset(pe.entry_point)

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -962,10 +962,11 @@ Reference
 
     .. versionadded:: 3.6.0
 
-    Function returning the file offset for RVA *addr*.
+    Function returning the file offset for RVA *addr*. Be careful to pass
+    relative addresses here and not absolute addresses, like `pe.entry_point`
+    when scanning a process.
 
-    *Example: pe.rva_to_offset(pe.entry_point)*
+    *Example: pe.rva_to_offset(pe.sections[0].virtual_address) == pe.sections[0].raw_data_offset*
 
-    Passing `pe.entry_point` here only makes sense when scanning a process. This
-    is because `pe.entry_point` will be an RVA when scanning a process and a
-    file offset when scanning a file.
+    This example will make sure the offset for the virtual address in the first
+    section equals the file offset for that section.

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -965,3 +965,7 @@ Reference
     Function returning the file offset for RVA *addr*.
 
     *Example: pe.rva_to_offset(pe.entry_point)*
+
+    Passing `pe.entry_point` here only makes sense when scanning a process. This
+    is because `pe.entry_point` will be an RVA when scanning a process and a
+    file offset when scanning a file.


### PR DESCRIPTION
In discussions with someone they noted they had seen a number of people doing `pe.rva_to_offset(pe.entry_point)` when scanning a file. This is not likely what they want since ` pe.entry_point`is already converted to an offset when `SCAN_FLAGS_PROCESS_MEMORY` is not set. This PR makes it clear that you need to be careful when doing this.