### PR TITLE
_MSC_VER < 1900 doesn't always work

### DIFF
--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -59,7 +59,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Cygwin already has these functions.
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #if defined(_MSC_VER) && _MSC_VER < 1900
+
+#if !defined(snprintf)
 #define snprintf _snprintf
+#endif
+
 #endif
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp


### PR DESCRIPTION
compiling on MSVC 2013 (toolset v120_xp) with windows 10 sdk and CRTs that are newer causes snprintf to already be defined (from stdio.h for example)
Adding a simple check to see if it is not already defined before defining.

Might be worth adding checks for all other macros like this to save compilation errors on other unexpected configurations.