### PR TITLE
add Cybereason to list of vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ awesome list of [YARA-related stuff](https://github.com/InQuest/awesome-yara).
 * [CrowdStrike FMS](https://github.com/CrowdStrike/CrowdFMS)
 * [Cuckoo Sandbox](https://github.com/cuckoosandbox/cuckoo)
 * [Cyber Triage](http://www.cybertriage.com)
+* [Cybereason](https://www.cybereason.com)
 * [Digita Security](https://digitasecurity.com/product/uxprotect)
 * [Dtex Systems](https://dtexsystems.com)
 * [ESET](https://www.eset.com)


### PR DESCRIPTION
We are implementing it in multiple systems of ours, please let me know if there's anything else I need to do in order to add us to the list of vendors who use this library