### PR TITLE
Fix small rule name typo

### DIFF
--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -124,28 +124,28 @@ static void test_comparison_operators()
       "rule test { condition: 0.5 <= 1}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: 1.0 <= 1}", NULL);
+      "rule test { condition: 1.0 <= 1}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abc\" == \"abc\"}", NULL);
+      "rule test { condition: \"abc\" == \"abc\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abc\" <= \"abc\"}", NULL);
+      "rule test { condition: \"abc\" <= \"abc\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abc\" >= \"abc\"}", NULL);
+      "rule test { condition: \"abc\" >= \"abc\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"ab\" < \"abc\"}", NULL);
+      "rule test { condition: \"ab\" < \"abc\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abc\" > \"ab\"}", NULL);
+      "rule test { condition: \"abc\" > \"ab\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abc\" < \"abd\"}", NULL);
+      "rule test { condition: \"abc\" < \"abd\"}", NULL);
 
   assert_true_rule(
-      "rule rest { condition: \"abd\" > \"abc\"}", NULL);
+      "rule test { condition: \"abd\" > \"abc\"}", NULL);
 
   assert_false_rule(
       "rule test { condition: 1 != 1}", NULL);


### PR DESCRIPTION
I'm cannibalizing all the rules here to use in unit tests for plyara (https://github.com/plyara/plyara). I noticed that someone starting typing rest rather than test. r is next to t.