### PR TITLE
Fixing suggested replacement for .*

### DIFF
--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -588,7 +588,7 @@ int yr_parser_reduce_string_declaration(
     {
       yywarning(
           yyscanner,
-          "%s contains .* or .+, consider using .{N} or .{1,N} with a reasonable value for N",
+          "%s contains .* or .+, consider using .{,N} or .{1,N} with a reasonable value for N",
           identifier);
     }
 


### PR DESCRIPTION
While refactoring some rules to avoid using .* because of performance based on the original warning message, I was wondering why .+ wouldn't have the same performance impact.

Looking at #713 I saw it also does as I supposed.

I was about to comment that the implemented  .{1-N} suggested change message was not correct and should have been .{1,N} but that was also fixed in #902 

So I think I'm right in saying that the original message suggesting using .{N} instead of .* is wrong since it will match exactly N repetitions, instead it should be .{,N} right?