### PR TITLE
Visual C++ 2013 through c99 log2 function support

### DIFF
--- a/libyara/modules/math.c
+++ b/libyara/modules/math.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // log2 is not defined by math.h in VC++
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1800
 double log2(double n)
 {
   return log(n) / log(2.0);


### PR DESCRIPTION
The log2 function is included in the c99 standard specification, and since Visual C ++ 2013 through c99 support, this code causes link errors.
