### PR TITLE
Fixed documentation of new -C|--compiled-rules command-line option

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -57,7 +57,7 @@ Available options are:
 
   Print rules named <identifier> and ignore the rest.
 
-.. option:: -c --count
+.. option:: -C --compiled-rules
 
   RULES_FILE contains rules already compiled with yarac.
 


### PR DESCRIPTION
I just noticed probably copy-paste error in the documentation of the new command-line option.