### PR TITLE
Fix NULL pointer usage

### DIFF
--- a/libyara/ahocorasick.c
+++ b/libyara/ahocorasick.c
@@ -811,6 +811,7 @@ int yr_ac_automaton_create(
 int yr_ac_automaton_destroy(
     YR_AC_AUTOMATON* automaton)
 {
+  if (automaton == NULL) return ERROR_SUCCESS;
   _yr_ac_state_destroy(automaton->root);
 
   yr_free(automaton->t_table);

--- a/libyara/ahocorasick.c
+++ b/libyara/ahocorasick.c
@@ -811,7 +811,7 @@ int yr_ac_automaton_create(
 int yr_ac_automaton_destroy(
     YR_AC_AUTOMATON* automaton)
 {
-  if (automaton == NULL) return ERROR_SUCCESS;
+  if (automaton == NULL) return ERROR_INVALID_ARGUMENT;
   _yr_ac_state_destroy(automaton->root);
 
   yr_free(automaton->t_table);


### PR DESCRIPTION
I've got crash dumps from clients where that function was called with NULL automaton pointer. 

RogueKiller64.exe!yr_ac_automaton_destroy(YR_AC_AUTOMATON * automaton=0x0000000000000000) Ligne 814	C++
RogueKiller64.exe!yr_compiler_destroy(_YR_COMPILER * compiler=0x000001d996a999e0) Ligne 269	C++
RogueKiller64.exe!yr_compiler_create(_YR_COMPILER * * compiler=0x000001d991c6c100) Ligne 246	C++