### PR TITLE
Guard against divide by 0

### DIFF
--- a/libyara/stopwatch.c
+++ b/libyara/stopwatch.c
@@ -48,6 +48,7 @@ uint64_t yr_stopwatch_elapsed_us(
 
   QueryPerformanceCounter(&li);
 
+  if (sw->frequency.QuadPart <= 0) return 0;
   return (li.QuadPart - sw->start.QuadPart) * 1000000L / sw->frequency.QuadPart;
 }
 


### PR DESCRIPTION
Got a crash dump with QuadPart == 0

RogueKiller64.exe!yr_stopwatch_elapsed_us(_YR_STOPWATCH * sw=0x000002b93cbdbe90) Ligne 51	C++
RogueKiller64.exe!yr_scanner_scan_mem_blocks(YR_SCAN_CONTEXT * scanner=0x000002b93cbdbe30, YR_MEMORY_BLOCK_ITERATOR * iterator=0x000000e10d7fe390) Ligne 484	C++
RogueKiller64.exe!yr_rules_scan_mem(YR_RULES * rules, const unsigned char * buffer, unsigned __int64 buffer_size, int flags=0x00000001, int(*)(int, void *, void *) callback=0x00007ff796357920, void * user_data=0x000000e10d7fe4d0, int timeout=0x00000005) Ligne 255	C++
RogueKiller64.exe!yr_rules_scan_fd(YR_RULES * rules=0x000002b935f32970, void * fd, int flags=0x00000001, int(*)(int, void *, void *) callback=0x00007ff796357920, void * user_data=0x000000e10d7fe4d0, int timeout=0x00000005) Ligne 318	C++