### PR TITLE
Fixed multiple memory leaks in tests

### DIFF
--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -520,7 +520,10 @@ YR_API int yr_rules_get_stats(
   }
 
   if (c == 0)
+  {
+    yr_free(match_list_lengths);
     return ERROR_SUCCESS;
+  }
 
   // sort match_list_lengths in increasing order for computing percentiles.
   qsort(match_list_lengths, c, sizeof(match_list_lengths[0]), _uint32_cmp);

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -1896,6 +1896,7 @@ void test_process_scan()
         all of them\
     }", &rules) == ERROR_SUCCESS);
   rc1 = yr_rules_scan_proc(rules, pid, 0, count_matches, &matches, 0);
+  yr_rules_destroy(rules);
   kill(pid, SIGALRM);
 
   rc2 = waitpid(pid, &status, 0);


### PR DESCRIPTION
There were some memory leaks in the tests which I found out about when I ran the tests with address sanitizer (`test-api`, `test-rules` and `test-atoms`). This should fix them all.