### PR TITLE
Define log2 as static to not export it out of libyara

### DIFF
--- a/libyara/modules/math.c
+++ b/libyara/modules/math.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // log2 is not defined by math.h in VC++
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
-double log2(double n)
+static double log2(double n)
 {
   return log(n) / log(2.0);
 }


### PR DESCRIPTION
If `log2` is not defined as static then it is being exported out of `libyara(32|64).lib`. We had problems linking two libraries which are linked against `libyara`. Linker was complaining about multiple definitions of the symbol. I have noticed that fix for VS2013, which support `log2` natively is already in the upstream, but `static` definition is missing.