### PR TITLE
Fix issue #1053.

### DIFF
--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -1573,18 +1573,7 @@ int yr_atoms_extract_from_string(
         *atoms = NULL;
       });
 
-    if (flags & STRING_GFLAGS_ASCII ||
-        flags & STRING_GFLAGS_WIDE ||
-        flags & STRING_GFLAGS_NO_CASE)
-    {
-      *atoms = _yr_atoms_list_concat(*atoms, xor_atoms);
-    }
-    else
-    {
-      yr_atoms_list_destroy(*atoms);
-      *atoms = xor_atoms;
-    }
-
+    *atoms = _yr_atoms_list_concat(*atoms, xor_atoms);
   }
 
   return ERROR_SUCCESS;

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -514,7 +514,7 @@ static void test_strings()
       strings:\n\
         $a = \"This program cannot\" xor\n\
       condition:\n\
-        #a == 255\n\
+        #a == 256\n\
     }", "tests/data/xor.out");
 
   assert_true_rule_file(
@@ -528,7 +528,39 @@ static void test_strings()
   assert_true_rule_file(
     "rule test {\n\
       strings:\n\
+        $a = \"This program cannot\" xor ascii wide\n\
+      condition:\n\
+        #a == 256\n\
+    }", "tests/data/xor.out");
+
+  assert_true_rule_file(
+    "rule test {\n\
+      strings:\n\
         $a = \"This program cannot\" xor wide\n\
+      condition:\n\
+        #a == 0\n\
+    }", "tests/data/xor.out");
+
+  assert_true_rule_file(
+    "rule test {\n\
+      strings:\n\
+        $a = \"This program cannot\" xor wide\n\
+      condition:\n\
+        #a == 256\n\
+    }", "tests/data/xorwide.out");
+
+  assert_true_rule_file(
+    "rule test {\n\
+      strings:\n\
+        $a = \"This program cannot\" xor ascii\n\
+      condition:\n\
+        #a == 0\n\
+    }", "tests/data/xorwide.out");
+
+  assert_true_rule_file(
+    "rule test {\n\
+      strings:\n\
+        $a = \"This program cannot\" xor wide ascii\n\
       condition:\n\
         #a == 256\n\
     }", "tests/data/xorwide.out");


### PR DESCRIPTION
Now the following two string definitions are equivalent:

        $xor_string = "This program cannot" xor
        $xor_string = "This program cannot" xor ascii

Before this patch the first case didn't match the original string (i.e: XORed with 0).