### PR TITLE
Add compiled Windows binaries to release automatically.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,11 +54,11 @@ for:
     verbosity: minimal
 
   after_build:
-  - cmd: 7z a yara-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\windows\vs2015\Release\*.exe
+  - cmd: 7z a yara-%CONFIGURATION%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
 
   artifacts:
-  - path: yara-$(platform).zip
-    name: yara-$(platform)
+  - path: yara-$(configuration)-$(platform).zip
+    name: yara-$(configuration)-$(platform)
     type: zip
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     VisualStudioVersion: 14.0
     platform: x86
     configuration: Release
-    artifactpostfix: win32
+    artifact_postfix: win32
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
@@ -23,7 +23,7 @@ environment:
     VisualStudioVersion: 14.0
     platform: x64
     configuration: Release
-    artifactpostfix: win64
+    artifact_postfix: win64
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
@@ -57,19 +57,19 @@ for:
     verbosity: minimal
 
   after_build:
-  - cmd: 7z a %NAME%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
+  - cmd: 7z a yara-%APPVEYOR_BUILD_VERSION%-%ARTIFACT_POSTFIX%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
 
   artifacts:
-  - path: yara-'{version}'-$(artifactpostfix).zip
-    name: yara-'{version}'-$(artifactpostfix)
+  - path: yara-$(appveyor_build_version)-$(artifact_postfix).zip
+    name: yara-$(appveyor_build_version)-$(artifact_postfix)
     type: zip
 
   deploy:
-    release: YARA '{version}'
+    release: YARA $(appveyor_build_version)
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
-    artifact: yara-'{version}'-$(artifactpostfix)
+    artifact:
     draft: true
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ for:
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
-    artifact: $(name).zip
+    artifact: $(name)
     draft: true
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ for:
     type: zip
 
   deploy:
-    release: YARA $(APPVEYOR_REPO_TAG_NAME)
+    description: YARA $(APPVEYOR_REPO_TAG_NAME)
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,8 @@ for:
     type: zip
 
   deploy:
-    tag: YARA $(APPVEYOR_REPO_TAG_NAME)
+    tag: $(APPVEYOR_REPO_TAG_NAME)
+    release: YARA $(APPVEYOR_REPO_TAG_NAME)
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,6 @@ for:
     artifact: yara-$(appveyor_build_version)-$(artifact_postfix)
     draft: true
     on:
-      branch: appveyor                 # release from master branch only
       APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,8 +53,11 @@ for:
     project: windows/vs2015/yara.sln
     verbosity: minimal
 
+  after_build:
+  - cmd: 7z a yara-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\windows\vs2015\Release\*.exe
+
   artifacts:
-  - path: windows\**\*.exe
+  - path: yara-$(platform).zip
     name: yara-$(platform)
     type: zip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,14 @@ for:
     name: $(name)
     type: zip
 
+  deploy:
+    release: YARA $(appveyor_build_version)
+    provider: GitHub
+    auth_token:
+      secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
+    artifact: $(name).zip
+    draft: true
+
   test: off
 
 -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     VisualStudioVersion: 14.0
     platform: x86
     configuration: Release
-    name: yara-win32
+    artifactpostfix: win32
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
@@ -23,7 +23,7 @@ environment:
     VisualStudioVersion: 14.0
     platform: x64
     configuration: Release
-    name: yara-win64
+    artifactpostfix: win64
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
@@ -60,16 +60,16 @@ for:
   - cmd: 7z a %NAME%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
 
   artifacts:
-  - path: $(name).zip
-    name: $(name)
+  - path: yara-'{version}'-$(artifactpostfix).zip
+    name: yara-'{version}'-$(artifactpostfix)
     type: zip
 
   deploy:
-    release: YARA $(appveyor_build_version)
+    release: YARA '{version}'
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
-    artifact: $(name)
+    artifact: yara-'{version}'-$(artifactpostfix)
     draft: true
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ for:
   matrix:
     only:
       - TARGET: vs2015
+      - configuration: Release
 
   before_build:
   - ps: nuget restore windows/vs2015/yara.sln
@@ -54,13 +55,6 @@ for:
   build:
     project: windows/vs2015/yara.sln
     verbosity: minimal
-
-  test: off
-
-- matrix:
-    only:
-      - TARGET: vs2015
-      - configuration: Release
 
   after_build:
   - cmd: 7z a %NAME%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
@@ -70,6 +64,22 @@ for:
     name: $(name)
     type: zip
 
+  test: off
+
+-
+  matrix:
+    only:
+      - TARGET: vs2015
+      - configuration: Debug
+
+  before_build:
+  - ps: nuget restore windows/vs2015/yara.sln
+
+  build:
+    project: windows/vs2015/yara.sln
+    verbosity: minimal
+
+  test: off
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This
 # allows connecting to the remote machine and debug issues.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # AppVeyor CI for Windows
 
-version: 3.9.0-{branch}-{build}
+version: '{branch}-{build}'
 
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,17 +63,6 @@ for:
 
   test: off
 
-  deploy:
-    release: YARA $(APPVEYOR_REPO_TAG_NAME)
-    provider: GitHub
-    auth_token:
-      secure: 6e5a58e1c5bc2e93b871bb6fe4dac90475e1772f
-    artifact: /yara-.*/
-    draft: true
-    on:
-      branch: appveyor                 # release from master branch only
-      APPVEYOR_REPO_TAG: true        # deploy on tag push only
-
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This
 # allows connecting to the remote machine and debug issues.
 # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ for:
     type: zip
 
   deploy:
-    description: YARA $(APPVEYOR_REPO_TAG_NAME)
+    tag: YARA $(APPVEYOR_REPO_TAG_NAME)
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,18 +10,20 @@ environment:
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
-    configuration: Release
     platform: x86
+    configuration: Release
+    name: yara-win32
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
-    configuration: Debug
     platform: x86
+    configuration: Debug
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
     platform: x64
     configuration: Release
+    name: yara-win64
   - TARGET: vs2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VisualStudioVersion: 14.0
@@ -53,15 +55,21 @@ for:
     project: windows/vs2015/yara.sln
     verbosity: minimal
 
+  test: off
+
+- matrix:
+    only:
+      - TARGET: vs2015
+      - configuration: Release
+
   after_build:
-  - cmd: 7z a yara-%CONFIGURATION%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
+  - cmd: 7z a %NAME%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
 
   artifacts:
-  - path: yara-$(configuration)-$(platform).zip
-    name: yara-$(configuration)-$(platform)
+  - path: $(name).zip
+    name: $(name)
     type: zip
 
-  test: off
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This
 # allows connecting to the remote machine and debug issues.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,16 +60,16 @@ for:
   - cmd: 7z a yara-%APPVEYOR_BUILD_VERSION%-%ARTIFACT_POSTFIX%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
 
   artifacts:
-  - path: yara-$(appveyor_build_version)-$(artifact_postfix).zip
-    name: yara-$(appveyor_build_version)-$(artifact_postfix)
+  - path: yara-$(APPVEYOR_BUILD_VERSION)-$(ARTIFACT_POSTFIX).zip
+    name: yara-$(APPVEYOR_BUILD_VERSION)-$(ARTIFACT_POSTFIX)
     type: zip
 
   deploy:
-    release: YARA $(appveyor_build_version)
+    release: YARA $(APPVEYOR_REPO_TAG_NAME)
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
-    artifact: yara-$(appveyor_build_version)-$(artifact_postfix)
+    artifact: yara-$(APPVEYOR_BUILD_VERSION)-$(ARTIFACT_POSTFIX)
     draft: true
     on:
       APPVEYOR_REPO_TAG: true        # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # AppVeyor CI for Windows
 
-version: 3.9.0-{build}
+version: 3.9.0-{branch}-{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,8 +55,21 @@ for:
 
   artifacts:
   - path: windows\**\*.exe
+    name: yara-$(platform)
+    type: zip
 
   test: off
+
+  deploy:
+    release: YARA $(APPVEYOR_REPO_TAG_NAME)
+    provider: GitHub
+    auth_token:
+      secure: 6e5a58e1c5bc2e93b871bb6fe4dac90475e1772f
+    artifact: /yara-.*/
+    draft: true
+    on:
+      branch: appveyor                 # release from master branch only
+      APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This
 # allows connecting to the remote machine and debug issues.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,9 @@ for:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
     artifact: yara-$(appveyor_build_version)-$(artifact_postfix)
     draft: true
+    on:
+      branch: appveyor                 # release from master branch only
+      APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
   test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ for:
     provider: GitHub
     auth_token:
       secure: d3qqX7bmrBiKJI38yFPc5vHrGGfS3LxLC7FaG6ewI2ghPPE22Pk6QtyrEFFb73PL
-    artifact:
+    artifact: yara-$(appveyor_build_version)-$(artifact_postfix)
     draft: true
 
   test: off


### PR DESCRIPTION
Windows binaries compiled in Appveyor are added automatically to GitHub release.