### PR TITLE
Do not match whitespace characters worked only for tabs and spaces

### DIFF
--- a/libyara/re_lexer.l
+++ b/libyara/re_lexer.l
@@ -365,6 +365,10 @@ hex_digit     [0-9a-fA-F]
 
   LEX_ENV->re_class.bitmap[' ' / 8] |= 1 << ' ' % 8;
   LEX_ENV->re_class.bitmap['\t' / 8] |= 1 << '\t' % 8;
+  LEX_ENV->re_class.bitmap['\r' / 8] |= 1 << '\r' % 8;
+  LEX_ENV->re_class.bitmap['\n' / 8] |= 1 << '\n' % 8;
+  LEX_ENV->re_class.bitmap['\v' / 8] |= 1 << '\v' % 8;
+  LEX_ENV->re_class.bitmap['\f' / 8] |= 1 << '\f' % 8;
 }
 
 
@@ -378,6 +382,14 @@ hex_digit     [0-9a-fA-F]
       LEX_ENV->re_class.bitmap[i] |= ~(1 << ' ' % 8);
     else if (i == '\t' / 8)
       LEX_ENV->re_class.bitmap[i] |= ~(1 << '\t' % 8);
+    else if (i == '\r' / 8)
+      LEX_ENV->re_class.bitmap[i] |= ~(1 << '\r' % 8);
+    else if (i == '\n' / 8)
+      LEX_ENV->re_class.bitmap[i] |= ~(1 << '\n' % 8);
+    else if (i == '\v' / 8)
+      LEX_ENV->re_class.bitmap[i] |= ~(1 << '\v' % 8);
+    else if (i == '\f' / 8)
+      LEX_ENV->re_class.bitmap[i] |= ~(1 << '\f' % 8);
     else
       LEX_ENV->re_class.bitmap[i] = 0xFF;
   }

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -1293,6 +1293,8 @@ void test_re()
   assert_false_regexp("a\\Sb", "a\nb");
   assert_false_regexp("a\\Sb", "a\vb");
   assert_false_regexp("a\\Sb", "a\fb");
+  assert_true_regexp("foo([^\\s]*)", "foobar\n", "foobar");
+  assert_true_regexp("foo([^\\s]*)", "foobar\r\n", "foobar");
   assert_true_regexp("\\n\\r\\t\\f\\a", "\n\r\t\f\a", "\n\r\t\f\a");
   assert_true_regexp("[\\n][\\r][\\t][\\f][\\a]", "\n\r\t\f\a", "\n\r\t\f\a");
   assert_true_regexp("\\x01\\x02\\x03", "\x01\x02\x03", "\x01\x02\x03");


### PR DESCRIPTION
This fixed is based on closed issue #131.
String $s = /foo([^\s]*)/ matched only spaces and tabulators.