### PR TITLE
Properly set DEX string size

### DIFF
--- a/libyara/modules/dex.c
+++ b/libyara/modules/dex.c
@@ -775,8 +775,8 @@ void dex_parse(
         "string_ids[%i].offset", i);
 
     set_integer(
-        yr_le32toh(string_id_item->string_data_offset), dex->object,
-        "string_ids[%i].size", value);
+        value, dex->object,
+        "string_ids[%i].size", i);
 
     set_sized_string(
         (const char*) ((dex->data + yr_le32toh(string_id_item->string_data_offset) + 1)),


### PR DESCRIPTION
It looks like some code was copy / pasted and the wrong variables were changed for setting dex string sizes. The code now is using the string size as the _index_ into the string table and the value its setting is the offset.