### PR TITLE
Add Bazel build for Yara and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ test-version
 test-version.log
 test-version.trs
 
+# Bazel
+bazel-*
+
 # Visual Studio files
 Release/
 Debug/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,268 @@
+# Copyright (c) 2019. The YARA Authors. All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+YARA_CONFIG_OPTS = [
+    "-DBORINGSSL",
+    "-DHAVE_CLOCK_GETTIME=1",
+    #"-DHAVE_COMMONCRYPTO_COMMONCRYPTO_H",
+    "-DHAVE_DLFCN_H=1",
+    "-DHAVE_INTTYPES_H=1",
+    "-DHAVE_LIBCRYPTO=1",
+    "-DHAVE_LIBM=1",
+    "-DHAVE_MEMMEM=1",
+    "-DHAVE_MEMORY_H=1",
+    #"-DHAVE__MKGMTIME",
+    "-DHAVE_OPENSSL_ASN1_H=1",
+    "-DHAVE_OPENSSL_BIO_H=1",
+    "-DHAVE_OPENSSL_CRYPTO_H=1",
+    "-DHAVE_OPENSSL_MD5_H=1",
+    "-DHAVE_OPENSSL_PKCS7_H=1",
+    "-DHAVE_OPENSSL_SAFESTACK_H=1",
+    "-DHAVE_OPENSSL_SHA_H=1",
+    "-DHAVE_OPENSSL_X509_H=1",
+    #"-DHAVE_PTHREAD",
+    "-DHAVE_STDBOOL_H=1",
+    "-DHAVE_STDINT_H=1",
+    "-DHAVE_STDLIB_H=1",
+    "-DHAVE_STRING_H=1",
+    "-DHAVE_STRINGS_H=1",
+    "-DHAVE_SYS_STAT_H=1",
+    "-DHAVE_SYS_TYPES_H=1",
+    "-DHAVE_TIMEGM=1",
+    "-DHAVE_UNISTD_H=1",
+]
+
+YARA_MODULE_OPTS = [
+    "-DDEX_MODULE",
+    "-DDOTNET_MODULE",
+    "-DHASH_MODULE",
+    "-DMACHO_MODULE",
+]
+
+YARA_COPTS = YARA_MODULE_OPTS + select({
+    "@bazel_tools//src/conditions:darwin": [
+        "-DUSE_MACH_PROC",
+        "-DHAVE_SCAN_PROC_IMPL=1",
+        "-DHAVE_STRLCAT=1",
+        "-DHAVE_STRLCPY=1",
+    ],
+    "@bazel_tools//src/conditions:freebsd": [
+        "-DUSE_FREEBSD_PROC",
+        "-DHAVE_SCAN_PROC_IMPL=1",
+        "-DHAVE_STRLCAT=1",
+        "-DHAVE_STRLCPY=1",
+    ],
+    "@bazel_tools//src/conditions:linux_aarch64": [
+        "-DUSE_LINUX_PROC",
+        "-DHAVE_SCAN_PROC_IMPL=1",
+    ],
+    "@bazel_tools//src/conditions:linux_x86_64": [
+        "-DUSE_LINUX_PROC",
+        "-DHAVE_SCAN_PROC_IMPL=1",
+    ],
+    "@bazel_tools//src/conditions:windows": [
+        "-DUSE_WINDOWS_PROC",
+        "-DHAVE_SCAN_PROC_IMPL=1",
+    ],
+    "//conditions:default": ["-DUSE_NO_PROC"],
+}) + [
+    # Additional include paths
+    "-Ilibyara",
+    "-Ilibyara/modules",
+] + YARA_CONFIG_OPTS
+
+# Just Yara's error codes. This is useful for sandboxing as it avoids pulling
+# in the whole library.
+cc_library(
+    name = "yara_errors",
+    hdrs = ["libyara/include/yara/error.h"],
+    copts = YARA_COPTS,
+    visibility = ["//visibility:public"],
+)
+
+# Yara library to be linked against.
+cc_library(
+    name = "libyara",
+    srcs = [
+        "libyara/ahocorasick.c",
+        "libyara/arena.c",
+        "libyara/atoms.c",
+        "libyara/bitmask.c",
+        "libyara/compiler.c",
+        "libyara/crypto.h",
+        "libyara/endian.c",
+        "libyara/exception.h",
+        "libyara/exec.c",
+        "libyara/exefiles.c",
+        "libyara/filemap.c",
+        "libyara/grammar.c",
+        "libyara/hash.c",
+        "libyara/hex_grammar.c",
+        "libyara/hex_grammar.h",
+        "libyara/hex_lexer.c",
+        "libyara/include/yara.h",
+        "libyara/include/yara/ahocorasick.h",
+        "libyara/include/yara/arena.h",
+        "libyara/include/yara/atoms.h",
+        "libyara/include/yara/bitmask.h",
+        "libyara/include/yara/compiler.h",
+        "libyara/include/yara/dex.h",
+        "libyara/include/yara/dotnet.h",
+        "libyara/include/yara/elf.h",
+        "libyara/include/yara/endian.h",
+        "libyara/include/yara/error.h",
+        "libyara/include/yara/exec.h",
+        "libyara/include/yara/exefiles.h",
+        "libyara/include/yara/filemap.h",
+        "libyara/include/yara/globals.h",
+        "libyara/include/yara/hash.h",
+        "libyara/include/yara/hex_lexer.h",
+        "libyara/include/yara/integers.h",
+        "libyara/include/yara/lexer.h",
+        "libyara/include/yara/libyara.h",
+        "libyara/include/yara/limits.h",
+        "libyara/include/yara/macho.h",
+        "libyara/include/yara/mem.h",
+        "libyara/include/yara/modules.h",
+        "libyara/include/yara/object.h",
+        "libyara/include/yara/parser.h",
+        "libyara/include/yara/pe.h",
+        "libyara/include/yara/pe_utils.h",
+        "libyara/include/yara/proc.h",
+        "libyara/include/yara/re.h",
+        "libyara/include/yara/re_lexer.h",
+        "libyara/include/yara/rules.h",
+        "libyara/include/yara/scan.h",
+        "libyara/include/yara/scanner.h",
+        "libyara/include/yara/sizedstr.h",
+        "libyara/include/yara/stack.h",
+        "libyara/include/yara/stopwatch.h",
+        "libyara/include/yara/stream.h",
+        "libyara/include/yara/strutils.h",
+        "libyara/include/yara/threading.h",
+        "libyara/include/yara/types.h",
+        "libyara/include/yara/utils.h",
+        "libyara/lexer.c",
+        "libyara/libyara.c",
+        "libyara/mem.c",
+        "libyara/modules.c",
+        #"libyara/modules/cuckoo.c",  # TODO(cblichmann): Add Jansson JSON depenency
+        "libyara/modules/dex.c",
+        #"libyara/modules/demo.c",    # Disabled
+        "libyara/modules/dotnet.c",
+        "libyara/modules/elf.c",
+        "libyara/modules/hash.c",
+        "libyara/modules/macho.c",
+        #"libyara/modules/magic.c",   # TODO(cblichmann): Add libmagic dependency
+        "libyara/modules/math.c",
+        "libyara/modules/pe.c",
+        "libyara/modules/pe_utils.c",
+        "libyara/modules/tests.c",
+        "libyara/modules/time.c",
+        "libyara/object.c",
+        "libyara/parser.c",
+        "libyara/proc.c",
+        "libyara/proc/freebsd.c",
+        "libyara/proc/linux.c",
+        "libyara/proc/mach.c",
+        "libyara/proc/none.c",
+        "libyara/proc/openbsd.c",
+        "libyara/proc/windows.c",
+        "libyara/re.c",
+        "libyara/re_grammar.c",
+        "libyara/re_grammar.h",
+        "libyara/re_lexer.c",
+        "libyara/rules.c",
+        "libyara/scan.c",
+        "libyara/scanner.c",
+        "libyara/sizedstr.c",
+        "libyara/stack.c",
+        "libyara/stopwatch.c",
+        "libyara/stream.c",
+        "libyara/strutils.c",
+        "libyara/threading.c",
+    ],
+    hdrs = [
+        "libyara/include/yara.h",
+        "libyara/include/yara/pe.h",
+        "libyara/include/yara/proc.h",
+        "libyara/include/yara/rules.h",
+    ],
+    copts = YARA_COPTS,
+    includes = ["libyara/include"],
+    textual_hdrs = [
+        "libyara/grammar.h",
+        "libyara/hex_grammar.y",
+        "libyara/include/yara/exefiles.h",
+        "libyara/include/yara/re_lexer.h",
+        "libyara/modules/module_list",
+        "libyara/modules/pe_utils.c",  # Included .c file
+        "libyara/re_grammar.y",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@boringssl//:crypto"],
+)
+
+# Code shared by the command-line tools.
+cc_library(
+    name = "cli_shared",
+    srcs = [
+        "args.c",
+        "threading.c",
+    ],
+    hdrs = [
+        "args.h",
+        "common.h",
+        "threading.h",
+    ],
+    copts = YARA_COPTS,
+    deps = [":libyara"],
+)
+
+# Yara command-line tool
+cc_binary(
+    name = "yara",
+    srcs = ["yara.c"],
+    copts = YARA_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cli_shared",
+        ":libyara",
+    ],
+)
+
+# The Yara compiler
+cc_binary(
+    name = "yarac",
+    srcs = ["yarac.c"],
+    copts = YARA_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cli_shared",
+        ":libyara",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,37 @@
+# Copyright (c) 2019. The YARA Authors. All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+# BoringSSL, see
+# https://boringssl.googlesource.com/boringssl/+/master/INCORPORATING.md#bazel
+git_repository(
+    name = "boringssl",
+    commit = "095d78b14f91cc9a910408eaae84a3bdafc54da9",  # 2019-06-05
+    remote = "https://boringssl.googlesource.com/boringssl",
+    shallow_since = "1559759280 +0000",
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,165 @@
+# Copyright (c) 2019. The YARA Authors. All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cc_library(
+    name = "blob",
+    hdrs = ["blob.h"],
+)
+
+cc_library(
+    name = "util",
+    srcs = ["util.c"],
+    textual_hdrs = ["util.h"],
+    deps = ["@//:libyara"],
+)
+
+cc_test(
+    name = "test_alignment",
+    srcs = ["test-alignment.c"],
+    deps = ["@//:libyara"],
+)
+
+cc_test(
+    name = "test_atoms",
+    srcs = ["test-atoms.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_rules",
+    srcs = ["test-rules.c"],
+    data = [
+        "data/baz.yar",
+        "data/foo.yar",
+        "data/include/bar.yar",
+        "data/xor.out",
+        "data/xornocase.out",
+        "data/xorwide.out",
+    ],
+    deps = [
+        ":blob",
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_pe",
+    srcs = ["test-pe.c"],
+    data = [
+        "data/079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885",
+        "data/tiny",
+        "data/tiny-idata-51ff",
+        "data/tiny-idata-5200",
+        "data/tiny-overlay",
+    ],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_elf",
+    srcs = ["test-elf.c"],
+    deps = [
+        ":blob",
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_api",
+    srcs = ["test-api.c"],
+    data = ["data/baz.yar"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_bitmask",
+    srcs = ["test-bitmask.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_math",
+    srcs = ["test-math.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_stack",
+    srcs = ["test-stack.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+# This test fails when running under ASAN
+cc_test(
+    name = "test_exception",
+    srcs = ["test-exception.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_macho",
+    srcs = ["test-macho.c"],
+    data = ["data/tiny-universal"],
+    deps = [
+        ":blob",
+        ":util",
+        "@//:libyara",
+    ],
+)
+
+cc_test(
+    name = "test_dex",
+    srcs = ["test-dex.c"],
+    deps = [
+        ":blob",
+        ":util",
+        "@//:libyara",
+    ],
+)


### PR DESCRIPTION
This will build Yara on Linux using BoringSSL, other platforms are currently untested.

A few of the modules are currently disabled in the build, namely Cuckoo and Magic. This is due to additional external dependencies (Jansson for JSON parsing and libmagic).

To build, install [Bazel](https://docs.bazel.build/versions/master/install.html) and simply run these commands from the top-level source directory:

```bash
bazel build ...
bazel test ...
```