### PR TITLE
Fix detection of libraries for OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ case $host_os in
             jemalloc_prefix= ;;
     openbsd*)
             CFLAGS="$CFLAGS -DUSE_OPENBSD_PROC"
+            CFLAGS="$CFLAGS -I/usr/local/include -L/usr/local/lib"
             posix=true
             proc_interface=openbsd
             jemalloc_prefix= ;;


### PR DESCRIPTION
OpenBSD installs jansson, libmagic etc into /usr/local, so add another CFLAGS to let configure know where to find them so the checks don't fail.