### PR TITLE
Add dependency on zlib when building with libmagic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,12 +119,14 @@ AC_ARG_ENABLE([magic],
   [AS_HELP_STRING([--enable-magic], [enable magic module])],
   [if test x$enableval = xyes; then
     build_magic_module=true
+    AC_CHECK_LIB(z, zlibVersion,,
+      AC_MSG_ERROR([please install zlib library]))
     AC_CHECK_HEADERS([magic.h],,
       AC_MSG_ERROR([please install libmagic library]))
     AC_CHECK_LIB(magic, magic_open,,
       AC_MSG_ERROR([please install libmagic library]))
     CFLAGS="$CFLAGS -DMAGIC_MODULE"
-    PC_LIBS_PRIVATE="$PC_LIBS_PRIVATE -lmagic"
+    PC_LIBS_PRIVATE="$PC_LIBS_PRIVATE -lmagic -lz"
   fi])
 
 AC_ARG_ENABLE([dotnet],


### PR DESCRIPTION
I ran into this when I was trying to compile yara with almost everything static so it can be portable among multiple Linux machines. Linking against static libmagic.a requires linking against zlib. Since zlib is dependency of libmagic, everyone who has installed libmagic will also have zlib.

I don't really know if this is the right way to solve it since I am not familiar with autotools whatsoever but I am open to any other (better) solutions.