### PR TITLE
Fix cc_library rule so yara builds when included via a bazel git_repository

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -213,7 +213,11 @@ cc_library(
         "libyara/include/yara/rules.h",
     ],
     copts = YARA_COPTS,
-    includes = ["libyara/include"],
+    includes = [
+        "libyara/modules",
+        "libyara/include",
+        "libyara",
+    ],
     textual_hdrs = [
         "libyara/grammar.h",
         "libyara/hex_grammar.y",


### PR DESCRIPTION
`bazel build :all` works fine to build yara in a clean workspace. But if another workspace tries to include the yara code as a remote git_repository, it doesn't build correctly. This change fixes that issue.  (Originally thought to be a bazel bug: https://github.com/bazelbuild/bazel/issues/8811)