### PR TITLE
Added parsing for PDB string in PE module

### DIFF
--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -452,9 +452,51 @@ typedef struct _IMAGE_RESOURCE_DIRECTORY {
     WORD  NumberOfIdEntries;
 } IMAGE_RESOURCE_DIRECTORY, *PIMAGE_RESOURCE_DIRECTORY;
 
+#define IMAGE_DEBUG_TYPE_UNKNOWN                         0
+#define IMAGE_DEBUG_TYPE_COFF                            1
+#define IMAGE_DEBUG_TYPE_CODEVIEW                        2
+#define IMAGE_DEBUG_TYPE_FPO                             3
+#define IMAGE_DEBUG_TYPE_MISC                            4
+#define IMAGE_DEBUG_TYPE_EXCEPTION                       5
+#define IMAGE_DEBUG_TYPE_FIXUP                           6
+#define IMAGE_DEBUG_TYPE_BORLAND                         9
+
+typedef struct _IMAGE_DEBUG_DIRECTORY {
+    DWORD Characteristics;
+    DWORD TimeDateStamp;
+    WORD  MajorVersion;
+    WORD  MinorVersion;
+    DWORD Type;
+    DWORD SizeOfData;
+    DWORD AddressOfRawData;
+    DWORD PointerToRawData;
+} IMAGE_DEBUG_DIRECTORY, *PIMAGE_DEBUG_DIRECTORY;
+
 #pragma pack(pop)
 
 #endif  // _WIN32
+
+#define CVINFO_PDB70_CVSIGNATURE                0x53445352 // "RSDS"
+#define CVINFO_PDB20_CVSIGNATURE                0x3031424e // "NB10"
+
+typedef struct _CV_HEADER {
+    DWORD dwSignature;
+    DWORD dwOffset;
+} CV_HEADER, *PCV_HEADER;
+
+typedef struct _CV_INFO_PDB20 {
+    CV_HEADER CvHeader;
+    DWORD dwSignature;
+    DWORD dwAge;
+    BYTE PdbFileName[1];
+} CV_INFO_PDB20, *PCV_INFO_PDB20;
+
+typedef struct _CV_INFO_PDB70 {
+    DWORD CvSignature;
+    DWORD Signature[4];
+    DWORD Age;
+    BYTE  PdbFileName[1];
+} CV_INFO_PDB70, *PCV_INFO_PDB70;
 
 typedef struct _VERSION_INFO {
     WORD   Length;

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -261,6 +261,91 @@ static void pe_parse_rich_signature(
   return;
 }
 
+static void pe_parse_debug_directory(
+    PE* pe)
+{
+  PIMAGE_DATA_DIRECTORY data_dir;
+  PIMAGE_DEBUG_DIRECTORY debug_dir;
+  int64_t offset;
+  int i, dcount;
+  size_t pdb_str_len;
+  
+  data_dir = pe_get_directory_entry(
+      pe, IMAGE_DIRECTORY_ENTRY_DEBUG);
+
+  if (data_dir == NULL)
+    return;
+
+  if (yr_le32toh(data_dir->Size) == 0)
+    return;
+
+  if (yr_le32toh(data_dir->Size) % sizeof(IMAGE_DEBUG_DIRECTORY) != 0)
+    return;
+
+  if (yr_le32toh(data_dir->VirtualAddress) == 0)
+    return;
+
+  offset = pe_rva_to_offset(pe, yr_le32toh(data_dir->VirtualAddress));
+
+  if (offset < 0)
+    return;
+
+  dcount = yr_le32toh(data_dir->Size) / sizeof(IMAGE_DEBUG_DIRECTORY);
+
+  for (i = 0; i < dcount; i++)
+  {
+    debug_dir = (PIMAGE_DEBUG_DIRECTORY) \
+        (pe->data + offset + i * sizeof(IMAGE_DEBUG_DIRECTORY));
+    
+    if (!struct_fits_in_pe(pe, debug_dir, IMAGE_DEBUG_DIRECTORY))
+      break;
+  
+    if (yr_le32toh(debug_dir->Type) != IMAGE_DEBUG_TYPE_CODEVIEW)
+      continue;
+    
+    if (yr_le32toh(debug_dir->AddressOfRawData) == 0)
+      continue;
+    
+    PCV_HEADER cv_hdr = (PCV_HEADER) \
+        (pe->data + pe_rva_to_offset(pe, yr_le32toh(debug_dir->AddressOfRawData)));
+    
+
+    if (yr_le32toh(cv_hdr->dwSignature) == CVINFO_PDB20_CVSIGNATURE)
+    {
+      PCV_INFO_PDB20 pdb20 = (PCV_INFO_PDB20)cv_hdr;
+      
+      if (!struct_fits_in_pe(pe, pdb20, CV_INFO_PDB20))
+        break;
+      
+      pdb_str_len = strlen((char *)(pdb20->PdbFileName));
+      
+      if (pdb_str_len && pdb_str_len < MAX_PATH)
+      {
+        set_sized_string((char *)(pdb20->PdbFileName), pdb_str_len,
+            pe->object, "pdb");
+        break;
+      }
+    }
+    else if (yr_le32toh(cv_hdr->dwSignature) == CVINFO_PDB70_CVSIGNATURE)
+    {
+      PCV_INFO_PDB70 pdb70 = (PCV_INFO_PDB70)cv_hdr;
+      
+      if (!struct_fits_in_pe(pe, pdb70, CV_INFO_PDB70))
+        break;
+      
+      pdb_str_len = strlen((char *)(pdb70->PdbFileName));
+      
+      if (pdb_str_len && pdb_str_len < MAX_PATH)
+      {
+        set_sized_string((char *)(pdb70->PdbFileName), pdb_str_len,
+            pe->object, "pdb");
+        break;
+      }
+    }
+  }
+  
+  return;
+}
 
 // Return a pointer to the resource directory string or NULL.
 // The callback function will parse this and call set_sized_string().
@@ -2603,6 +2688,7 @@ begin_declarations;
   end_struct_array("resources");
 
   declare_integer("number_of_resources");
+  declare_string("pdb");
 
   #if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
   begin_struct_array("signatures");
@@ -3016,7 +3102,8 @@ int module_load(
 
         pe_parse_header(pe, block->base, context->flags);
         pe_parse_rich_signature(pe, block->base);
-
+        pe_parse_debug_directory(pe);
+        
         #if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
         pe_parse_certificates(pe);
         #endif

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -321,7 +321,8 @@ static void pe_parse_debug_directory(
       if (!struct_fits_in_pe(pe, pdb20, CV_INFO_PDB20))
         break;
       
-      pdb_str_len = strnlen((char *)(pdb20->PdbFileName), MAX_PATH * sizeof(char));
+      pdb_str_len = strnlen((char *)(pdb20->PdbFileName),
+                  yr_min(available_space(pe, pdb20->PdbFileName), MAX_PATH * sizeof(char)));
       
       if (pdb_str_len && pdb_str_len < MAX_PATH)
       {
@@ -337,7 +338,8 @@ static void pe_parse_debug_directory(
       if (!struct_fits_in_pe(pe, pdb70, CV_INFO_PDB70))
         break;
       
-      pdb_str_len = strnlen((char *)(pdb70->PdbFileName), MAX_PATH * sizeof(char));
+      pdb_str_len = strnlen((char *)(pdb70->PdbFileName),
+                  yr_min(available_space(pe, pdb70->PdbFileName), MAX_PATH * sizeof(char)));
       
       if (pdb_str_len && pdb_str_len < MAX_PATH)
       {

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -199,6 +199,14 @@ int main(int argc, char** argv)
       }",
       "tests/data/tiny");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.pdb == \"D:\\\\workspace\\\\2018_R9_RelBld\\\\target\\\\checkout\\\\custprof\\\\Release\\\\custprof.pdb\" \
+      }",
+       "tests/data/079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
   assert_false_rule_file(
       "import \"pe\" \
       rule test { \


### PR DESCRIPTION
Implements this feature request: https://github.com/VirusTotal/yara/issues/736

Now it's possible to do following rules:
```
import "pe"

rule pdb_rule
{
   condition:
     pe.pdb contains "substring"
}
```