### PR TITLE
Fix chained strings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,8 @@ test_math_SOURCES = tests/test-math.c tests/util.c
 test_math_LDADD = libyara/.libs/libyara.a
 test_stack_SOURCES = tests/test-stack.c
 test_stack_LDADD = libyara/.libs/libyara.a
+test_re_split_SOURCES = tests/test-re-split.c
+test_re_split_LDADD = libyara/.libs/libyara.a
 
 TESTS = $(check_PROGRAMS)
 TESTS_ENVIRONMENT = TOP_SRCDIR=$(top_srcdir)
@@ -59,7 +61,8 @@ check_PROGRAMS = test-alignment \
   test-version \
   test-bitmask \
   test-math \
-  test-stack
+  test-stack \
+  test-re-split
 
 if POSIX
 # The -fsanitize=address option makes test-exception fail. Include the test

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -506,7 +506,7 @@ int _yr_atoms_trim(
   if (atom->length == 0)
     return 0;
 
-  // At this point the actual atom goes from i to i + atom->length and the
+  // The trimmed atom goes from trim_left to trim_left + atom->length and the
   // first and last byte in the atom are known (mask == 0xFF). Now count the
   // number of known and unknown bytes in the atom (mask == 0xFF and
   // mask == 0x00 respectively).
@@ -520,10 +520,10 @@ int _yr_atoms_trim(
   }
 
   // If the number of unknown bytes is >= than the number of known bytes
-  // it doesn't make sense the to use this atom, so we use the a single byte
-  // atom with the first known byte. If YR_MAX_ATOM_LENGTH == 4 this happens
+  // it doesn't make sense the to use this atom, so we use a single byte atpm
+  // containing the first known byte. If YR_MAX_ATOM_LENGTH == 4 this happens
   // only when the atom is like { XX ?? ?? YY }, so using the first known
-  // atom is good enough. For larger values of YR_MAX_ATOM_LENGTH this is not
+  // byte is good enough. For larger values of YR_MAX_ATOM_LENGTH this is not
   // the most efficient solution, as better atoms could be choosen. For
   // example, in { XX ?? ?? ?? YY ZZ } the best atom is { YY ZZ } not { XX }.
   // But let's keep it like this for simplicity.
@@ -980,8 +980,9 @@ static int _yr_atoms_extract_from_re(
 
   FAIL_ON_ERROR(yr_stack_create(1024, sizeof(si), &stack));
 
-  // This first item pushed in the stack is the last one to be poped out, its
-  // sole purpose is forcing that any pending
+  // This first item pushed in the stack is the last one to be poped out, the
+  // sole purpose of this item is forcing that any pending leaf is appended to
+  // current_appending_node during the last iteration of the loop.
   si.re_node = NULL;
   si.new_appending_node = appending_node;
 

--- a/libyara/include/yara/re.h
+++ b/libyara/include/yara/re.h
@@ -125,7 +125,6 @@ int yr_re_ast_contains_dot_star(
 
 int yr_re_ast_split_at_chaining_point(
     RE_AST* re_ast,
-    RE_AST** result_re_ast,
     RE_AST** remainder_re_ast,
     int32_t* min_gap,
     int32_t* max_gap);

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -469,9 +469,10 @@ static int _yr_scan_verify_chained_string_match(
         match = next_match;
       }
     }
-    else // it's a part of a chain, but not the tail.
+    else // It's a part of a chain, but not the tail.
     {
       if (matching_string->matches[tidx].count == 0 &&
+          matching_string->private_matches[tidx].count == 0 &&
           matching_string->unconfirmed_matches[tidx].count == 0)
       {
         // If this is the first match for the string, put the string in the

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -318,6 +318,20 @@ static void _yr_scan_remove_match_from_list(
   match->prev = NULL;
 }
 
+//
+// _yr_scan_verify_chained_string_match
+//
+// Given a string that is part of a string chain and is matching at some
+// point in the scanned data, this function determines if the whole string
+// chain is also matching. For example, if the string S was splitted and
+// converted in a chain S1 <- S2 <- S3 (see yr_re_ast_split_at_chaining_point),
+// and a match for S3 was found, this functions finds out if there are matches
+// for S1 and S2 that together with the match found for S3 conform a match for
+// the whole S.
+//
+// Notice that this function operates in a non-greedy fashion. Matches found
+// for S will be the shortest possible ones.
+//
 
 static int _yr_scan_verify_chained_string_match(
     YR_STRING* matching_string,
@@ -350,10 +364,10 @@ static int _yr_scan_verify_chained_string_match(
   else
   {
     // If some unconfirmed match exists, the lowest possible offset where the
-    // string can match is the offset of the first string in the list of
-    // unconfirmed matches. Unconfirmed matches are sorted in ascending offset
-    // order. If no unconfirmed match exists, the lowest possible offset is
-    // the offset of the current match.
+    // whole string chain can match is the offset of the first string in the
+    // list of unconfirmed matches. Unconfirmed matches are sorted in ascending
+    // offset order. If no unconfirmed match exists, the lowest possible offset
+    // is the offset of the current match.
     if (matching_string->unconfirmed_matches[tidx].head != NULL)
       lowest_offset = matching_string->unconfirmed_matches[tidx].head->offset;
     else

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -367,6 +367,9 @@ static int _yr_scan_verify_chained_string_match(
 
     while (match != NULL)
     {
+      // Store match->next so that we can use it later for advancing in the
+      // list, if _yr_scan_remove_match_from_list is called, match->next is
+      // set to NULL, that's why we store its current value before that happens.
       next_match = match->next;
 
       // The unconfirmed match starts at match->offset and finishes at
@@ -406,9 +409,15 @@ static int _yr_scan_verify_chained_string_match(
 
     if (STRING_IS_CHAIN_TAIL(matching_string))
     {
-      // Chain tails must be chained to some other string
+      // The matching string is the tail of the string chain. It must be
+      // chained to some other string.
       assert(matching_string->chained_to != NULL);
 
+      // Iterate over the list of unconfirmed matches of the preceeding string
+      // in the chain and update the chain_length field for each of them. This
+      // is a recursive operation that will update the chain_length field for
+      // every unconfirmed match in all the strings in the chain up to the head
+      // of the chain.
       match = matching_string->chained_to->unconfirmed_matches[tidx].head;
 
       while (match != NULL)
@@ -434,10 +443,13 @@ static int _yr_scan_verify_chained_string_match(
         string = string->chained_to;
       }
 
-      // "string" points now to the head of the strings chain
-
+      // "string" points now to the head of the strings chain.
       match = string->unconfirmed_matches[tidx].head;
 
+      // Iterate over the list of unconfirmed matches of the head of the chain,
+      // and move to the list of confirmed matches those with a chain_length
+      // equal to full_chain_length, which means that the whole chain has been
+      // confirmed to match.
       while (match != NULL)
       {
         next_match = match->next;
@@ -471,12 +483,12 @@ static int _yr_scan_verify_chained_string_match(
     }
     else // It's a part of a chain, but not the tail.
     {
+      // If this is the first match for the string, put the string in the
+      // list of strings whose flags needs to be cleared after the scan.
       if (matching_string->matches[tidx].count == 0 &&
           matching_string->private_matches[tidx].count == 0 &&
           matching_string->unconfirmed_matches[tidx].count == 0)
       {
-        // If this is the first match for the string, put the string in the
-        // list of strings whose flags needs to be cleared after the scan.
         FAIL_ON_ERROR(yr_arena_write_data(
             context->matching_strings_arena,
             &matching_string,
@@ -489,6 +501,15 @@ static int _yr_scan_verify_chained_string_match(
           sizeof(YR_MATCH),
           (void**) &new_match));
 
+      new_match->base = match_base;
+      new_match->offset = match_offset;
+      new_match->match_length = match_length;
+      new_match->chain_length = 0;
+      new_match->prev = NULL;
+      new_match->next = NULL;
+
+      // A copy of the matching data is written to the matches_arena, the
+      // amount of data copies is limited by YR_CONFIG_MAX_MATCH_DATA.
       new_match->data_length = yr_min(match_length, max_match_data);
 
       if (new_match->data_length > 0)
@@ -504,13 +525,9 @@ static int _yr_scan_verify_chained_string_match(
         new_match->data = NULL;
       }
 
-      new_match->base = match_base;
-      new_match->offset = match_offset;
-      new_match->match_length = match_length;
-      new_match->chain_length = 0;
-      new_match->prev = NULL;
-      new_match->next = NULL;
-
+      // Add the match to the list of unconfirmed matches because the string
+      // is part of a chain but not its tail, so we can't be sure the this is
+      // an actual match until finding the remaining parts of the chain.
       FAIL_ON_ERROR(_yr_scan_add_match_to_list(
           new_match,
           &matching_string->unconfirmed_matches[tidx],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -163,3 +163,12 @@ cc_test(
         "@//:libyara",
     ],
 )
+
+cc_test(
+    name = "test_re_split",
+    srcs = ["test-re-split.c"],
+    deps = [
+        ":util",
+        "@//:libyara",
+    ],
+)

--- a/tests/test-re-split.c
+++ b/tests/test-re-split.c
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2019. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <yara.h>
+#include <stdio.h>
+#include "util.h"
+
+
+int main(int argc, char** argv)
+{
+  RE_AST* re_ast;
+  RE_AST* re_ast_remain;
+
+  RE_ERROR re_error;
+
+  int32_t min_gap;
+  int32_t max_gap;
+
+  yr_initialize();
+  yr_re_parse_hex(
+      "{ 01 02 03 04 [0-300] 05 06 07 08 [1-400] 09 0A 0B 0C }",
+      &re_ast, &re_error);
+
+  if (re_ast == NULL)
+    exit(EXIT_FAILURE);
+
+  yr_re_ast_split_at_chaining_point(
+      re_ast, &re_ast, &re_ast_remain, &min_gap, &max_gap);
+
+  if (re_ast == NULL || re_ast_remain == NULL)
+    exit(EXIT_FAILURE);
+
+  yr_re_ast_destroy(re_ast);
+  re_ast = re_ast_remain;
+
+  assert(min_gap == 0);
+  assert(max_gap == 300);
+
+  yr_re_ast_split_at_chaining_point(
+    re_ast, &re_ast, &re_ast_remain, &min_gap, &max_gap);
+
+  if (re_ast == NULL || re_ast_remain == NULL)
+    exit(EXIT_FAILURE);
+
+  assert(min_gap == 1);
+  assert(max_gap == 400);
+
+  yr_re_ast_destroy(re_ast);
+  yr_re_ast_destroy(re_ast_remain);
+}

--- a/tests/test-re-split.c
+++ b/tests/test-re-split.c
@@ -47,30 +47,35 @@ int main(int argc, char** argv)
       "{ 01 02 03 04 [0-300] 05 06 07 08 [1-400] 09 0A 0B 0C }",
       &re_ast, &re_error);
 
-  if (re_ast == NULL)
-    exit(EXIT_FAILURE);
+  assert(re_ast != NULL);
 
   yr_re_ast_split_at_chaining_point(
-      re_ast, &re_ast, &re_ast_remain, &min_gap, &max_gap);
+      re_ast, &re_ast_remain, &min_gap, &max_gap);
 
-  if (re_ast == NULL || re_ast_remain == NULL)
-    exit(EXIT_FAILURE);
+  assert(re_ast != NULL);
+  assert(re_ast_remain != NULL);
+  assert(min_gap == 0);
+  assert(max_gap == 300);
 
   yr_re_ast_destroy(re_ast);
   re_ast = re_ast_remain;
 
-  assert(min_gap == 0);
-  assert(max_gap == 300);
-
   yr_re_ast_split_at_chaining_point(
-    re_ast, &re_ast, &re_ast_remain, &min_gap, &max_gap);
+      re_ast, &re_ast_remain, &min_gap, &max_gap);
 
-  if (re_ast == NULL || re_ast_remain == NULL)
-    exit(EXIT_FAILURE);
-
+  assert(re_ast != NULL);
+  assert(re_ast_remain != NULL);
   assert(min_gap == 1);
   assert(max_gap == 400);
 
   yr_re_ast_destroy(re_ast);
-  yr_re_ast_destroy(re_ast_remain);
+  re_ast = re_ast_remain;
+
+  yr_re_ast_split_at_chaining_point(
+      re_ast, &re_ast_remain, &min_gap, &max_gap);
+
+  assert(re_ast != NULL);
+  assert(re_ast_remain == NULL);
+
+  yr_re_ast_destroy(re_ast);
 }

--- a/tests/util.c
+++ b/tests/util.c
@@ -328,10 +328,10 @@ void assert_re_atoms(
   yr_re_parse(re, &re_ast, &re_error);
   exit_code = _assert_atoms(re_ast, expected_atom_count, expected_atoms);
 
-  if(re_ast != NULL)
+  if (re_ast != NULL)
     yr_re_ast_destroy(re_ast);
 
-  if(exit_code != EXIT_SUCCESS)
+  if (exit_code != EXIT_SUCCESS)
     exit(exit_code);
 }
 
@@ -349,9 +349,9 @@ void assert_hex_atoms(
   yr_re_parse_hex(hex, &re_ast, &re_error);
   exit_code = _assert_atoms(re_ast, expected_atom_count, expected_atoms);
 
-  if(re_ast != NULL)
+  if (re_ast != NULL)
     yr_re_ast_destroy(re_ast);
 
-  if(exit_code != EXIT_SUCCESS)
+  if (exit_code != EXIT_SUCCESS)
     exit(exit_code);
 }


### PR DESCRIPTION
The function yr_re_ast_split_at_chaining_point was not splitting correctly regexps and hex strings that contained more than one large jump (a.k.a gap). For example, { 01 02 03 [0-1000] 04 05 06 [500-2000] 07 08 09 } was not splitted in three parts as expected, but only in two parts: { 01 02 03 } and { 04 05 06 [500-2000] 07 08 09 } . This didn't affected the correctness of the matches, but it caused ERROR_TOO_MANY_RE_FIBERS in some cases while trying to match { 04 05 06 [500-2000] 07 08 09 } because of the large jump in the pattern. The occurrence of the error depended on the data being scanned.

This PR fixes the aforementioned issue, improves the documentation of related functions and simplifies some portions of the code.