### PR TITLE
Allow include files parallel read access instead of denying all RW operations.

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -84,7 +84,7 @@ const char* _yr_compiler_default_include_callback(
   int fd = -1;
 
   #if defined(_MSC_VER)
-  _sopen_s(&fd, include_name, _O_RDONLY | _O_BINARY, _SH_DENYRW, _S_IREAD);
+  _sopen_s(&fd, include_name, _O_RDONLY | _O_BINARY, _SH_DENYWR, _S_IREAD);
   #elif defined(_WIN32) || defined(__CYGWIN__)
   fd = open(include_name, O_RDONLY | O_BINARY);
   #else


### PR DESCRIPTION
Hi,

while I was experimenting with parallel yara compilation of `.yar` files, I encountered an error where if a multiple files share similar includes it would not compile those files and throw an exception.

Currently `_yr_compiler_default_include_callback` opens files exclusively which forbids any writes and even _reads_ from those files. I think it makes more sense to restrict only writing of those files and let read only access succeed. This would allow parallel execution of yara.