### PR TITLE
Update command line example

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -165,7 +165,7 @@ Here you have some examples:
 
 * Scan all files in the */foo* directory and its subdirectories::
 
-    yara -r /foo
+    yara /foo/bar/rules -r /foo
 
 * Defines three external variables *mybool*, *myint* and *mystring*::
 


### PR DESCRIPTION
Changed `yara -r /foo` to `yara /foo/bar/rules -r /foo`.
I understand that it's only an example, but I think that it's clearer when it's a valid one.