### PR TITLE
Make YR_STOPWATCH to have the same size, independently of HAVE_CLOCK_GETTIME being true or not.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
       install: |
         sudo apt-get update
-        sudo apt-get install -y autoconf automake libtool libjansson-dev libmagic-dev libssl-de
+        sudo apt-get install -y autoconf automake libtool libjansson-dev libmagic-dev libssl-dev
 
     # Build for 64-bit Linux with profiling enabled
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 
 matrix:
   include:
+
+    # Build for 64-bit Linux with profiling enabled
     - os: linux
       dist: trusty
       sudo: required
@@ -12,7 +14,18 @@ matrix:
       before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
       install: |
         sudo apt-get update
+        sudo apt-get install -y autoconf automake libtool libjansson-dev libmagic-dev libssl-de
+
+    # Build for 64-bit Linux with profiling enabled
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: CONFIGFLAGS="CFLAGS=-m64 --enable-cuckoo --enable-magic --enable-address-sanitizer --enable-profiling"
+      install: |
+        sudo apt-get update
         sudo apt-get install -y autoconf automake libtool libjansson-dev libmagic-dev libssl-dev
+
+    # Build for 32-bit Linux
     - os: linux
       dist: trusty
       sudo: required
@@ -23,6 +36,8 @@ matrix:
         sudo apt-get remove postgresql-9.3
         sudo apt-get upgrade -y gcc
         sudo apt-get install -y gcc-multilib autoconf automake libtool libjansson-dev:i386 libmagic-dev:i386 libssl-dev:i386
+
+    # Build for 64-bit Window using MinGW cross-compiler
     - os: linux
       dist: trusty
       sudo: required
@@ -30,6 +45,8 @@ matrix:
       install: |
         sudo apt-get update
         sudo apt-get install -y gcc-mingw-w64 autoconf automake libtool
+
+    # Build for 64-bit Window using MinGW cross-compiler
     - os: linux
       dist: trusty
       sudo: required
@@ -37,6 +54,8 @@ matrix:
       install: |
         sudo apt-get update
         sudo apt-get install -y gcc-mingw-w64 autoconf automake libtool
+
+    # Build for 64-bit Linux using Bazel instead of make.
     - os: linux
       dist: trusty
       install: |
@@ -44,6 +63,8 @@ matrix:
          sudo dpkg -i bazel_0.29.0-linux-x86_64.deb
       before_script: bazel info
       script: bazel test //tests/...
+
+    # Build for OS X
     - os: osx
       osx_image: xcode7.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,9 @@ env:
     - secure: "JWobvJ94pWt/xVciQURkNFS3I+gyu2IyZPKYEs6HDlHrpHs4BoVDZeRjmgx0s6aDeQjKJHowGDu17IlbnCkKzXrZErEJkA+Oc/d0SwgXKiUU9WYiaGBJjJUoYZw66QIEuGGKkF4uQ7EIcW/vN7wzrCDyAiPeOPUjVP4Tc2XRzmkSfakfmf9cE5nqT84DPUYiRegM7iepMrZi9kEaAoboBuETT+6eUKdERRadM0QNjZmCYMEMjtFj3lE51Ey2stGqZdKJvJN0FUmxGoaXCFFAsNmZPnFeDkqTf0a+MzxG2m4nnIXyNC/nT5XLItKHog4KROHb4tUpCZJ4iJhcw3loWMCtkZqB2fq2PaOkKk2zxPr3HLCn7ltmOzReBEDjEg68UqWydRW5534JGosbcA9IfshS1VqnZLgGwQHieXNeqhJUumt1DpON7AQEiEzbzAk0y2VcPlDPuCt9QS1k+zPMZLzbwgvs1ZOH39oFESW+iEDdzZjbhyC3J6azTHFcnA7r5SsYe1pzcSUaYtS1ehhb0lU/442JSHw2j00Nv9qFycYNvDrRNQNBxLziVustT0WJoVdFlkKy16iu1tUYOVXKgmMfqUDINfU6zRz3DskVuB9MZzq/4cMdK4jMRIDNZWvye1BzM7o/PiJoNaQc/6iav2RD+5YV46bBr60TqnYyjlM="
 
 addons:
+  apt:
+    packages:
+      - ca-certificates
   coverity_scan:
     project:
       name: "plusvic/yara"

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -55,7 +55,7 @@ typedef struct _YR_STOPWATCH
 
 } YR_STOPWATCH;
 
-#elif
+#else
 
 #include <sys/time.h>
 

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -55,21 +55,16 @@ typedef struct _YR_STOPWATCH
 
 } YR_STOPWATCH;
 
-#elif defined(HAVE_CLOCK_GETTIME)
-
-typedef struct _YR_STOPWATCH
-{
-  struct timespec ts_start;
-
-} YR_STOPWATCH;
-
-#else
+#elif
 
 #include <sys/time.h>
 
 typedef struct _YR_STOPWATCH
 {
-  struct timeval tv_start;
+  union {
+    struct timeval tv_start;
+    struct timespec ts_start;
+  };
 
 } YR_STOPWATCH;
 


### PR DESCRIPTION
No matter the value for HAVE_CLOCK_GETTIME the YR_STOPWATCH structure now have the same size in Linux, and users of the library don't  need to provide the right value for HAVE_CLOCK_GETTIME while building their programs.