### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -18,7 +18,7 @@ You can download and install YARA using the `vcpkg <https://github.com/Microsoft
     ./vcpkg integrate install
     vcpkg install yara
 
-YARA is kept up to date by Microsoft team members and community contributors. If the version of YARA in vcpkg is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
+The YARA port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
 
 Download the source tarball and get prepared for compiling it::
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -10,10 +10,15 @@ find the latest release at https://github.com/VirusTotal/yara/releases.
 Compiling and installing YARA
 =============================
 
-If you are using the vcpkg dependency manager (https://github.com/Microsoft/vcpkg/) you can download and install YARA with a single command:
-```
-vcpkg install yara
-```
+You can download and install YARA using the `vcpkg <https://github.com/Microsoft/vcpkg/>`_ dependency manager::
+
+    git clone https://github.com/microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap.sh
+    ./vcpkg integrate install
+    vcpkg install yara
+
+If the version of YARA in vcpkg is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository so that Microsoft team members and community contributors can update it.
 
 Download the source tarball and get prepared for compiling it::
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -10,6 +10,11 @@ find the latest release at https://github.com/VirusTotal/yara/releases.
 Compiling and installing YARA
 =============================
 
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install YARA with a single command:
+```
+vcpkg install yara
+```
+
 Download the source tarball and get prepared for compiling it::
 
     tar -zxf yara-3.10.0.tar.gz

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -10,7 +10,7 @@ find the latest release at https://github.com/VirusTotal/yara/releases.
 Compiling and installing YARA
 =============================
 
-If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install YARA with a single command:
+If you are using the vcpkg dependency manager (https://github.com/Microsoft/vcpkg/) you can download and install YARA with a single command:
 ```
 vcpkg install yara
 ```

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -14,11 +14,11 @@ You can download and install YARA using the `vcpkg <https://github.com/Microsoft
 
     git clone https://github.com/microsoft/vcpkg.git
     cd vcpkg
-    ./bootstrap.sh
+    ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
     vcpkg install yara
 
-If the version of YARA in vcpkg is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository so that Microsoft team members and community contributors can update it.
+YARA is kept up to date by Microsoft team members and community contributors. If the version of YARA in vcpkg is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
 
 Download the source tarball and get prepared for compiling it::
 


### PR DESCRIPTION
YARA is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build YARA and include it into their projects