### PR TITLE
Fix undefined line numbers in yr_lex_parse_rules_fd.

### DIFF
--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -3675,6 +3675,7 @@ int yr_lex_parse_rules_fd(
 
   yyset_extra(compiler, yyscanner);
   yy_scan_bytes((const char*) buffer, (int) file_size, yyscanner);
+  yyset_lineno(1, yyscanner);
   yyparse(yyscanner, compiler);
   yylex_destroy(yyscanner);
 

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -956,6 +956,7 @@ int yr_lex_parse_rules_fd(
 
   yyset_extra(compiler, yyscanner);
   yy_scan_bytes((const char*) buffer, (int) file_size, yyscanner);
+  yyset_lineno(1, yyscanner);
   yyparse(yyscanner, compiler);
   yylex_destroy(yyscanner);
 


### PR DESCRIPTION
Initializing lexer starting line number to 1 in yr_lex_parse_rules_fd. If uninitialized, bug would manifest itself when e.g. syntax error occurs and wrong line number (random memory) is passed to the user.