### PR TITLE
Fix .NET parser for big-endian architectures

### DIFF
--- a/libyara/modules/dotnet.c
+++ b/libyara/modules/dotnet.c
@@ -92,17 +92,17 @@ void dotnet_parse_guid(
   char guid[37];
   int i = 0;
 
-  const uint8_t* guid_offset = pe->data + metadata_root + guid_header->Offset;
-  DWORD guid_size = guid_header->Size;
+  const uint8_t* guid_offset = pe->data + metadata_root + yr_le32toh(guid_header->Offset);
+  DWORD guid_size = yr_le32toh(guid_header->Size);
 
   // Parse GUIDs if we have them.
   // GUIDs are 16 bytes each.
   while (guid_size >= 16 && fits_in_pe(pe, guid_offset, 16))
   {
     sprintf(guid, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-        *(uint32_t*) guid_offset,
-        *(uint16_t*) (guid_offset + 4),
-        *(uint16_t*) (guid_offset + 6),
+        yr_le32toh(*(uint32_t*) guid_offset),
+        yr_le16toh(*(uint16_t*) (guid_offset + 4)),
+        yr_le16toh(*(uint16_t*) (guid_offset + 6)),
         *(guid_offset + 8),
         *(guid_offset + 9),
         *(guid_offset + 10),
@@ -203,12 +203,14 @@ void dotnet_parse_us(
   BLOB_PARSE_RESULT blob_result;
   int i = 0;
 
-  const uint8_t* offset = pe->data + metadata_root + us_header->Offset;
-  const uint8_t* end_of_header = offset + us_header->Size;
+  const uint32_t ush_sz = yr_le32toh(us_header->Size);
+
+  const uint8_t* offset = pe->data + metadata_root + yr_le32toh(us_header->Offset);
+  const uint8_t* end_of_header = offset + ush_sz;
 
   // Make sure the header size is larger than 0 and its end is not past the
   // end of PE.
-  if (us_header->Size == 0 || !fits_in_pe(pe, offset, us_header->Size))
+  if (ush_sz == 0 || !fits_in_pe(pe, offset, ush_sz))
     return;
 
   // The first entry MUST be single NULL byte.
@@ -285,9 +287,9 @@ STREAMS dotnet_parse_stream_headers(
     set_string(stream_name,
         pe->object, "streams[%i].name", i);
     // Offset is relative to metadata_root.
-    set_integer(metadata_root + stream_header->Offset,
+    set_integer(metadata_root + yr_le32toh(stream_header->Offset),
         pe->object, "streams[%i].offset", i);
-    set_integer(stream_header->Size,
+    set_integer(yr_le32toh(stream_header->Size),
         pe->object, "streams[%i].size", i);
 
     // Store necessary bits to parse these later. Not all tables will be
@@ -412,22 +414,22 @@ void dotnet_parse_tilde_2(
   // Should use this technique:
   // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
   for (i = 0; i < 64; i++)
-    valid_rows += ((tilde_header->Valid >> i) & 0x01);
+    valid_rows += ((yr_le64toh(tilde_header->Valid) >> i) & 0x01);
 
   row_offset = (uint32_t*) (tilde_header + 1);
   table_offset = (uint8_t*) row_offset;
   table_offset += sizeof(uint32_t) * valid_rows;
 
 #define DOTNET_STRING_INDEX(Name) \
-  index_sizes.string == 2 ? Name.Name_Short : Name.Name_Long
+  index_sizes.string == 2 ? yr_le16toh(Name.Name_Short) : yr_le32toh(Name.Name_Long)
 
-  string_offset = pe->data + metadata_root + streams->string->Offset;
+  string_offset = pe->data + metadata_root + yr_le32toh(streams->string->Offset);
 
   // Now walk again this time parsing out what we care about.
   for (bit_check = 0; bit_check < 64; bit_check++)
   {
     // If the Valid bit is not set for this table, skip it...
-    if (!((tilde_header->Valid >> bit_check) & 0x01))
+    if (!((yr_le64toh(tilde_header->Valid) >> bit_check) & 0x01))
       continue;
 
     // Make sure table_offset doesn't go crazy by inserting a large value
@@ -436,7 +438,7 @@ void dotnet_parse_tilde_2(
     if (!fits_in_pe(pe, table_offset, 1))
       return;
 
-    num_rows = *(row_offset + matched_bits);
+    num_rows = yr_le32toh(*(row_offset + matched_bits));
 
     // Those tables which exist, but that we don't care about must be
     // skipped.
@@ -467,10 +469,10 @@ void dotnet_parse_tilde_2(
 
       case BIT_TYPEREF:
         row_count = max_rows(4,
-            rows.module,
-            rows.moduleref,
-            rows.assemblyref,
-            rows.typeref);
+            yr_le32toh(rows.module),
+            yr_le32toh(rows.moduleref),
+            yr_le32toh(rows.assemblyref),
+            yr_le32toh(rows.typeref));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -485,9 +487,9 @@ void dotnet_parse_tilde_2(
 
       case BIT_TYPEDEF:
         row_count = max_rows(3,
-            rows.typedef_,
-            rows.typeref,
-            rows.typespec);
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typespec));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -528,9 +530,9 @@ void dotnet_parse_tilde_2(
 
       case BIT_INTERFACEIMPL:
         row_count = max_rows(3,
-            rows.typedef_,
-            rows.typeref,
-            rows.typespec);
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typespec));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -542,10 +544,10 @@ void dotnet_parse_tilde_2(
 
       case BIT_MEMBERREF:
         row_count = max_rows(4,
-            rows.methoddef,
-            rows.moduleref,
-            rows.typeref,
-            rows.typespec);
+            yr_le32toh(rows.methoddef),
+            yr_le32toh(rows.moduleref),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typespec));
 
         if (row_count > (0xFFFF >> 0x03))
           index_size = 4;
@@ -559,7 +561,10 @@ void dotnet_parse_tilde_2(
         break;
 
       case BIT_CONSTANT:
-        row_count = max_rows(3, rows.param, rows.field, rows.property);
+        row_count = max_rows(3,
+            yr_le32toh(rows.param),
+            yr_le32toh(rows.field),
+            yr_le32toh(rows.property));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -580,7 +585,7 @@ void dotnet_parse_tilde_2(
           constant_table = (PCONSTANT_TABLE) row_ptr;
 
           // Only look for constants of type string.
-          if (constant_table->Type != ELEMENT_TYPE_STRING)
+          if (yr_le32toh(constant_table->Type) != ELEMENT_TYPE_STRING)
           {
             row_ptr += row_size;
             continue;
@@ -599,7 +604,7 @@ void dotnet_parse_tilde_2(
           // is valid (non-null and within range).
           blob_offset = \
               pe->data + metadata_root +
-              streams->blob->Offset + blob_index;
+              yr_le32toh(streams->blob->Offset) + blob_index;
 
           blob_result = dotnet_parse_blob_entry(pe, blob_offset);
 
@@ -637,27 +642,27 @@ void dotnet_parse_tilde_2(
       case BIT_CUSTOMATTRIBUTE:
         // index_size is size of the parent column.
         row_count = max_rows(21,
-            rows.methoddef,
-            rows.field,
-            rows.typeref,
-            rows.typedef_,
-            rows.param,
-            rows.interfaceimpl,
-            rows.memberref,
-            rows.module,
-            rows.property,
-            rows.event,
-            rows.standalonesig,
-            rows.moduleref,
-            rows.typespec,
-            rows.assembly,
-            rows.assemblyref,
-            rows.file,
-            rows.exportedtype,
-            rows.manifestresource,
-            rows.genericparam,
-            rows.genericparamconstraint,
-            rows.methodspec);
+            yr_le32toh(rows.methoddef),
+            yr_le32toh(rows.field),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.param),
+            yr_le32toh(rows.interfaceimpl),
+            yr_le32toh(rows.memberref),
+            yr_le32toh(rows.module),
+            yr_le32toh(rows.property),
+            yr_le32toh(rows.event),
+            yr_le32toh(rows.standalonesig),
+            yr_le32toh(rows.moduleref),
+            yr_le32toh(rows.typespec),
+            yr_le32toh(rows.assembly),
+            yr_le32toh(rows.assemblyref),
+            yr_le32toh(rows.file),
+            yr_le32toh(rows.exportedtype),
+            yr_le32toh(rows.manifestresource),
+            yr_le32toh(rows.genericparam),
+            yr_le32toh(rows.genericparamconstraint),
+            yr_le32toh(rows.methodspec));
 
         if (row_count > (0xFFFF >> 0x05))
           index_size = 4;
@@ -666,8 +671,8 @@ void dotnet_parse_tilde_2(
 
         // index_size2 is size of the type column.
         row_count = max_rows(2,
-            rows.methoddef,
-            rows.memberref);
+            yr_le32toh(rows.methoddef),
+            yr_le32toh(rows.memberref));
 
         if (row_count > (0xFFFF >> 0x03))
           index_size2 = 4;
@@ -789,10 +794,10 @@ void dotnet_parse_tilde_2(
             // Skip over the ResolutionScope and check the Name field,
             // which is an index into the Strings heap.
             row_count = max_rows(4,
-                rows.module,
-                rows.moduleref,
-                rows.assemblyref,
-                rows.typeref);
+                yr_le32toh(rows.module),
+                yr_le32toh(rows.moduleref),
+                yr_le32toh(rows.assemblyref),
+                yr_le32toh(rows.typeref));
 
             if (row_count > (0xFFFF >> 0x02))
               typeref_row += 4;
@@ -829,7 +834,7 @@ void dotnet_parse_tilde_2(
             // Everything checks out. Make sure the index into the blob field
             // is valid (non-null and within range).
             blob_offset = \
-                pe->data + metadata_root + streams->blob->Offset + blob_index;
+                pe->data + metadata_root + yr_le32toh(streams->blob->Offset) + blob_index;
 
             // If index into blob is 0 or past the end of the blob stream, skip
             // it. We don't know the size of the blob entry yet because that is
@@ -897,8 +902,8 @@ void dotnet_parse_tilde_2(
 
       case BIT_FIELDMARSHAL:
         row_count = max_rows(2,
-            rows.field,
-            rows.param);
+            yr_le32toh(rows.field),
+            yr_le32toh(rows.param));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -910,9 +915,9 @@ void dotnet_parse_tilde_2(
 
       case BIT_DECLSECURITY:
         row_count = max_rows(3,
-            rows.typedef_,
-            rows.methoddef,
-            rows.assembly);
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.methoddef),
+            yr_le32toh(rows.assembly));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -945,9 +950,9 @@ void dotnet_parse_tilde_2(
 
       case BIT_EVENT:
         row_count = max_rows(3,
-            rows.typedef_,
-            rows.typeref,
-            rows.typespec);
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typespec));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -972,8 +977,8 @@ void dotnet_parse_tilde_2(
 
       case BIT_METHODSEMANTICS:
         row_count = max_rows(2,
-            rows.event,
-            rows.property);
+            yr_le32toh(rows.event),
+            yr_le32toh(rows.property));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -985,8 +990,8 @@ void dotnet_parse_tilde_2(
 
       case BIT_METHODIMPL:
         row_count = max_rows(2,
-            rows.methoddef,
-            rows.memberref);
+            yr_le32toh(rows.methoddef),
+            yr_le32toh(rows.memberref));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -1031,8 +1036,8 @@ void dotnet_parse_tilde_2(
 
       case BIT_IMPLMAP:
         row_count = max_rows(2,
-            rows.field,
-            rows.methoddef);
+            yr_le32toh(rows.field),
+            yr_le32toh(rows.methoddef));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -1090,13 +1095,13 @@ void dotnet_parse_tilde_2(
         row_ptr = table_offset;
         assembly_table = (PASSEMBLY_TABLE) table_offset;
 
-        set_integer(assembly_table->MajorVersion,
+        set_integer(yr_le16toh(assembly_table->MajorVersion),
             pe->object, "assembly.version.major");
-        set_integer(assembly_table->MinorVersion,
+        set_integer(yr_le16toh(assembly_table->MinorVersion),
             pe->object, "assembly.version.minor");
-        set_integer(assembly_table->BuildNumber,
+        set_integer(yr_le16toh(assembly_table->BuildNumber),
             pe->object, "assembly.version.build_number");
-        set_integer(assembly_table->RevisionNumber,
+        set_integer(yr_le16toh(assembly_table->RevisionNumber),
             pe->object, "assembly.version.revision_number");
 
         // Can't use assembly_table here because the PublicKey comes before
@@ -1106,16 +1111,16 @@ void dotnet_parse_tilde_2(
           name = pe_get_dotnet_string(
               pe,
               string_offset,
-              *(DWORD*) (
+              yr_le32toh(*(DWORD*) (
                   row_ptr + 4 + 2 + 2 + 2 + 2 + 4 +
-                  index_sizes.blob));
+                  index_sizes.blob)));
         else
           name = pe_get_dotnet_string(
               pe,
               string_offset,
-              *(WORD*) (
+              yr_le16toh(*(WORD*) (
                   row_ptr + 4 + 2 + 2 + 2 + 2 + 4 +
-                  index_sizes.blob));
+                  index_sizes.blob)));
 
         if (name != NULL)
           set_string(name, pe->object, "assembly.name");
@@ -1126,20 +1131,20 @@ void dotnet_parse_tilde_2(
           name = pe_get_dotnet_string(
               pe,
               string_offset,
-              *(DWORD*) (
+              yr_le32toh(*(DWORD*) (
                   row_ptr + 4 + 2 + 2 + 2 + 2 + 4 +
                   index_sizes.blob +
-                  index_sizes.string));
+                  index_sizes.string)));
         }
         else
         {
           name = pe_get_dotnet_string(
               pe,
               string_offset,
-              *(WORD*) (
+              yr_le16toh(*(WORD*) (
                   row_ptr + 4 + 2 + 2 + 2 + 2 + 4 +
                   index_sizes.blob +
-                  index_sizes.string));
+                  index_sizes.string)));
         }
 
         // Sometimes it will be a zero length string. This is technically
@@ -1172,23 +1177,23 @@ void dotnet_parse_tilde_2(
 
           assemblyref_table = (PASSEMBLYREF_TABLE) row_ptr;
 
-          set_integer(assemblyref_table->MajorVersion,
+          set_integer(yr_le16toh(assemblyref_table->MajorVersion),
               pe->object, "assembly_refs[%i].version.major", i);
-          set_integer(assemblyref_table->MinorVersion,
+          set_integer(yr_le16toh(assemblyref_table->MinorVersion),
               pe->object, "assembly_refs[%i].version.minor", i);
-          set_integer(assemblyref_table->BuildNumber,
+          set_integer(yr_le16toh(assemblyref_table->BuildNumber),
               pe->object, "assembly_refs[%i].version.build_number", i);
-          set_integer(assemblyref_table->RevisionNumber,
+          set_integer(yr_le16toh(assemblyref_table->RevisionNumber),
               pe->object, "assembly_refs[%i].version.revision_number", i);
 
-          blob_offset = pe->data + metadata_root + streams->blob->Offset;
+          blob_offset = pe->data + metadata_root + yr_le32toh(streams->blob->Offset);
 
           if (index_sizes.blob == 4)
             blob_offset += \
-                assemblyref_table->PublicKeyOrToken.PublicKeyOrToken_Long;
+                yr_le32toh(assemblyref_table->PublicKeyOrToken.PublicKeyOrToken_Long);
           else
             blob_offset += \
-                assemblyref_table->PublicKeyOrToken.PublicKeyOrToken_Short;
+                yr_le16toh(assemblyref_table->PublicKeyOrToken.PublicKeyOrToken_Short);
 
           blob_result = dotnet_parse_blob_entry(pe, blob_offset);
           blob_offset += blob_result.size;
@@ -1214,11 +1219,11 @@ void dotnet_parse_tilde_2(
           if (index_sizes.string == 4)
             name = pe_get_dotnet_string(pe,
                 string_offset,
-                *(DWORD*) (row_ptr + 2 + 2 + 2 + 2 + 4 + index_sizes.blob));
+                yr_le32toh(*(DWORD*) (row_ptr + 2 + 2 + 2 + 2 + 4 + index_sizes.blob)));
           else
             name = pe_get_dotnet_string(pe,
                 string_offset,
-                *(WORD*) (row_ptr + 2 + 2 + 2 + 2 + 4 + index_sizes.blob));
+                yr_le16toh(*(WORD*) (row_ptr + 2 + 2 + 2 + 2 + 4 + index_sizes.blob)));
 
           if (name != NULL)
             set_string(name, pe->object, "assembly_refs[%i].name", i);
@@ -1243,7 +1248,10 @@ void dotnet_parse_tilde_2(
         break;
 
       case BIT_EXPORTEDTYPE:
-        row_count = max_rows(3, rows.file, rows.assemblyref, rows.exportedtype);
+        row_count = max_rows(3,
+            yr_le32toh(rows.file),
+            yr_le32toh(rows.assemblyref),
+            yr_le32toh(rows.exportedtype));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -1255,7 +1263,9 @@ void dotnet_parse_tilde_2(
 
       case BIT_MANIFESTRESOURCE:
         // This is an Implementation coded index with no 3rd bit specified.
-        row_count = max_rows(2, rows.file, rows.assemblyref);
+        row_count = max_rows(2,
+            yr_le32toh(rows.file),
+            yr_le32toh(rows.assemblyref));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -1275,15 +1285,15 @@ void dotnet_parse_tilde_2(
             break;
 
           manifestresource_table = (PMANIFESTRESOURCE_TABLE) row_ptr;
-          resource_offset = manifestresource_table->Offset;
+          resource_offset = yr_le32toh(manifestresource_table->Offset);
 
           // Only set offset if it is in this file (implementation != 0).
           // Can't use manifestresource_table here because the Name and
           // Implementation fields are variable size.
           if (index_size == 4)
-            implementation = *(DWORD*) (row_ptr + 4 + 4 + index_sizes.string);
+            implementation = yr_le32toh(*(DWORD*) (row_ptr + 4 + 4 + index_sizes.string));
           else
-            implementation = *(WORD*) (row_ptr + 4 + 4 + index_sizes.string);
+            implementation = yr_le16toh(*(WORD*) (row_ptr + 4 + 4 + index_sizes.string));
 
           if (implementation != 0)
           {
@@ -1300,7 +1310,7 @@ void dotnet_parse_tilde_2(
             continue;
           }
 
-          resource_size = *(DWORD*)(pe->data + resource_base + resource_offset);
+          resource_size = yr_le32toh(*(DWORD*)(pe->data + resource_base + resource_offset));
 
           if (!fits_in_pe(
                 pe, pe->data + resource_base +
@@ -1339,7 +1349,9 @@ void dotnet_parse_tilde_2(
         break;
 
       case BIT_GENERICPARAM:
-        row_count = max_rows(2, rows.typedef_, rows.methoddef);
+        row_count = max_rows(2,
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.methoddef));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -1350,7 +1362,9 @@ void dotnet_parse_tilde_2(
         break;
 
       case BIT_METHODSPEC:
-        row_count = max_rows(2, rows.methoddef, rows.memberref);
+        row_count = max_rows(2,
+            yr_le32toh(rows.methoddef), 
+            yr_le32toh(rows.memberref));
 
         if (row_count > (0xFFFF >> 0x01))
           index_size = 4;
@@ -1361,7 +1375,10 @@ void dotnet_parse_tilde_2(
         break;
 
       case BIT_GENERICPARAMCONSTRAINT:
-        row_count = max_rows(3, rows.typedef_, rows.typeref, rows.typespec);
+        row_count = max_rows(3,
+            yr_le32toh(rows.typedef_),
+            yr_le32toh(rows.typeref),
+            yr_le32toh(rows.typespec));
 
         if (row_count > (0xFFFF >> 0x02))
           index_size = 4;
@@ -1420,17 +1437,19 @@ void dotnet_parse_tilde(
   tilde_header = (PTILDE_HEADER) (
       pe->data +
       metadata_root +
-      streams->tilde->Offset);
+      yr_le32toh(streams->tilde->Offset));
 
   if (!struct_fits_in_pe(pe, tilde_header, TILDE_HEADER))
     return;
 
+  uint32_t heap_sizes = yr_le32toh(tilde_header->HeapSizes);
+
   // Set index sizes for various heaps.
-  if (tilde_header->HeapSizes & 0x01)
+  if (heap_sizes & 0x01)
     index_sizes.string = 4;
-  if (tilde_header->HeapSizes & 0x02)
+  if (heap_sizes & 0x02)
     index_sizes.guid = 4;
-  if (tilde_header->HeapSizes & 0x04)
+  if (heap_sizes & 0x04)
     index_sizes.blob = 4;
 
   // Immediately after the tilde header is an array of 32bit values which
@@ -1445,7 +1464,7 @@ void dotnet_parse_tilde(
   // coded indexes, which are documented in ECMA-335 II.24.2.6.
   for (bit_check = 0; bit_check < 64; bit_check++)
   {
-    if (!((tilde_header->Valid >> bit_check) & 0x01))
+    if (!((yr_le64toh(tilde_header->Valid) >> bit_check) & 0x01))
       continue;
 
 #define ROW_CHECK(name) \
@@ -1454,7 +1473,7 @@ void dotnet_parse_tilde(
 
 #define ROW_CHECK_WITH_INDEX(name) \
     ROW_CHECK(name); \
-    if (rows.name > 0xFFFF) \
+    if (yr_le32toh(rows.name) > 0xFFFF)         \
       index_sizes.name = 4;
 
     switch (bit_check)
@@ -1533,7 +1552,7 @@ void dotnet_parse_tilde(
   }
 
   // This is used when parsing the MANIFEST RESOURCE table.
-  resource_base = pe_rva_to_offset(pe, cli_header->Resources.VirtualAddress);
+  resource_base = pe_rva_to_offset(pe, yr_le32toh(cli_header->Resources.VirtualAddress));
 
   dotnet_parse_tilde_2(
       pe,
@@ -1557,12 +1576,13 @@ void dotnet_parse_com(
   char* end;
   STREAMS headers;
   WORD num_streams;
+  uint32_t md_len;
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR);
   if (directory == NULL)
     return;
 
-  offset = pe_rva_to_offset(pe, directory->VirtualAddress);
+  offset = pe_rva_to_offset(pe, yr_le32toh(directory->VirtualAddress));
 
   if (offset < 0 || !struct_fits_in_pe(pe, pe->data + offset, CLI_HEADER))
     return;
@@ -1570,22 +1590,23 @@ void dotnet_parse_com(
   cli_header = (PCLI_HEADER) (pe->data + offset);
 
   offset = metadata_root = pe_rva_to_offset(
-      pe, cli_header->MetaData.VirtualAddress);
+      pe, yr_le32toh(cli_header->MetaData.VirtualAddress));
 
   if (!struct_fits_in_pe(pe, pe->data + offset, NET_METADATA))
     return;
 
   metadata = (PNET_METADATA) (pe->data + offset);
 
-  if (metadata->Magic != NET_METADATA_MAGIC)
+  if (yr_le32toh(metadata->Magic) != NET_METADATA_MAGIC)
     return;
 
   // Version length must be between 1 and 255, and be a multiple of 4.
   // Also make sure it fits in pe.
-  if (metadata->Length == 0 ||
-      metadata->Length > 255 ||
-      metadata->Length % 4 != 0 ||
-      !fits_in_pe(pe, pe->data + offset, metadata->Length))
+  md_len = yr_le32toh(metadata->Length);
+  if (md_len == 0 ||
+      md_len > 255 ||
+      md_len % 4 != 0 ||
+      !fits_in_pe(pe, pe->data + offset, md_len))
   {
     return;
   }
@@ -1593,7 +1614,7 @@ void dotnet_parse_com(
   // The length includes the NULL terminator and is rounded up to a multiple of
   // 4. We need to exclude the terminator and the padding, so search for the
   // first NULL byte.
-  end = (char*) memmem((void*) metadata->Version, metadata->Length, "\0", 1);
+  end = (char*) memmem((void*) metadata->Version, md_len, "\0", 1);
   if (end != NULL)
       set_sized_string(metadata->Version,
           (end - metadata->Version),
@@ -1604,7 +1625,7 @@ void dotnet_parse_com(
   // We must manually parse things from here on out.
   //
   // Flags are 2 bytes (always 0).
-  offset += sizeof(NET_METADATA) + metadata->Length + 2;
+  offset += sizeof(NET_METADATA) + md_len + 2;
 
   // 2 bytes for Streams.
   if (!fits_in_pe(pe, pe->data + offset, 2))


### PR DESCRIPTION
yara 3.11.0 fails the dotnet tests on s390x and other big-endian architectures, see <https://buildd.debian.org/status/logs.php?pkg=yara&ver=3.11.0-1>.

I sprinkled `yr_leXXtoh()` all over the code. Now the tests run successfully, but I am not quite sure whether I missed anything.