### PR TITLE
Improve pe.imports(...) functions to return the count of matches

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -868,10 +868,13 @@ Reference
 
     .. versionadded:: 3.5.0
 
-    Function returning true if the PE imports anything from *dll_name*,
-    or false otherwise. *dll_name* is case insensitive.
+    Function returning the number of functions from the *dll_name*, in the PE
+    imports. *dll_name* is case insensitive.
 
-    *Example:  pe.imports("kernel32.dll")*
+    Note: Prior to version 3.12.0, this function returns only a boolean value
+    (0 or 1) if the given DLL name is found in the PE imports.
+
+    *Example:  pe.imports("kernel32.dll") == 10*
 
 .. c:function:: imports(dll_name, ordinal)
 
@@ -886,12 +889,16 @@ Reference
 
     .. versionadded:: 3.8.0
 
-    Function returning true if the PE imports a function name matching
-    *function_regexp* from a DLL matching *dll_regexp*. *dll_regexp* is case
-    sensitive unless you use the "/i" modifier in the regexp, as shown in the
-    example below.
+    Function returning the number of functions from the PE imports where a
+    function name matches *function_regexp* and a DLL name matches
+    *dll_regexp*. Both *dll_regexp* and *function_regexp* are case sensitive
+    unless you use the "/i" modifier in the regexp, as shown in the example
+    below.
 
-    *Example:  pe.imports(/kernel32\.dll/i, /(Read|Write)ProcessMemory/)*
+    Note: Prior to version 3.12.0, this function returns only a boolean value
+    (0 or 1) if the given regexp matches any library and function.
+
+    *Example:  pe.imports(/kernel32\.dll/i, /(Read|Write)ProcessMemory/) == 2*
 
 .. c:function:: locale(locale_identifier)
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -2037,6 +2037,7 @@ define_function(imports_regex)
   PE* pe = (PE*)module->data;
 
   IMPORTED_DLL* imported_dll;
+  uint64_t imported_func_count = 0;
 
   if (!pe)
     return_integer(UNDEFINED);
@@ -2052,7 +2053,7 @@ define_function(imports_regex)
       while (imported_func != NULL)
       {
         if (yr_re_match(scan_context(), regexp_argument(2), imported_func->name) > 0)
-          return_integer(1);
+          imported_func_count++;
         imported_func = imported_func->next;
       }
     }
@@ -2060,7 +2061,7 @@ define_function(imports_regex)
     imported_dll = imported_dll->next;
   }
 
-  return_integer(0);
+  return_integer(imported_func_count);
 }
 
 define_function(imports_dll)
@@ -2071,6 +2072,7 @@ define_function(imports_dll)
   PE* pe = (PE*) module->data;
 
   IMPORTED_DLL* imported_dll;
+  uint64_t imported_func_count = 0;
 
   if (!pe)
     return_integer(UNDEFINED);
@@ -2081,13 +2083,19 @@ define_function(imports_dll)
   {
     if (strcasecmp(imported_dll->name, dll_name) == 0)
     {
-      return_integer(1);
+      IMPORT_FUNCTION* imported_func = imported_dll->functions;
+
+      while (imported_func != NULL)
+      {
+        imported_func_count++;
+        imported_func = imported_func->next;
+      }
     }
 
     imported_dll = imported_dll->next;
   }
 
-  return_integer(0);
+  return_integer(imported_func_count);
 }
 
 define_function(locale)

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
       "import \"pe\" \
       rule test { \
         condition: \
-          pe.imports(/.*/, /.*CriticalSection/) \
+          pe.imports(/.*/, /.*CriticalSection/) == 4 \
       }",
       "tests/data/tiny");
 
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
       "import \"pe\" \
       rule test { \
         condition: \
-          pe.imports(/kernel32\\.dll/i, /.*/) \
+          pe.imports(/kernel32\\.dll/i, /.*/) == 21 \
       }",
       "tests/data/tiny");
 


### PR DESCRIPTION
Improve the `pe.imports(...)` functions to return the count of matches instead of a boolean value.

This change affects `pe.imports(dll_name)` and `pe.imports(dll_regex, func_regex)`.

Like in e68eff98, it remains backward compatible because the count, when casted to a boolean, will be true if it is larger or equal to 1.

Perhaps this function could be aliased to a new `number_of_imports`, but we wanted to minimize changes.