### PR TITLE
Cuckoo module upgrades

### DIFF
--- a/docs/modules/cuckoo.rst
+++ b/docs/modules/cuckoo.rst
@@ -113,6 +113,13 @@ Reference
 
         Similar to :func:`http_request`, but only takes into account POST
         requests.
+       
+    .. function:: http_user_agent(regexp)
+
+        Function returning true if the program sent a HTTP request with a
+        user agent matching the provided regular expression.
+
+        *Example: cuckoo.network.http_user_agent(/MSIE 6\\.0/)*   
 
     .. function:: dns_lookup(regexp)
 
@@ -143,13 +150,6 @@ Reference
         port number.
 
         *Example: cuckoo.network.udp(/evil\\.com/, 53)*  
-
-      .. function:: user_agent(regexp)
-
-        Function returning true if the program sent a HTTP request with a
-        user agent matching the provided regular expression.
-
-        *Example: cuckoo.network.user_agent(/MSIE 6\\.0/)*   
 
 .. type:: registry
 

--- a/docs/modules/cuckoo.rst
+++ b/docs/modules/cuckoo.rst
@@ -141,7 +141,7 @@ Reference
         matching the provided regular expression, over TCP on the provided
         port number.
 
-        *Example: cuckoo.network.tcp(/evil\\.com/, 443)*  
+        *Example: cuckoo.network.tcp(/192\\.168\\.1\\.1/, 443)*  
 
       .. function:: udp(regexp, port)
 
@@ -149,7 +149,7 @@ Reference
         matching the provided regular expression, over UDP on the provided
         port number.
 
-        *Example: cuckoo.network.udp(/evil\\.com/, 53)*  
+        *Example: cuckoo.network.udp(/192\\.168\\.1\\.1/, 53)*  
 
 .. type:: registry
 

--- a/docs/modules/cuckoo.rst
+++ b/docs/modules/cuckoo.rst
@@ -120,6 +120,36 @@ Reference
         request for a domain matching the provided regular expression.
 
         *Example: cuckoo.network.dns_lookup(/evil\\.com/)*
+        
+    .. function:: host(regexp)
+
+        Function returning true if the program contacted an IP address
+        matching the provided regular expression.
+
+        *Example: cuckoo.network.host(/192\\.168\\.1\\.1/)*  
+
+      .. function:: tcp(regexp, port)
+
+        Function returning true if the program contacted an IP address
+        matching the provided regular expression, over TCP on the provided
+        port number.
+
+        *Example: cuckoo.network.tcp(/evil\\.com/, 443)*  
+
+      .. function:: udp(regexp, port)
+
+        Function returning true if the program contacted an IP address
+        matching the provided regular expression, over UDP on the provided
+        port number.
+
+        *Example: cuckoo.network.udp(/evil\\.com/, 53)*  
+
+      .. function:: user_agent(regexp)
+
+        Function returning true if the program sent a HTTP request with a
+        user agent matching the provided regular expression.
+
+        *Example: cuckoo.network.user_agent(/MSIE 6\\.0/)*   
 
 .. type:: registry
 

--- a/libyara/modules/cuckoo/cuckoo.c
+++ b/libyara/modules/cuckoo/cuckoo.c
@@ -27,12 +27,14 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+
 #include <string.h>
 #include <jansson.h>
 
 
 #include <yara/re.h>
 #include <yara/modules.h>
+
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define strcasecmp _stricmp
@@ -174,6 +176,138 @@ define_function(network_http_post)
 }
 
 
+// checks the host array in network JSON
+// loops through array and checks value for argument
+define_function(network_host)
+{
+  YR_SCAN_CONTEXT* context = scan_context();
+  YR_OBJECT* network_obj = parent();
+
+  json_t* network_json = (json_t*) network_obj->data;
+  json_t* value;
+
+  uint64_t result = 0;
+  size_t index;
+
+  json_t* hosts_info_json = json_object_get(network_json, "hosts");
+
+  json_array_foreach(hosts_info_json, index, value)
+  {
+    if (yr_re_match(context, regexp_argument(1), json_string_value(value)) > 0)
+    {
+      result = 1;
+      break;
+    }
+  }
+
+  return_integer(result);
+}
+
+// loops through TCP array in network JSON
+// checks for dest IP regex and dest port integer match
+define_function(network_tcp)
+{
+  YR_SCAN_CONTEXT* context = scan_context();
+  YR_OBJECT* network_obj = parent();
+
+  json_t* network_json = (json_t*) network_obj->data;
+  json_t* value;
+
+  uint64_t result = 0;
+  size_t index;
+
+  int dport;
+  char* dst;
+
+  json_t* tcp_info_json = json_object_get(network_json, "tcp");
+
+  json_array_foreach(tcp_info_json, index, value)
+  {
+    if (json_unpack(value, "{s:i, s:s}", "dport", &dport, "dst", &dst) == 0)
+    {
+      if (yr_re_match(context, regexp_argument(1), dst) > 0)
+      {
+        if ((int64_t)dport == integer_argument(2)) {
+          result = 1;
+          break;
+        }
+      }
+    }
+  }
+
+  return_integer(result);
+}
+
+
+// loops through UDP array in network JSON
+// checks for dest IP regex and dest port integer match
+define_function(network_udp)
+{
+  YR_SCAN_CONTEXT* context = scan_context();
+  YR_OBJECT* network_obj = parent();
+
+  json_t* network_json = (json_t*) network_obj->data;
+  json_t* value;
+
+  uint64_t result = 0;
+  size_t index;
+
+  int dport;
+  char* dst;
+
+  json_t* udp_info_json = json_object_get(network_json, "udp");
+
+  json_array_foreach(udp_info_json, index, value)
+  {
+    if (json_unpack(value, "{s:i, s:s}", "dport", &dport, "dst", &dst) == 0)
+    {
+      if (yr_re_match(context, regexp_argument(1), dst) > 0)
+      {
+        if ((int64_t)dport == integer_argument(2)) {
+          result = 1;
+          break;
+        }
+      }
+    }
+  }
+
+  return_integer(result);
+}
+
+
+// loops through http array in network JSON
+// checks for regex match on user-agent
+define_function(network_http_user_agent)
+{
+  
+  YR_SCAN_CONTEXT* context = scan_context();
+  YR_OBJECT* network_obj = parent();
+
+  json_t* network_json = (json_t*) network_obj->data;
+  json_t* http_json = json_object_get(network_json, "http");
+  json_t* value;
+
+  uint64_t result = 0;
+  size_t index;
+
+  char* user_agent;
+
+  json_array_foreach(http_json, index, value)
+  {
+    if (json_unpack(value, "{s:s}", "user-agent", &user_agent) == 0)
+    {
+      if (yr_re_match(context, regexp_argument(1), user_agent) > 0)
+      {
+        result = 1;
+        break;
+      }
+    }
+  }
+
+  return_integer(result);
+}
+
+
 define_function(registry_key_access)
 {
   YR_SCAN_CONTEXT* context = scan_context();
@@ -254,6 +388,10 @@ begin_declarations;
     declare_function("http_get", "r", "i", network_http_get);
     declare_function("http_post", "r", "i", network_http_post);
     declare_function("http_request", "r", "i", network_http_request);
+    declare_function("http_user_agent", "r", "i", network_http_user_agent);
+    declare_function("host", "r", "i", network_host);
+    declare_function("tcp", "ri", "i", network_tcp);
+    declare_function("udp", "ri", "i", network_udp);
   end_struct("network");
 
   begin_struct("registry");
@@ -344,3 +482,4 @@ int module_unload(YR_OBJECT* module)
 
   return ERROR_SUCCESS;
 }
+


### PR DESCRIPTION
See #1175. Added support for:
- network.host(regexp)
    -  example: cuckoo.network.host(/192.168.1.1/)
- network.tcp(regexp, int)
    - aguments: (destintion_ip, destination_port)
    - example: cuckoo.network.tcp(/192.168.1.1:80/)
- network.udp(regexp, int)
    - aguments: (destintion_ip, destination_port)
    - example: cuckoo.network.tcp(/192.168.1.1:53/)
- network.http_user_agent(regexp)
    - example: cuckoo.network.http_user_agent(/MSIE 6\.0/)

I tested with a JSON cuckoo report I grabbed from a VT CuckooFork run. I looked into creating/running tests, but as there are not any tests for the cuckoo module I decided it was out of scope of this PR to implement that. Happy to help with future work though. 

I think that the whole module could probably use a refactor, but I designed my additions around the existing code set. There is definitely some code-reuse and repetition.