### PR TITLE
Recheck atom quality after generating xor atoms.

### DIFF
--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -1579,14 +1579,15 @@ int yr_atoms_extract_from_string(
     yr_atoms_list_destroy(*atoms);
     *atoms = xor_atoms;
 
-    // Recheck the atom quality, in case we have just generated some poor atoms.
-    // https://github.com/VirusTotal/yara/issues/1172
-    for (item = *atoms; item != NULL; item = item->next)
-    {
-      quality = config->get_atom_quality(config, &item->atom);
-      if (quality < *min_atom_quality)
-        *min_atom_quality = quality;
-    }
+  }
+
+  // Recheck the atom quality, in case we have just generated some poor atoms.
+  // https://github.com/VirusTotal/yara/issues/1172
+  for (item = *atoms; item != NULL; item = item->next)
+  {
+    quality = config->get_atom_quality(config, &item->atom);
+    if (quality < *min_atom_quality)
+      *min_atom_quality = quality;
   }
 
   return ERROR_SUCCESS;

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -1576,8 +1576,17 @@ int yr_atoms_extract_from_string(
         *atoms = NULL;
       });
 
-      yr_atoms_list_destroy(*atoms);
-      *atoms = xor_atoms;
+    yr_atoms_list_destroy(*atoms);
+    *atoms = xor_atoms;
+
+    // Recheck the atom quality, in case we have just generated some poor atoms.
+    // https://github.com/VirusTotal/yara/issues/1172
+    for (item = *atoms; item != NULL; item = item->next)
+    {
+      quality = config->get_atom_quality(config, &item->atom);
+      if (quality < *min_atom_quality)
+        *min_atom_quality = quality;
+    }
   }
 
   return ERROR_SUCCESS;

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2392,6 +2392,18 @@ void test_performance_warnings()
        "rule test { \
         strings: $a = \"MZ\" \
         condition: $a }")
+
+  assert_warning(
+      "rule test { \
+        strings: $a = \"                    \" xor(0x20) \
+        condition: $a }")
+
+  // This will eventually xor with 0x41 and should cause a warning.
+  assert_warning(
+      "rule test { \
+        strings: $a = \"AAAAAAAAAAAAAAAAAAAA\" xor \
+        condition: $a }")
+
 }
 
 


### PR DESCRIPTION
When generating xor atoms we need to recheck the atom quality in case we have
just generated bad atoms.

Fixes #1172