### PR TITLE
Support dex version 039

### DIFF
--- a/libyara/include/yara/dex.h
+++ b/libyara/include/yara/dex.h
@@ -10,6 +10,7 @@
 #define DEX_FILE_MAGIC_036 "dex\n036\x00"
 #define DEX_FILE_MAGIC_037 "dex\n037\x00"
 #define DEX_FILE_MAGIC_038 "dex\n038\x00"
+#define DEX_FILE_MAGIC_039 "dex\n039\x00"
 
 #pragma pack(push,1)
 

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -45,6 +45,7 @@ begin_declarations;
   declare_string("DEX_FILE_MAGIC_036");
   declare_string("DEX_FILE_MAGIC_037");
   declare_string("DEX_FILE_MAGIC_038");
+  declare_string("DEX_FILE_MAGIC_039");
 
   declare_integer("ENDIAN_CONSTANT");
   declare_integer("REVERSE_ENDIAN_CONSTANT");
@@ -306,7 +307,8 @@ dex_header_t* dex_get_header(
   if (memcmp(dex_header->magic, DEX_FILE_MAGIC_035, 8) != 0 &&
       memcmp(dex_header->magic, DEX_FILE_MAGIC_036, 8) != 0 &&
       memcmp(dex_header->magic, DEX_FILE_MAGIC_037, 8) != 0 &&
-      memcmp(dex_header->magic, DEX_FILE_MAGIC_038, 8) != 0)
+      memcmp(dex_header->magic, DEX_FILE_MAGIC_038, 8) != 0 &&
+      memcmp(dex_header->magic, DEX_FILE_MAGIC_039, 8) != 0)
   {
     return NULL;
   }

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -1145,6 +1145,7 @@ int module_load(
   set_string(DEX_FILE_MAGIC_036, module_object, "DEX_FILE_MAGIC_036");
   set_string(DEX_FILE_MAGIC_037, module_object, "DEX_FILE_MAGIC_037");
   set_string(DEX_FILE_MAGIC_038, module_object, "DEX_FILE_MAGIC_038");
+  set_string(DEX_FILE_MAGIC_039, module_object, "DEX_FILE_MAGIC_039");
 
   set_integer(0x12345678, module_object, "ENDIAN_CONSTANT");
   set_integer(0x78563412, module_object, "REVERSE_ENDIAN_CONSTANT");


### PR DESCRIPTION
New dex files aren't typed correctly because the magic bytes are now: `dex\n039\x00`.

I can upload a sample if you want. Easily created by using Android Studio and creating an Android API 29 project (possibly set this as the min API level) and compile it.