### PR TITLE
Fix some dex header field typos

### DIFF
--- a/libyara/include/yara/dex.h
+++ b/libyara/include/yara/dex.h
@@ -75,7 +75,7 @@ typedef struct {
 	uint32_t class_idx;
 	uint32_t access_flags;
 	uint32_t super_class_idx;
-	uint32_t interfaces_off;
+	uint32_t interfaces_offset;
 	uint32_t source_file_idx;
 	uint32_t annotations_offset;
 	uint32_t class_data_offset;

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -147,7 +147,7 @@ begin_declarations;
   begin_struct_array("class_defs");
     declare_integer("class_idx");
     declare_integer("access_flags");
-    declare_integer("superclass_idx");
+    declare_integer("super_class_idx");
     declare_integer("interfaces_offset");
     declare_integer("source_file_idx");
     declare_integer("annotations_offset");
@@ -939,13 +939,13 @@ void dex_parse(
 
     #ifdef DEBUG_DEX_MODULE
     printf("[DEX] CLASS ID item class_idx:0x%x access_flags:0x%x " \
-           "super_class_idx:0x%x interfaces_off:0x%x source_file_idx:0x%x "\
+           "super_class_idx:0x%x interfaces_offset:0x%x source_file_idx:0x%x "\
            "annotations_offset:0x%x class_data_offset:0x%x "\
            "static_values_offset:0x%x\n",
            yr_le32toh(class_id_item->class_idx),
            yr_le32toh(class_id_item->access_flags),
            yr_le32toh(class_id_item->super_class_idx),
-           yr_le32toh(class_id_item->interfaces_off),
+           yr_le32toh(class_id_item->interfaces_offset),
            yr_le32toh(class_id_item->source_file_idx),
            yr_le32toh(class_id_item->annotations_offset),
            yr_le32toh(class_id_item->class_data_offset),
@@ -958,14 +958,14 @@ void dex_parse(
                 "class_defs[%i].access_flags", i);
     set_integer(yr_le32toh(class_id_item->super_class_idx), dex->object,
                 "class_defs[%i].super_class_idx", i);
-    set_integer(yr_le32toh(class_id_item->interfaces_off), dex->object,
-                "class_defs[%i].interfaces_off", i);
+    set_integer(yr_le32toh(class_id_item->interfaces_offset), dex->object,
+                "class_defs[%i].interfaces_offset", i);
     set_integer(yr_le32toh(class_id_item->source_file_idx), dex->object,
                 "class_defs[%i].source_file_idx", i);
     set_integer(yr_le32toh(class_id_item->annotations_offset), dex->object,
                 "class_defs[%i].annotations_offset", i);
     set_integer(yr_le32toh(class_id_item->class_data_offset), dex->object,
-                "class_defs[%i].class_data_off", i);
+                "class_defs[%i].class_data_offset", i);
     set_integer(yr_le32toh(class_id_item->static_values_offset), dex->object,
                 "class_defs[%i].static_values_offset", i);
 


### PR DESCRIPTION
This fixes a few typos and makes the naming consistent (`off` -> `offset`).