### PR TITLE
Fix trailing byte in some dotnet user strings.

### DIFF
--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -196,6 +196,12 @@ BLOB_PARSE_RESULT dotnet_parse_blob_entry(
     result.size = 0;
   }
 
+  // There is an additional terminal byte which is 0x01 under certain
+  // conditions. The exact conditions are not relevant to our parsing but are
+  // documented in ECMA-335 II.24.2.4.
+  if (result.length > 0)
+    result.length--;
+
   return result;
 }
 

--- a/tests/test-dotnet.c
+++ b/tests/test-dotnet.c
@@ -72,6 +72,13 @@ int main(int argc, char** argv)
       }",
       "tests/data/33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b");
 
+  assert_true_rule_file(
+      "import \"dotnet\" \
+      rule test { \
+        condition: \
+          dotnet.user_strings[0] == \"F\\x00r\\x00e\\x00e\\x00D\\x00i\\x00s\\x00c\\x00B\\x00u\\x00r\\x00n\\x00e\\x00r\\x00.\\x00S\\x00t\\x00r\\x00i\\x00n\\x00g\\x00R\\x00e\\x00s\\x00o\\x00u\\x00r\\x00c\\x00e\\x00s\\x00\" \
+      }",
+      "tests/data/33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b");
   yr_finalize();
   return 0;
 }


### PR DESCRIPTION
There is always a trailing byte added into user strings and blob entries. This
byte is 0x00 or 0x01 and is used to indicate if any UTF16 character requires
handling beyond the normal 8-bit encoding sets. See ECMA-335 II.24.2.4 for
exact details, which are not relevant at all to our parsing. This commit just
ignores that trailing byte.

Add a test for this too. It's worth noting that this does break anyone who is
looking for specific user strings but given that this module is not on by
default I'm willing to break those people. :(

Noticed by: Robert Simmons