### PR TITLE
CIFuzz Dogfood

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CIFuzz
+
+on: [pull_request]
+
+jobs:
+  fuzz:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Building and running fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions@master
+      with:
+        project-name: 'yara'
+        fuzz-time: 600
+        dry-run: True
+    - uses: actions/upload-artifact@v1
+      with:
+        name: fuzzer_testcase
+        path: ./out/testcase


### PR DESCRIPTION
OSS-Fuzz was wondering if yara would dogfood CIFuzz,
a new feature being rolled out in OSS-Fuzz. It allows for pull
requests to be fuzzed in CI using fuzz targets enabled in OSS-Fuzz. 
It will be active in dry_run mode meaning that it will never fail. 