### PR TITLE
Skip larger files

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -105,6 +105,10 @@ Available options are:
 
   Abort scanning after a number of seconds has elapsed.
 
+.. option:: -z <bytes> --size-limit=<bytes>
+
+  Skip files larger than the given limit (in bytes, 0 means no limit)
+
 .. option:: -k <slots> --stack-size=<slots>
 
   Allocate a stack size of "slots" number of slots. Default: 16384. This
@@ -129,7 +133,7 @@ Available options are:
 
 .. option:: -r --recursive
 
-  Recursively search for directories. It follows symlinks.
+  Recursively search for directories.
 
 .. option:: -f --fast-scan
 

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -133,7 +133,7 @@ Available options are:
 
 .. option:: -r --recursive
 
-  Recursively search for directories.
+  Recursively search for directories. It follows symlinks.
 
 .. option:: -f --fast-scan
 


### PR DESCRIPTION
Hello,

This PR implement a new option:   Skip files larger than the given limit in bytes
By default no limit is applied.
A limit definite as 0 mean no limit.
I use stat() to get the file-size in case of symlink
Available in recursive mode and direct access mode

Thomas.


Example:
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  tree

├── lamashell.php
├── lamashell_sub_sumlink -> sub1/lamashell_sub
├── rfxn.yar
└── sub1
    └── lamashell_sub
```

File size (2480 bytes)
```
╰─➤  stat lamashell.php                                                                                                                                                                                                                                                    
  File: lamashell.php
  Size: 2480      	Blocks: 8          IO Block: 4096   regular file
(.....)
```

Classic test = detected
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara rfxn.yar lamashell.php 
lamashell_php lamashell.php
WebShell_lamashell lamashell.php
```

Set limit 2000 bytes = skipping
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara -z 2000 rfxn.yar lamashell.php                                                                                                                                                                                                                                   
skipping lamashell.php (2000 bytes) because it's larger than 2480 bytes.
```

Set limit 3000 bytes = detected
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara -z 3000 rfxn.yar lamashell.php
lamashell_php lamashell.php
WebShell_lamashell lamashell.php
```

Set limit 2000bytes and on a symlink = skipping
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara -z 2000 rfxn.yar lamashell_sub_sumlink 
skipping lamashell_sub_sumlink (2000 bytes) because it's larger than 2480 bytes.
```

Test with recursive and limit  2000 bytes = skipping ( | grep -v .yar  = exclude rfxn.yar from scan output)
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara -z 2000 -r rfxn.yar ../test_patch |grep -v .yar  
skipping ../test_patch/sub1/lamashell_sub (2000 bytes) because it's larger than 2480 bytes.
skipping ../test_patch/lamashell_sub_sumlink (2000 bytes) because it's larger than 2480 bytes.
skipping ../test_patch/lamashell.php (2000 bytes) because it's larger than 2480 bytes.
```

Test with recursive and no limit set (detected)
```
╭─yara-dev@debian-yara ~/test_patch  
╰─➤  yara  -r rfxn.yar ../test_patch |grep -v .yar  
lamashell_php ../test_patch/lamashell_sub_sumlink
WebShell_lamashell ../test_patch/lamashell_sub_sumlink
lamashell_php ../test_patch/lamashell.php
WebShell_lamashell ../test_patch/lamashell.php
lamashell_php ../test_patch/sub1/lamashell_sub
WebShell_lamashell ../test_patch/sub1/lamashell_sub
```