### PR TITLE
Update workflow to reflect new CIFuzz format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,18 +3,22 @@ name: CIFuzz
 on: [pull_request]
 
 jobs:
-  fuzz:
-
+  Fuzzing:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Building and running fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions@master
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         project-name: 'yara'
+        dry-run: true
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
         fuzz-time: 600
-        dry-run: True
-    - uses: actions/upload-artifact@v1
+        dry-run: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
       with:
         name: fuzzer_testcase
         path: ./out/testcase


### PR DESCRIPTION
Separated build fuzzers and run fuzzers actions. This change needs to be reflected in the workflow file. This should make the bug detected logs clear and not full with useless build information.