### PR TITLE
CIFuzz: Surfacing test cases and stack on failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: fuzzer_testcase
-        path: ./out/testcase
+        name: bug_report
+        path: ./out/bug_report


### PR DESCRIPTION
Surfacing a directory containing the failure stack trace and the test case for reproducing the bug. This should be the last config change for a while. 