### PR TITLE
CIFuzz renaming output to artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: bug_report
-        path: ./out/bug_report
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
We had a last minute design decision to rename the output directory to 'artifacts'. Sorry for the inconvenience, and thanks for dog fooding CIFuzz!