### PR TITLE
Remove code that is not necessary.

### DIFF
--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -635,26 +635,7 @@ int yr_parser_reduce_string_declaration(
 
       goto _exit;
     }
-
-    if (modifier.flags & STRING_GFLAGS_BASE64 ||
-        modifier.flags & STRING_GFLAGS_BASE64_WIDE)
-    {
-      RE re;
-
-      FAIL_ON_ERROR(yr_arena_reserve_memory(
-          compiler->code_arena, sizeof(int64_t) + RE_MAX_CODE_SIZE));
-
-      re.flags = 0;
-
-      FAIL_ON_ERROR_WITH_CLEANUP(
-          yr_arena_write_data(
-              compiler->re_code_arena,
-              &re,
-              sizeof(re),
-              NULL),
-          yr_re_ast_destroy(re_ast));
-    }
-
+    
     if (re_ast->flags & RE_FLAGS_FAST_REGEXP)
       modifier.flags |= STRING_GFLAGS_FAST_REGEXP;
 


### PR DESCRIPTION
This code snippet is apparently unnecessary. The call to `yr_arena_reserve_memory` is reserving memory in the arena dedicated to the VM code, which is not related to the regular expression's code. The call to `yr_arena_write` is writing a `RE` struct in the `re_code_arena` but this structure is not referenced from anywhere.