### PR TITLE
Add check for reproducible build in PE module

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -820,6 +820,13 @@ Reference
     Path of the PDB file for this PE if present.
 
     * Example: pe.pdb_path == "D:\\workspace\\2018_R9_RelBld\\target\\checkout\\custprof\\Release\\custprof.pdb"
+    
+.. c:type:: is_reproducible_build
+
+    .. versionadded:: 3.13.0
+    
+    Value that indicates if the PE is build using compiler settings to achieve reproducibility.
+    
 
 .. c:function:: exports(function_name)
 

--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -465,7 +465,13 @@ typedef struct _IMAGE_RESOURCE_DIRECTORY {
 #define IMAGE_DEBUG_TYPE_MISC                            4
 #define IMAGE_DEBUG_TYPE_EXCEPTION                       5
 #define IMAGE_DEBUG_TYPE_FIXUP                           6
+#define IMAGE_DEBUG_TYPE_OMAP_TO_SRC                     7
+#define IMAGE_DEBUG_TYPE_OMAP_FROM_SRC                   8
 #define IMAGE_DEBUG_TYPE_BORLAND                         9
+#define IMAGE_DEBUG_TYPE_RESERVED10                     10
+#define IMAGE_DEBUG_TYPE_CLSID                          11
+#define IMAGE_DEBUG_TYPE_REPRO                          16
+#define IMAGE_DEBUG_TYPE_EX_DLLCHARACTERISTICS          20
 
 typedef struct _IMAGE_DEBUG_DIRECTORY {
     DWORD Characteristics;

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -291,6 +291,8 @@ static void pe_parse_debug_directory(
   size_t pdb_path_len;
   char* pdb_path = NULL;
   
+  set_integer(0, pe->object, "is_reproducible_build");
+  
   data_dir = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_DEBUG);
 
@@ -321,6 +323,12 @@ static void pe_parse_debug_directory(
     
     if (!struct_fits_in_pe(pe, debug_dir, IMAGE_DEBUG_DIRECTORY))
       break;
+
+    if (yr_le32toh(debug_dir->Type) == IMAGE_DEBUG_TYPE_REPRO)
+    {
+      set_integer(1, pe->object, "is_reproducible_build");
+      continue;
+    }
   
     if (yr_le32toh(debug_dir->Type) != IMAGE_DEBUG_TYPE_CODEVIEW)
       continue;
@@ -359,7 +367,6 @@ static void pe_parse_debug_directory(
       if (pdb_path_len > 0 && pdb_path_len < MAX_PATH)
       {
         set_sized_string(pdb_path, pdb_path_len, pe->object, "pdb_path");
-        break;
       }
     }
   }
@@ -2631,7 +2638,8 @@ begin_declarations;
   declare_integer("number_of_symbols");
   declare_integer("size_of_optional_header");
   declare_integer("characteristics");
-
+  declare_integer("is_reproducible_build");
+  
   declare_integer("entry_point");
   declare_integer("image_base");
   declare_integer("number_of_rva_and_sizes");


### PR DESCRIPTION
Since there is a code that parses debug directory, I thought it's a good idea to add some value that can be used for checking if the PE binary build as "reproducible build". If this value is set, it means that timestamps in the PE can be replaced with some other values to achieve reproducibility.

Here is more information about reproducible builds:
https://devblogs.microsoft.com/oldnewthing/20180103-00/?p=97705
https://docs.microsoft.com/en-us/windows/win32/debug/pe-format?redirectedfrom=MSDN#debug-type