### PR TITLE
Locale/language bug fix in pe module

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -2448,7 +2448,7 @@ define_function(locale)
   for (i = 0; i < n; i++)
   {
     uint64_t rsrc_language = get_integer(
-        module, "resources[%" PRId64 "].language", i);
+        module, "resources[%" PRIi32 "].language",  (int32_t)i);
 
     if ((rsrc_language & 0xFFFF) == locale)
       return_integer(1);
@@ -2479,7 +2479,7 @@ define_function(language)
   for (i = 0; i < n; i++)
   {
     uint64_t rsrc_language = get_integer(
-        module, "resources[%" PRId64 "].language", i);
+        module, "resources[%" PRIi32 "].language", (int32_t)i);
 
     if ((rsrc_language & 0xFF) == language)
       return_integer(1);

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -302,6 +302,14 @@ int main(int argc, char** argv)
       }",
       "tests/data/weird_rich");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.language(0x09) and pe.locale(0x0409) \
+      }",
+      "tests/data/mtxex.dll");
+
   yr_finalize();
   return 0;
 }


### PR DESCRIPTION
  A change introduced in commit 75babbc0248f14b3ecb135c88d592268f1c1edce
  silently broke language check due to integer size and signedness.

  Tested using pe.language(0x04) on file 33659578e2f6e143c4e0533d598bf690