### PR TITLE
Make the YR_ARENA_REF struct to be 64-bits long without any padding.

### DIFF
--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -652,10 +652,6 @@ int yr_arena_save_stream(
 
     YR_ARENA_REF ref;
 
-    // Fill reference with zeroes, as this structure is going to be written
-    // we don't want random bytes in the padding.
-    memset(&ref, 0, sizeof(ref));
-
     int found = yr_arena_ptr_to_ref(arena, *reloc_ptr, &ref);
 
     // yr_arena_ptr_to_ref returns 0 if the relocatable pointer is pointing

--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -323,7 +323,7 @@ int yr_arena_allocate_memory(
 //    [in]  YR_ARENA* arena     - Pointer to the arena.
 //    [in]  int buffer_id       - Buffer number.
 //    [in]  size_t size         - Size of the region to be allocated.
-//    [out] YR_ARENA_REF* ref  - Pointer to a reference that will point to the
+//    [out] YR_ARENA_REF* ref   - Pointer to a reference that will point to the
 //                                newly allocated structure when the function
 //                                returns. The pointer can be NULL if you don't
 //                                need the reference.

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -406,7 +406,7 @@ int yr_execute_code(
       yr_free(stack.items));
 
   #ifdef PROFILING_ENABLED
-  start_time = yr_stopwatch_elapsed_us(&context->stopwatch);
+  start_time = yr_stopwatch_elapsed_ns(&context->stopwatch);
   #endif
 
   #if PARANOID_EXEC
@@ -840,7 +840,7 @@ int yr_execute_code(
           yr_bitmask_set(context->ns_unsatisfied_flags, rule->ns->idx);
 
         #ifdef PROFILING_ENABLED
-        elapsed_time = yr_stopwatch_elapsed_us(&context->stopwatch);
+        elapsed_time = yr_stopwatch_elapsed_ns(&context->stopwatch);
         context->time_cost[r2.i] += (elapsed_time - start_time);
         start_time = elapsed_time;
         #endif
@@ -1612,7 +1612,7 @@ int yr_execute_code(
 
     if (context->timeout > 0L && ++cycle == 100)
     {
-      elapsed_time = yr_stopwatch_elapsed_us(&context->stopwatch);
+      elapsed_time = yr_stopwatch_elapsed_ns(&context->stopwatch);
 
       if (elapsed_time > context->timeout)
       {

--- a/libyara/include/yara/arena.h
+++ b/libyara/include/yara/arena.h
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_ARENA_FILE_VERSION  17
 
 #define YR_ARENA_NULL_REF  \
-    (YR_ARENA_REF){ UINT8_MAX, UINT32_MAX }
+    (YR_ARENA_REF){ UINT32_MAX, UINT32_MAX }
 
 typedef uint32_t yr_arena_off_t;
 
@@ -63,7 +63,7 @@ typedef struct YR_RELOC YR_RELOC;
 
 struct YR_ARENA_REF
 {
-  uint8_t buffer_id;
+  uint32_t buffer_id;
   uint32_t offset;
 };
 

--- a/libyara/include/yara/rules.h
+++ b/libyara/include/yara/rules.h
@@ -161,10 +161,6 @@ YR_API int yr_rules_define_string_variable(
     const char* value);
 
 
-YR_API void yr_rules_print_profiling_info(
-    YR_RULES* rules);
-
-
 YR_API int yr_rules_get_stats(
     YR_RULES* rules,
     YR_RULES_STATS *stats);

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -75,9 +75,9 @@ typedef struct _YR_STOPWATCH
 void yr_stopwatch_start(
     YR_STOPWATCH* stopwatch);
 
-// yr_stopwatch_elapsed_us returns the number of microseconds elapsed
+// yr_stopwatch_elapsed_ns returns the number of nanoseconds elapsed
 // since the last call to yr_stopwatch_start.
-uint64_t yr_stopwatch_elapsed_us(
+uint64_t yr_stopwatch_elapsed_ns(
     YR_STOPWATCH* stopwatch);
 
 #endif

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -907,7 +907,7 @@ int yr_scan_verify_match(
     return ERROR_SUCCESS;
 
   #ifdef PROFILING_ENABLED
-  uint64_t start_time = yr_stopwatch_elapsed_us(&context->stopwatch);
+  uint64_t start_time = yr_stopwatch_elapsed_ns(&context->stopwatch);
   #endif
 
   if (STRING_IS_LITERAL(string))
@@ -922,7 +922,7 @@ int yr_scan_verify_match(
   }
 
   #ifdef PROFILING_ENABLED
-  uint64_t finish_time = yr_stopwatch_elapsed_us(&context->stopwatch);
+  uint64_t finish_time = yr_stopwatch_elapsed_ns(&context->stopwatch);
   context->time_cost[string->rule_idx] += (finish_time - start_time);
   #endif
 

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -63,7 +63,7 @@ static int _yr_scanner_scan_mem_block(
   {
     if (i % 4096 == 0 && scanner->timeout > 0)
     {
-      if (yr_stopwatch_elapsed_us(&scanner->stopwatch) > scanner->timeout)
+      if (yr_stopwatch_elapsed_ns(&scanner->stopwatch) > scanner->timeout)
         return ERROR_SCAN_TIMEOUT;
     }
 

--- a/libyara/stopwatch.c
+++ b/libyara/stopwatch.c
@@ -39,14 +39,14 @@ void yr_stopwatch_start(
 }
 
 
-uint64_t yr_stopwatch_elapsed_us(
+uint64_t yr_stopwatch_elapsed_ns(
     YR_STOPWATCH* sw)
 {
   LARGE_INTEGER li;
 
   QueryPerformanceCounter(&li);
 
-  return (li.QuadPart - sw->start.QuadPart) * 1000000L / sw->frequency.QuadPart;
+  return (li.QuadPart - sw->start.QuadPart) * 1000000000L / sw->frequency.QuadPart;
 }
 
 
@@ -60,14 +60,11 @@ void yr_stopwatch_start(
 }
 
 
-uint64_t yr_stopwatch_elapsed_us(
+uint64_t yr_stopwatch_elapsed_ns(
     YR_STOPWATCH* sw)
 {
-  uint64_t now;
-
-  now = mach_absolute_time();
-  return (now - sw->start) * sw->timebase.numer /
-         (sw->timebase.denom * 1000ULL);
+  uint64_t now = mach_absolute_time();
+  return ((now - sw->start) * sw->timebase.numer) / sw->timebase.denom;
 }
 
 
@@ -91,7 +88,7 @@ void yr_stopwatch_start(
 }
 
 
-uint64_t yr_stopwatch_elapsed_us(
+uint64_t yr_stopwatch_elapsed_ns(
     YR_STOPWATCH* stopwatch)
 {
   struct timespec ts_stop;
@@ -99,7 +96,7 @@ uint64_t yr_stopwatch_elapsed_us(
 
   clock_gettime(CLOCK_MONOTONIC, &ts_stop);
   timespecsub(&ts_stop, &stopwatch->ts_start, &ts_elapsed);
-  return ts_elapsed.tv_sec * 1000000L + ts_elapsed.tv_nsec / 1000;
+  return ts_elapsed.tv_sec * 1000000000L + ts_elapsed.tv_nsec;
 }
 
 
@@ -125,7 +122,7 @@ void yr_stopwatch_start(
 }
 
 
-uint64_t yr_stopwatch_elapsed_us(
+uint64_t yr_stopwatch_elapsed_ns(
     YR_STOPWATCH* stopwatch)
 {
   struct timeval tv_stop;
@@ -133,7 +130,7 @@ uint64_t yr_stopwatch_elapsed_us(
 
   gettimeofday(&tv_stop, NULL);
   timevalsub(&tv_stop, &stopwatch->tv_start, &tv_elapsed);
-  return tv_elapsed.tv_sec * 1000000L + tv_elapsed.tv_usec;
+  return tv_elapsed.tv_sec * 1000000000L + tv_elapsed.tv_usec * 1000L;
 }
 
 #endif

--- a/yara.c
+++ b/yara.c
@@ -1306,6 +1306,10 @@ int main(
 
     if (print_count_only)
       printf("%d\n", user_data.current_count);
+
+    #ifdef PROFILING_ENABLED
+    yr_scanner_print_profiling_info(scanner);
+    #endif
   }
 
   result = EXIT_SUCCESS;


### PR DESCRIPTION
When we have assignments like ref = YR_ARENA_NULL_REF we don't want the resulting struct "ref" to have padding bytes that can be filled with random bytes from memory. If the YR_ARENA_REF has some padding we can't make sure that result from such assignments don't have random values in the padding bytes.