### PR TITLE
Bump library version number

### DIFF
--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -144,7 +144,7 @@ dist_noinst_DATA = pb/yara.proto
 
 lib_LTLIBRARIES = libyara.la
 
-libyara_la_LDFLAGS = -version-number 3:11:0
+libyara_la_LDFLAGS = -version-number 4:0:0
 
 BUILT_SOURCES = \
 	lexer.c \


### PR DESCRIPTION
The following public symbols have been removed from the shared library
since 3.11:

- yr_finalize_thread
- yr_{get,set}_tidx
- yr_rules_reset_profiling_info

These introduce a binary incompatibility for programs that have been
dynamically linked with YARA 3.