### PR TITLE
Don't include CFLAGS in pkg-config file

### DIFF
--- a/libyara/yara.pc.in
+++ b/libyara/yara.pc.in
@@ -8,6 +8,6 @@ Description: YARA library
 URL: https://virustotal.github.io/yara/
 Version: @PACKAGE_VERSION@
 Requires.private: @PC_REQUIRES_PRIVATE@
-Cflags: -I${includedir} @CFLAGS@
+Cflags: -I${includedir}
 Libs: -L${libdir} -lyara
 Libs.private: @PC_LIBS_PRIVATE@ @PTHREAD_LIBS@


### PR DESCRIPTION
I'm not sure what was the intention for adding CFLAGS in fd8145c69cce7b40d7e8ca719214de253b1e7913, but when I build a Debian package from YARA 4.0.0-rc3, all sorts of compiler flags end up in `yara.pc` to be used by other packages:
```
Cflags: -I${includedir} -g -O2 -fdebug-prefix-map=/build/yara-hH5OOg/yara-4.0.0~rc3=. -fstack-protector-strong -Wformat -Werror=format-security -DUSE_LINUX_PROC -pthread -DCUCKOO_MODULE -DMAGIC_MODULE -DDOTNET_MODULE -DMACHO_MODULE -DDEX_MODULE -DHASH_MODULE
```