### PR TITLE
Fix signature parsing on 32-bit big-endian

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -249,7 +249,7 @@ static void pe_parse_rich_signature(
 
   set_integer(rich_len, pe->object, "rich_signature.length");
 
-  set_integer(rich_signature->key1, pe->object, "rich_signature.key");
+  set_integer(yr_le32toh(rich_signature->key1), pe->object, "rich_signature.key");
 
   clear_data = (BYTE*) yr_malloc(rich_len);
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1552,7 +1552,7 @@ static void pe_parse_certificates(
     end = (uintptr_t)((uint8_t*) win_cert) + yr_le32toh(win_cert->Length);
     while ((uintptr_t) cert_p < end && counter < MAX_PE_CERTS)
     {
-      pkcs7 = d2i_PKCS7(NULL, &cert_p, (win_cert->Length));
+      pkcs7 = d2i_PKCS7(NULL, &cert_p, (yr_le32toh(win_cert->Length)));
       if (pkcs7 == NULL)
         break;
       _parse_pkcs7(pe, pkcs7, &counter);

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -298,6 +298,7 @@ int main(int argc, char** argv)
         condition: \
           pe.rich_signature.offset == 0x200 and \
           pe.rich_signature.length == 64 and \
+          pe.rich_signature.key == 0x9f1d8511 and \
           pe.rich_signature.clear_data == \"DanS\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x11\\x00\\x00\\x00\\xc3\\x0f]\\x00\\x03\\x00\\x00\\x00\\x09x\\x95\\x00\\x01\\x00\\x00\\x00\\x09x\\x83\\x00\\x05\\x00\\x00\\x00\\x09x\\x94\\x00\\x01\\x00\\x00\\x00\\x09x\\x91\\x00\\x01\\x00\\x00\\x00\" \
       }",
       "tests/data/weird_rich");


### PR DESCRIPTION
(Fixes test-pe on Debian/powerpc and Debian/hppa.)