### PR TITLE
Add option (--scan-list) to scan a list of files and/or directories

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -127,6 +127,10 @@ Available options are:
 
   Pass file's content as extra data to module.
 
+.. option:: --scan-list
+
+  Scan files listed in FILE, one per line.
+
 .. option:: -r --recursive
 
   Recursively search for directories. It follows symlinks.

--- a/yara.man
+++ b/yara.man
@@ -80,6 +80,9 @@ Print the tags associated to the rule.
 .B \-r " --recursive"
 Scan files in directories recursively. It follows symlinks.
 .TP
+.BI "    --scan-list"
+Scan files listed in FILE, one per line.
+.TP
 .BI \-k " slots" " --stack-size=" slots
 Set maximum stack size to the specified number of
 .I slots.


### PR DESCRIPTION
Continuation of #1254.

Adds a new mode (`--scan-list`) to `/usr/bin/yara` that scans multiple files and directories (with or without recursion/`-r`, as usual).  `FILE` (final argument) is not scanned itself in this mode, but instead contains the scan list, one item (file or directory) per line.

The use case is a vast collection of potential targets (in a flat directory or a dense tree) and curated set of actual scan targets (e.g., contextual tags).

Code footprint is small, dovetailing into existing `scan_dir` and `file_queue_put`.

Command-line convention is maintained:
* `yara [OPTION]... [NAMESPACE:]RULES_FILE... FILE | DIR | PID`.

A very rough test script (not intended to thoroughly exercise):

```bash
#!/bin/bash -x

YARA=/build/yara-e66b1385/bin/yara
#FLAGS=-r --scan-list
FLAGS=--scan-list

DIR=$(mktemp -d)
RULE_FILE=$DIR/rule.yara
SCAN_FILE=$DIR/to-scan.txt
FILES=$DIR/files

mkdir -p $FILES/manual $FILES/wanted $FILES/unwanted
echo "rule hit {condition: true}" > $RULE_FILE
for FILE in \
    $FILES/wanted/yes \
    $FILES/unwanted/no \
    $FILES/manual/yes \
    $FILES/manual/no; do
  touch $FILE
done
echo -e "$FILES/wanted\n$FILES/manual/yes" > $SCAN_FILE
$YARA $FLAGS $RULE_FILE $SCAN_FILE
echo "User needs to manually clean: $DIR"
```

```bash
$ ./run-test.sh
+ YARA=/build/yara-e66b1385/bin/yara
+ FLAGS=--scan-list
++ mktemp -d
+ DIR=/tmp/tmp.TInnsm9Gse
+ RULE_FILE=/tmp/tmp.TInnsm9Gse/rule.yara
+ SCAN_FILE=/tmp/tmp.TInnsm9Gse/to-scan.txt
+ FILES=/tmp/tmp.TInnsm9Gse/files
+ mkdir -p /tmp/tmp.TInnsm9Gse/files/manual /tmp/tmp.TInnsm9Gse/files/wanted /tmp/tmp.TInnsm9Gse/files/unwanted
+ echo 'rule hit {condition: true}'
+ for FILE in $FILES/wanted/yes $FILES/unwanted/no $FILES/manual/yes $FILES/manual/no
+ touch /tmp/tmp.TInnsm9Gse/files/wanted/yes
+ for FILE in $FILES/wanted/yes $FILES/unwanted/no $FILES/manual/yes $FILES/manual/no
+ touch /tmp/tmp.TInnsm9Gse/files/unwanted/no
+ for FILE in $FILES/wanted/yes $FILES/unwanted/no $FILES/manual/yes $FILES/manual/no
+ touch /tmp/tmp.TInnsm9Gse/files/manual/yes
+ for FILE in $FILES/wanted/yes $FILES/unwanted/no $FILES/manual/yes $FILES/manual/no
+ touch /tmp/tmp.TInnsm9Gse/files/manual/no
+ echo -e '/tmp/tmp.TInnsm9Gse/files/wanted\n/tmp/tmp.TInnsm9Gse/files/manual/yes'
+ /build/yara-e66b1385/bin/yara --scan-list /tmp/tmp.TInnsm9Gse/rule.yara /tmp/tmp.TInnsm9Gse/to-scan.txt
hit /tmp/tmp.TInnsm9Gse/files/wanted/yes
hit /tmp/tmp.TInnsm9Gse/files/manual/yes
+ echo 'User needs to manually clean: /tmp/tmp.TInnsm9Gse'
User needs to manually clean: /tmp/tmp.TInnsm9Gse
```

As discussed in #1254, this PR uses POSIX.1-2008 `getline(3)` (`strok_s` for Windows) to parse the scan list file line by line.

See also historical #550.  I believe the code contribution here is value-add. 