### PR TITLE
Add `copts` option to `yara_library`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,9 +53,12 @@ config_setting(
     values = {"define": "yara_crypto_library=boringssl"},
 )
 
-
 yara_library(
     name = "libyara",
+    crypto_libs = select({
+        ":crypto_library_boringssl": ["@boringssl//:crypto"],
+        "//conditions:default": ["@openssl//:crypto"],
+    }),
     defines = select({
         ":profiling_enabled": ["YR_PROFILING_ENABLED"],
         "//conditions:default": [],
@@ -90,16 +93,11 @@ yara_library(
         "libyara/modules/tests/tests.c",
         "libyara/modules/time/time.c",
     ],
-    crypto_libs = select({
-        ":crypto_library_boringssl": ["@boringssl//:crypto"],
-        "//conditions:default": ["@openssl//:crypto"],
-    }),
     deps = [
-        "@jansson//:jansson",
-        "@magic//:magic",
-    ]
+        "@jansson",
+        "@magic",
+    ],
 )
-
 
 # Code shared by the command-line tools.
 cc_library(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -30,18 +30,22 @@
 workspace(name = "com_github_virustotal_yara")
 
 load("//:bazel/yara_deps.bzl", "yara_deps")
-yara_deps()
 
+yara_deps()
 
 load(
     "@rules_proto//proto:repositories.bzl",
-    "rules_proto_dependencies", "rules_proto_toolchains"
+    "rules_proto_dependencies",
+    "rules_proto_toolchains",
 )
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 load(
     "@com_google_sandboxed_api//sandboxed_api/bazel:sapi_deps.bzl",
     "sapi_deps",
 )
+
 sapi_deps()

--- a/bazel/jansson.BUILD
+++ b/bazel/jansson.BUILD
@@ -44,12 +44,12 @@ genrule(
 
 cc_library(
     name = "jansson",
+    srcs = glob(["src/*.c"]),
     hdrs = glob(["src/*.h"]) + [
         "jansson_config.h",
         "jansson_private_config.h",
     ],
-    srcs = glob(["src/*.c"]),
-    includes = [".", "src"],
+    copts = ["-Wno-unused-function"],
     # These defines are usually in jansson_config.h but we define them here,
     # as jansson_config.h is just an empty file.
     defines = [
@@ -57,26 +57,43 @@ cc_library(
         "JSON_INLINE=inline",
         "JSON_PARSER_MAX_DEPTH=2048",
     ],
-    copts = ["-Wno-unused-function"],
+    includes = [
+        ".",
+        "src",
+    ],
     visibility = ["//visibility:public"],
 )
-
 
 load("@com_github_virustotal_yara//:bazel/jansson.bzl", "jansson_api_test")
 
 jansson_api_test("test_array")
+
 jansson_api_test("test_chaos")
+
 jansson_api_test("test_copy")
+
 jansson_api_test("test_dump")
+
 jansson_api_test("test_dump_callback")
+
 jansson_api_test("test_equal")
+
 jansson_api_test("test_load")
+
 jansson_api_test("test_load_callback")
+
 jansson_api_test("test_loadb")
+
 jansson_api_test("test_memory_funcs")
+
 jansson_api_test("test_number")
+
 jansson_api_test("test_object")
+
 jansson_api_test("test_pack")
+
 jansson_api_test("test_simple")
+
 jansson_api_test("test_sprintf")
+
 jansson_api_test("test_unpack")

--- a/bazel/jansson.bzl
+++ b/bazel/jansson.bzl
@@ -26,11 +26,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 def jansson_api_test(name):
-  native.cc_test(
-    name = name,
-    srcs = [
-        "test/suites/api/util.h",
-        "test/suites/api/" + name + ".c",
-    ],
-    deps = [":jansson"]
-  )
+    native.cc_test(
+        name = name,
+        srcs = [
+            "test/suites/api/util.h",
+            "test/suites/api/" + name + ".c",
+        ],
+        deps = [":jansson"],
+    )

--- a/bazel/magic.BUILD
+++ b/bazel/magic.BUILD
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2020. The YARA Authors. All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -46,7 +45,7 @@ MAGIC_COPTS = [
     # The VERSION macro usually contains the actual version (e.g: "5.38") but
     # any arbitrary string will work. We simply use "BUILT_BY_YARA".
     "-DVERSION=\\\"BUILT_BY_YARA\\\"",
-    ] + select({
+] + select({
     "@bazel_tools//src/conditions:darwin": [
         "-DHAVE_FORK=1",
         "-DHAVE_INTTYPES_H=1",
@@ -76,12 +75,11 @@ MAGIC_COPTS = [
         "-DHAVE_UNISTD_H=1",
     ],
     "@bazel_tools//src/conditions:windows": [
-    ]
+    ],
 })
 
 cc_library(
     name = "magic",
-    hdrs = ["src/magic.h"],
     srcs = glob(["src/*.h"]) + [
         "src/apprentice.c",
         "src/apptype.c",
@@ -117,23 +115,28 @@ cc_library(
         "src/teststrchr.c",
         "src/vasprintf.c",
     ] + select({
-    "@bazel_tools//src/conditions:darwin": [
-    ],
-    "@bazel_tools//src/conditions:freebsd": [
-    ],
-    "@bazel_tools//src/conditions:linux_aarch64": [
-        "src/strlcat.c",
-        "src/strlcpy.c",
-    ],
-    "@bazel_tools//src/conditions:linux_x86_64": [
-        "src/strlcat.c",
-        "src/strlcpy.c",
-    ],
-    "@bazel_tools//src/conditions:windows": [
-        "src/strlcat.c",
-        "src/strlcpy.c",
-    ]}),
-    includes = [".", "src"],
+        "@bazel_tools//src/conditions:darwin": [
+        ],
+        "@bazel_tools//src/conditions:freebsd": [
+        ],
+        "@bazel_tools//src/conditions:linux_aarch64": [
+            "src/strlcat.c",
+            "src/strlcpy.c",
+        ],
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "src/strlcat.c",
+            "src/strlcpy.c",
+        ],
+        "@bazel_tools//src/conditions:windows": [
+            "src/strlcat.c",
+            "src/strlcpy.c",
+        ],
+    }),
+    hdrs = ["src/magic.h"],
     copts = MAGIC_COPTS,
+    includes = [
+        ".",
+        "src",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/openssl.BUILD
+++ b/bazel/openssl.BUILD
@@ -37,28 +37,34 @@ config_setting(
 
 cc_library(
     name = "crypto",
-    hdrs = glob(["include/openssl/*.h"]) + ["include/openssl/opensslconf.h"],
     srcs = ["libcrypto.a"],
+    hdrs = glob(["include/openssl/*.h"]) + ["include/openssl/opensslconf.h"],
     includes = ["include"],
     linkopts = select({
         ":darwin": [],
-        "//conditions:default": ["-lpthread", "-ldl"],
+        "//conditions:default": [
+            "-lpthread",
+            "-ldl",
+        ],
     }),
     visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "ssl",
-    deps = [":crypto"],
-    hdrs = glob(["include/openssl/*.h"]) + ["include/openssl/opensslconf.h"],
     srcs = ["libssl.a"],
+    hdrs = glob(["include/openssl/*.h"]) + ["include/openssl/opensslconf.h"],
     includes = ["include"],
     visibility = ["//visibility:public"],
+    deps = [":crypto"],
 )
 
 genrule(
     name = "openssl-build",
-    srcs = glob(["**/*"], exclude=["bazel-*"]),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["bazel-*"],
+    ),
     outs = [
         "libcrypto.a",
         "libssl.a",

--- a/bazel/yara.bzl
+++ b/bazel/yara.bzl
@@ -1,4 +1,3 @@
-
 YARA_CONFIG_OPTS = [
     "-DHAVE_CLOCK_GETTIME=1",
     #"-DHAVE_COMMONCRYPTO_COMMONCRYPTO_H",
@@ -44,12 +43,11 @@ YARA_COPTS = YARA_CONFIG_OPTS + [
     "//conditions:default": ["-DUSE_NO_PROC"],
 })
 
-
 # Define rule for generating the module_list file. This rule has an attribute
 # "modules" which is a list of module names that we want in the file.
 def _module_list_impl(ctx):
     output = ctx.outputs.out
-    content = '\n'.join(["MODULE(%s)" % m for m in ctx.attr.modules])
+    content = "\n".join(["MODULE(%s)" % m for m in ctx.attr.modules])
     ctx.actions.write(output = output, content = content)
 
 module_list = rule(
@@ -58,149 +56,154 @@ module_list = rule(
     outputs = {"out": "libyara/modules/module_list"},
 )
 
+def yara_library(
+        name,
+        defines = [],
+        modules = [],
+        modules_srcs = [],
+        deps = [],
+        copts = YARA_COPTS,
+        crypto_libs = ["@openssl//:crypto"]):
+    """Macro for generating the YARA library with a specific list of modules.
 
-def yara_library(name, defines=[], modules=[], modules_srcs=[],
-                 deps=[], crypto_libs=["@openssl//:crypto"]):
-  """Macro for generating the YARA library with a specific list of modules.
+    This macro allows to cherry-pick the modules that you want to build into the
+    library. For example, for building it with modules pe and elf only, you can
+    use:
 
-  This macro allows to cherry-pick the modules that you want to build into the
-  library. For example, for building it with modules pe and elf only, you can
-  use:
+    yara_library(
+      name = "libyara",
+      modules = [
+          "cuckoo",
+          "dex",
+          "dotnet",
+          "elf",
+      ],
+      modules_srcs = [
+          "libyara/modules/elf/elf.c",
+          "libyara/modules/pe/pe.c",
+          "libyara/modules/pe/pe_utils.c",
+      ]
+    )
 
-  yara_library(
-    name = "libyara",
-    modules = [
-        "cuckoo",
-        "dex",
-        "dotnet",
-        "elf",
-    ],
-    modules_srcs = [
-        "libyara/modules/elf/elf.c",
-        "libyara/modules/pe/pe.c",
-        "libyara/modules/pe/pe_utils.c",
-    ]
-  )
+    The "modules_srcs" list must contain the source files implementing the modules
+    listed in the "modules" argument.
+    """
+    module_list(
+        name = "module_list",
+        modules = modules,
+    )
 
-  The "modules_srcs" list must contain the source files implementing the modules
-  listed in the "modules" argument.
-  """
-  module_list(
-      name = "module_list",
-      modules = modules,
-  )
-
-  native.cc_library(
-    name = name,
-    defines = defines + [m.upper() + "_MODULE" for m in modules],
-    srcs = modules_srcs + [
-        "libyara/ahocorasick.c",
-        "libyara/arena.c",
-        "libyara/atoms.c",
-        "libyara/base64.c",
-        "libyara/bitmask.c",
-        "libyara/compiler.c",
-        "libyara/crypto.h",
-        "libyara/endian.c",
-        "libyara/exception.h",
-        "libyara/exec.c",
-        "libyara/exefiles.c",
-        "libyara/filemap.c",
-        "libyara/grammar.c",
-        "libyara/hash.c",
-        "libyara/hex_grammar.c",
-        "libyara/hex_grammar.h",
-        "libyara/hex_lexer.c",
-        "libyara/include/yara.h",
-        "libyara/include/yara/ahocorasick.h",
-        "libyara/include/yara/arena.h",
-        "libyara/include/yara/atoms.h",
-        "libyara/include/yara/base64.h",
-        "libyara/include/yara/bitmask.h",
-        "libyara/include/yara/compiler.h",
-        "libyara/include/yara/dex.h",
-        "libyara/include/yara/dotnet.h",
-        "libyara/include/yara/elf.h",
-        "libyara/include/yara/endian.h",
-        "libyara/include/yara/error.h",
-        "libyara/include/yara/exec.h",
-        "libyara/include/yara/exefiles.h",
-        "libyara/include/yara/filemap.h",
-        "libyara/include/yara/globals.h",
-        "libyara/include/yara/hash.h",
-        "libyara/include/yara/hex_lexer.h",
-        "libyara/include/yara/integers.h",
-        "libyara/include/yara/lexer.h",
-        "libyara/include/yara/libyara.h",
-        "libyara/include/yara/limits.h",
-        "libyara/include/yara/macho.h",
-        "libyara/include/yara/mem.h",
-        "libyara/include/yara/modules.h",
-        "libyara/include/yara/notebook.h",
-        "libyara/include/yara/object.h",
-        "libyara/include/yara/parser.h",
-        "libyara/include/yara/pe.h",
-        "libyara/include/yara/pe_utils.h",
-        "libyara/include/yara/proc.h",
-        "libyara/include/yara/re.h",
-        "libyara/include/yara/re_lexer.h",
-        "libyara/include/yara/rules.h",
-        "libyara/include/yara/scan.h",
-        "libyara/include/yara/scanner.h",
-        "libyara/include/yara/sizedstr.h",
-        "libyara/include/yara/stack.h",
-        "libyara/include/yara/stopwatch.h",
-        "libyara/include/yara/stream.h",
-        "libyara/include/yara/strutils.h",
-        "libyara/include/yara/threading.h",
-        "libyara/include/yara/types.h",
-        "libyara/include/yara/utils.h",
-        "libyara/lexer.c",
-        "libyara/libyara.c",
-        "libyara/mem.c",
-        "libyara/modules.c",
-        "libyara/notebook.c",
-        "libyara/object.c",
-        "libyara/parser.c",
-        "libyara/proc.c",
-        "libyara/proc/freebsd.c",
-        "libyara/proc/linux.c",
-        "libyara/proc/mach.c",
-        "libyara/proc/none.c",
-        "libyara/proc/openbsd.c",
-        "libyara/proc/windows.c",
-        "libyara/re.c",
-        "libyara/re_grammar.c",
-        "libyara/re_grammar.h",
-        "libyara/re_lexer.c",
-        "libyara/rules.c",
-        "libyara/scan.c",
-        "libyara/scanner.c",
-        "libyara/sizedstr.c",
-        "libyara/stack.c",
-        "libyara/stopwatch.c",
-        "libyara/stream.c",
-        "libyara/strutils.c",
-        "libyara/threading.c",
-    ],
-    hdrs = [
-        "libyara/include/yara.h",
-        "libyara/include/yara/pe.h",
-        "libyara/include/yara/proc.h",
-        "libyara/include/yara/rules.h",
-    ],
-    copts = YARA_COPTS,
-    includes = [
-        "libyara/modules",
-        "libyara/include",
-        "libyara",
-    ],
-    textual_hdrs = [
-        ":module_list",
-        "libyara/grammar.h",
-        "libyara/hex_grammar.y",
-        "libyara/re_grammar.y",
-    ],
-    deps = deps + crypto_libs,
-    visibility = ["//visibility:public"],
-  )
+    native.cc_library(
+        name = name,
+        defines = defines + [m.upper() + "_MODULE" for m in modules],
+        srcs = modules_srcs + [
+            "libyara/ahocorasick.c",
+            "libyara/arena.c",
+            "libyara/atoms.c",
+            "libyara/base64.c",
+            "libyara/bitmask.c",
+            "libyara/compiler.c",
+            "libyara/crypto.h",
+            "libyara/endian.c",
+            "libyara/exception.h",
+            "libyara/exec.c",
+            "libyara/exefiles.c",
+            "libyara/filemap.c",
+            "libyara/grammar.c",
+            "libyara/hash.c",
+            "libyara/hex_grammar.c",
+            "libyara/hex_grammar.h",
+            "libyara/hex_lexer.c",
+            "libyara/include/yara.h",
+            "libyara/include/yara/ahocorasick.h",
+            "libyara/include/yara/arena.h",
+            "libyara/include/yara/atoms.h",
+            "libyara/include/yara/base64.h",
+            "libyara/include/yara/bitmask.h",
+            "libyara/include/yara/compiler.h",
+            "libyara/include/yara/dex.h",
+            "libyara/include/yara/dotnet.h",
+            "libyara/include/yara/elf.h",
+            "libyara/include/yara/endian.h",
+            "libyara/include/yara/error.h",
+            "libyara/include/yara/exec.h",
+            "libyara/include/yara/exefiles.h",
+            "libyara/include/yara/filemap.h",
+            "libyara/include/yara/globals.h",
+            "libyara/include/yara/hash.h",
+            "libyara/include/yara/hex_lexer.h",
+            "libyara/include/yara/integers.h",
+            "libyara/include/yara/lexer.h",
+            "libyara/include/yara/libyara.h",
+            "libyara/include/yara/limits.h",
+            "libyara/include/yara/macho.h",
+            "libyara/include/yara/mem.h",
+            "libyara/include/yara/modules.h",
+            "libyara/include/yara/notebook.h",
+            "libyara/include/yara/object.h",
+            "libyara/include/yara/parser.h",
+            "libyara/include/yara/pe.h",
+            "libyara/include/yara/pe_utils.h",
+            "libyara/include/yara/proc.h",
+            "libyara/include/yara/re.h",
+            "libyara/include/yara/re_lexer.h",
+            "libyara/include/yara/rules.h",
+            "libyara/include/yara/scan.h",
+            "libyara/include/yara/scanner.h",
+            "libyara/include/yara/sizedstr.h",
+            "libyara/include/yara/stack.h",
+            "libyara/include/yara/stopwatch.h",
+            "libyara/include/yara/stream.h",
+            "libyara/include/yara/strutils.h",
+            "libyara/include/yara/threading.h",
+            "libyara/include/yara/types.h",
+            "libyara/include/yara/utils.h",
+            "libyara/lexer.c",
+            "libyara/libyara.c",
+            "libyara/mem.c",
+            "libyara/modules.c",
+            "libyara/notebook.c",
+            "libyara/object.c",
+            "libyara/parser.c",
+            "libyara/proc.c",
+            "libyara/proc/freebsd.c",
+            "libyara/proc/linux.c",
+            "libyara/proc/mach.c",
+            "libyara/proc/none.c",
+            "libyara/proc/openbsd.c",
+            "libyara/proc/windows.c",
+            "libyara/re.c",
+            "libyara/re_grammar.c",
+            "libyara/re_grammar.h",
+            "libyara/re_lexer.c",
+            "libyara/rules.c",
+            "libyara/scan.c",
+            "libyara/scanner.c",
+            "libyara/sizedstr.c",
+            "libyara/stack.c",
+            "libyara/stopwatch.c",
+            "libyara/stream.c",
+            "libyara/strutils.c",
+            "libyara/threading.c",
+        ],
+        hdrs = [
+            "libyara/include/yara.h",
+            "libyara/include/yara/pe.h",
+            "libyara/include/yara/proc.h",
+            "libyara/include/yara/rules.h",
+        ],
+        copts = copts,
+        includes = [
+            "libyara/modules",
+            "libyara/include",
+            "libyara",
+        ],
+        textual_hdrs = [
+            ":module_list",
+            "libyara/grammar.h",
+            "libyara/hex_grammar.y",
+            "libyara/re_grammar.y",
+        ],
+        deps = deps + crypto_libs,
+        visibility = ["//visibility:public"],
+    )

--- a/bazel/yara_deps.bzl
+++ b/bazel/yara_deps.bzl
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2020. The YARA Authors. All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -27,8 +26,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Load dependencies needed to compile YARA as a 3rd-party consumer."""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def yara_deps():
     """Loads common dependencies needed to compile YARA."""


### PR DESCRIPTION
This allows for more customization for Alphabet-internal builds.

Follow-up PRs will update/fix the Sandboxed API dependency.

Drive-by:
- Ran this through buildifier, which reformatted the Bazel files a bit.

Signed-off-by: Christian Blichmann <cblichmann@google.com>