### PR TITLE
Update YARA Sandboxed API for 4.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Build in C++17 mode without a custom CROSSTOOL
+build --cxxopt=-std=c++17

--- a/bazel/yara_deps.bzl
+++ b/bazel/yara_deps.bzl
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2020. The YARA Authors. All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -27,66 +26,68 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Load dependencies needed to compile YARA as a 3rd-party consumer."""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def yara_deps():
     """Loads common dependencies needed to compile YARA."""
-    if not native.existing_rule("openssl"):
-        http_archive(
-            name = "openssl",
-            url = "https://github.com/openssl/openssl/archive/OpenSSL_1_1_0h.tar.gz",
-            sha256 = "f56dd7d81ce8d3e395f83285bd700a1098ed5a4cb0a81ce9522e41e6db7e0389",
-            strip_prefix = "openssl-OpenSSL_1_1_0h",
-            build_file = "@com_github_virustotal_yara//:bazel/openssl.BUILD",
-        )
-    if not native.existing_rule("borinssl"):
-        git_repository(
-            name = "boringssl",
-            commit = "095d78b14f91cc9a910408eaae84a3bdafc54da9",  # 2019-06-05
-            remote = "https://boringssl.googlesource.com/boringssl",
-            shallow_since = "1559759280 +0000",
-        )
-    if not native.existing_rule("jansson"):
-        http_archive(
-            name = "jansson",
-            url = "https://github.com/akheron/jansson/archive/v2.12.tar.gz",
-            sha256 = "76260d30e9bbd0ef392798525e8cd7fe59a6450c54ca6135672e3cd6a1642941",
-            strip_prefix = "jansson-2.12",
-            build_file = "@com_github_virustotal_yara//:bazel/jansson.BUILD",
-        )
-    if not native.existing_rule("magic"):
+    maybe(
+        http_archive,
+        name = "openssl",
+        url = "https://github.com/openssl/openssl/archive/OpenSSL_1_1_0h.tar.gz",
+        sha256 = "f56dd7d81ce8d3e395f83285bd700a1098ed5a4cb0a81ce9522e41e6db7e0389",
+        strip_prefix = "openssl-OpenSSL_1_1_0h",
+        build_file = "@com_github_virustotal_yara//:bazel/openssl.BUILD",
+    )
+    maybe(
+        git_repository,
+        name = "boringssl",
+        commit = "095d78b14f91cc9a910408eaae84a3bdafc54da9",  # 2019-06-05
+        remote = "https://boringssl.googlesource.com/boringssl",
+        shallow_since = "1559759280 +0000",
+    )
+    maybe(
+        http_archive,
+        name = "jansson",
+        url = "https://github.com/akheron/jansson/archive/v2.12.tar.gz",
+        sha256 = "76260d30e9bbd0ef392798525e8cd7fe59a6450c54ca6135672e3cd6a1642941",
+        strip_prefix = "jansson-2.12",
+        build_file = "@com_github_virustotal_yara//:bazel/jansson.BUILD",
+    )
+    maybe(
         # When updating this dependency to a more recent version, the version
         # in the bazel/magic.BUILD must be updated acordingly.
-        http_archive(
-            name = "magic",
-            url = "https://github.com/file/file/archive/FILE5_38.tar.gz",
-            sha256 = "338ebe8cb536a3f86750b4df62be2d382f6da66afdb0087b36a1a3e14ea4baf8",
-            strip_prefix = "file-FILE5_38",
-            build_file = "@com_github_virustotal_yara//:bazel/magic.BUILD",
-        )
-    if not native.existing_rule("com_google_sandboxed_api"):
-        git_repository(
-            name = "com_google_sandboxed_api",
-            commit = "2301e05097818734f59b881d7fbe1624c17fc840",  # 2019-07-08
-            remote = "https://github.com/google/sandboxed-api.git",
-            shallow_since = "1562590596 -0700",
-        )
-    if not native.existing_rule("rules_proto"):
-        http_archive(
-            name = "rules_proto",
-            sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-            strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-            urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-                "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-            ],
-        )
-    if not native.existing_rule("com_google_googletest"):
+        http_archive,
+        name = "magic",
+        url = "https://github.com/file/file/archive/FILE5_38.tar.gz",
+        sha256 = "338ebe8cb536a3f86750b4df62be2d382f6da66afdb0087b36a1a3e14ea4baf8",
+        strip_prefix = "file-FILE5_38",
+        build_file = "@com_github_virustotal_yara//:bazel/magic.BUILD",
+    )
+    maybe(
+        git_repository,
+        name = "com_google_sandboxed_api",
+        commit = "aafc597630ecf22e32ae71fdd45cab8c43584e65",  # 2020-04-30
+        remote = "https://github.com/google/sandboxed-api.git",
+        shallow_since = "1588247853 -0700",
+    )
+    maybe(
+        http_archive,
+        name = "rules_proto",
+        sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+        strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        ],
+    )
+    maybe(
         # GoogleTest/GoogleMock for testing the sandbox
-        http_archive(
-            name = "com_google_googletest",
-            sha256 = "baed63b97595c32667694de0a434f8f23da59609c4a44f3360ba94b0abd5c583",
-            strip_prefix = "googletest-8ffb7e5c88b20a297a2e786c480556467496463b",
-            urls = ["https://github.com/google/googletest/archive/8ffb7e5c88b20a297a2e786c480556467496463b.zip"],  # 2019-05-30
-        )
+        http_archive,
+        name = "com_google_googletest",
+        sha256 = "ba5b04a4849246e7c16ba94227eed46486ef942f61dc8b78609732543c19c9f4",  # 2019-11-21
+        strip_prefix = "googletest-200ff599496e20f4e39566feeaf2f6734ca7570f",
+        urls = ["https://github.com/google/googletest/archive/200ff599496e20f4e39566feeaf2f6734ca7570f.zip"],
+    )

--- a/bazel/yara_deps.bzl
+++ b/bazel/yara_deps.bzl
@@ -69,9 +69,9 @@ def yara_deps():
     maybe(
         git_repository,
         name = "com_google_sandboxed_api",
-        commit = "aafc597630ecf22e32ae71fdd45cab8c43584e65",  # 2020-04-30
+        commit = "144a441d798f13d27cc71e7c2a630e0063d747b5",  # 2020-05-12
         remote = "https://github.com/google/sandboxed-api.git",
-        shallow_since = "1588247853 -0700",
+        shallow_since = "1589270865 -0700",
     )
     maybe(
         http_archive,

--- a/sandbox/BUILD.bazel
+++ b/sandbox/BUILD.bazel
@@ -25,10 +25,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-
+load(
+    "@com_google_sandboxed_api//sandboxed_api/bazel:proto.bzl",
+    "sapi_proto_library",
+)
 load(
     "@com_google_sandboxed_api//sandboxed_api/bazel:sapi.bzl",
     "sapi_library",
@@ -36,14 +38,9 @@ load(
 
 # Proto message that stores YARA matches. Used to communicate matches from
 # the sandboxee to the host code.
-proto_library(
+sapi_proto_library(
     name = "yara_matches",
     srcs = ["yara_matches.proto"],
-)
-
-cc_proto_library(
-    name = "yara_matches_cc_proto",
-    deps = [":yara_matches"],
 )
 
 # Library with a callback function to collect YARA matches into a YaraMatches

--- a/sandbox/collect_matches.cc
+++ b/sandbox/collect_matches.cc
@@ -34,7 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace yara {
 
-int CollectMatches(int message, void* message_data, void* user_data) {
+int CollectMatches(YR_SCAN_CONTEXT*, int message, void* message_data,
+                   void* user_data) {
   if (message != CALLBACK_MSG_RULE_MATCHING) {
     return ERROR_SUCCESS;  // There are no matching rules, simply return
   }
@@ -47,7 +48,7 @@ int CollectMatches(int message, void* message_data, void* user_data) {
     match->mutable_id()->set_rule_namespace(rule->ns->name);
   }
   match->mutable_id()->set_rule_name(rule->identifier);
-  while (!META_IS_NULL(rule_meta)) {
+  yr_rule_metas_foreach(rule, rule_meta) {
     auto* meta = match->add_meta();
     meta->set_identifier(rule_meta->identifier);
     switch (rule_meta->type) {

--- a/sandbox/collect_matches.h
+++ b/sandbox/collect_matches.h
@@ -30,11 +30,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef SANDBOX_COLLECT_MATCHES_H_
 #define SANDBOX_COLLECT_MATCHES_H_
 
+struct YR_SCAN_CONTEXT;
+
 namespace yara {
 
 // Callback function for yr_scan_mem() that collects YARA matches in a
 // YaraMatches proto given in user_data.
-int CollectMatches(int message, void* message_data, void* user_data);
+int CollectMatches(YR_SCAN_CONTEXT*, int message, void* message_data,
+                   void* user_data);
 
 }  // namespace yara
 

--- a/sandbox/yara_transaction.h
+++ b/sandbox/yara_transaction.h
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "sandbox/yara_matches.pb.h"

--- a/sandbox/yara_transaction_test.cc
+++ b/sandbox/yara_transaction_test.cc
@@ -63,17 +63,16 @@ class MemoryFD {
     mem_fd.fd_ = syscall(__NR_memfd_create, reinterpret_cast<uintptr_t>(kName),
                          MFD_CLOEXEC);
     if (mem_fd.fd_ == -1) {
-      return ::sapi::UnknownError(absl::StrCat("memfd(): ", strerror(errno)));
+      return absl::UnknownError(absl::StrCat("memfd(): ", strerror(errno)));
     }
     if (ftruncate(mem_fd.fd_, content.size()) == -1) {
-      return ::sapi::UnknownError(
-          absl::StrCat("ftruncate(): ", strerror(errno)));
+      return absl::UnknownError(absl::StrCat("ftruncate(): ", strerror(errno)));
     }
     while (!content.empty()) {
       ssize_t written =
           TEMP_FAILURE_RETRY(write(mem_fd.fd_, content.data(), content.size()));
       if (written <= 0) {
-        return ::sapi::UnknownError(absl::StrCat("write(): ", strerror(errno)));
+        return absl::UnknownError(absl::StrCat("write(): ", strerror(errno)));
       }
       content.remove_prefix(written);
     }


### PR DESCRIPTION
This PR updates YARA's sandbox to use the latest Sandboxed API and makes it compatible to the API changes in YARA 4.0.

Other changes:
- Updated Bazel dependencies to use `maybe()`
- Update to latest Abseil and newer GoogleTest to match what Sandboxed API uses (to avoid duplication)
- Force C++ parts to be build with C++17, as that is required for the sandbox