### PR TITLE
Fixed use-after-free bug in PE module

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1552,11 +1552,12 @@ static void pe_parse_certificates(
     end = (uintptr_t)((uint8_t*) win_cert) + yr_le32toh(win_cert->Length);
     while ((uintptr_t) cert_p < end && counter < MAX_PE_CERTS)
     {
-      pkcs7 = d2i_PKCS7(NULL, &cert_p, (yr_le32toh(win_cert->Length)));
+      pkcs7 = d2i_PKCS7(NULL, &cert_p, (yr_le32toh( (uint32_t)((uintptr_t)end - (uintptr_t)cert_p)) ));
       if (pkcs7 == NULL)
         break;
       _parse_pkcs7(pe, pkcs7, &counter);
       PKCS7_free(pkcs7);
+      pkcs7 = NULL;
     }
 
     win_cert = (PWIN_CERTIFICATE) (end + (end % 8));


### PR DESCRIPTION
The bug was triggered by digitally signed malformed PE file (md5: fd6d7a3b087e9a0d6d4abafb47701da0).
To reproduce, run any rule that does import "pe". The bug effects may vary depending on your memory state.