### PR TITLE
Fixed possible referencing of an uninitialized value

### DIFF
--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -194,6 +194,7 @@ BLOB_PARSE_RESULT dotnet_parse_blob_entry(
   {
     // Return a 0 size as an error.
     result.size = 0;
+    return result;
   }
 
   // There is an additional terminal byte which is 0x01 under certain


### PR DESCRIPTION
This pull request fixes an access to a possible uninitialized `result.length` variable, which occurs when
the code flow takes branch at line 196.

When done in MS Visual Studio 2015 or newer, it throws an assertion window.
