### PR TITLE
libyara/strutils.c: fix potential null pointer dereference found by cppcheck

### DIFF
--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -233,11 +233,13 @@ void* memmem(
 {
   char *sp = (char *) haystack;
   char *pp = (char *) needle;
-  char *eos = sp + haystack_size - needle_size;
+  char *eos;
 
   if (haystack == NULL || haystack_size == 0 ||
       needle == NULL || needle_size == 0)
     return NULL;
+
+  eos = sp + haystack_size - needle_size;
 
   while (sp <= eos)
   {


### PR DESCRIPTION

libyara/strutils.c:236:18: warning: Either the condition 'haystack==NULL'
is redundant or there is pointer arithmetic with NULL pointer.