### PR TITLE
RfC: Make compiled rules smaller by adding smaller instruction variants

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -545,6 +545,29 @@ int yr_execute_code(
         push(r1);
         break;
 
+      case OP_PUSH_8:
+        r1.i = *ip;
+        ip += sizeof(uint8_t);
+        push(r1);
+        break;
+
+      case OP_PUSH_16:
+        r1.i = *(uint16_t*)(ip);
+        ip += sizeof(uint16_t);
+        push(r1);
+        break;
+
+      case OP_PUSH_32:
+        r1.i = *(uint32_t*)(ip);
+        ip += sizeof(uint32_t);
+        push(r1);
+        break;
+
+      case OP_PUSH_U:
+        r1.i = YR_UNDEFINED;
+        push(r1);
+        break;
+
       case OP_POP:
         pop(r1);
         break;

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -1276,15 +1276,13 @@ boolean_expression
 expression
     : _TRUE_
       {
-        fail_if_error(yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 1, NULL, NULL));
+        fail_if_error(yr_parser_emit_push_const(yyscanner, 1));
 
         $$.type = EXPRESSION_TYPE_BOOLEAN;
       }
     | _FALSE_
       {
-        fail_if_error(yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 0, NULL, NULL));
+        fail_if_error(yr_parser_emit_push_const(yyscanner, 0));
 
         $$.type = EXPRESSION_TYPE_BOOLEAN;
       }
@@ -2024,8 +2022,7 @@ integer_set
     : '(' integer_enumeration ')'
       {
         // $2 contains the number of integers in the enumeration
-        fail_if_error(yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, $2, NULL, NULL));
+        fail_if_error(yr_parser_emit_push_const(yyscanner, $2));
 
         fail_if_error(yr_parser_emit(
             yyscanner, OP_ITER_START_INT_ENUM, NULL));
@@ -2100,13 +2097,12 @@ string_set
     : '('
       {
         // Push end-of-list marker
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, YR_UNDEFINED, NULL, NULL);
+        yr_parser_emit_push_const(yyscanner, YR_UNDEFINED);
       }
       string_enumeration ')'
     | _THEM_
       {
-        fail_if_error(yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, YR_UNDEFINED, NULL, NULL));
+        fail_if_error(yr_parser_emit_push_const(yyscanner, YR_UNDEFINED));
 
         fail_if_error(yr_parser_emit_pushes_for_strings(
             yyscanner, "$*"));
@@ -2145,12 +2141,12 @@ for_expression
       }
     | _ALL_
       {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, YR_UNDEFINED, NULL, NULL);
+        yr_parser_emit_push_const(yyscanner, YR_UNDEFINED);
         $$ = FOR_EXPRESSION_ALL;
       }
     | _ANY_
       {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL, NULL);
+        yr_parser_emit_push_const(yyscanner, 1);
         $$ = FOR_EXPRESSION_ANY;
       }
     ;
@@ -2197,8 +2193,7 @@ primary_expression
       }
     | _NUMBER_
       {
-        fail_if_error(yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, $1, NULL, NULL));
+        fail_if_error(yr_parser_emit_push_const(yyscanner, $1));
 
         $$.type = EXPRESSION_TYPE_INTEGER;
         $$.value.integer = $1;
@@ -2262,8 +2257,7 @@ primary_expression
       }
     | _STRING_OFFSET_
       {
-        int result = yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 1, NULL, NULL);
+        int result = yr_parser_emit_push_const(yyscanner, 1);
 
         if (result == ERROR_SUCCESS)
           result = yr_parser_reduce_string_identifier(
@@ -2290,8 +2284,7 @@ primary_expression
       }
     | _STRING_LENGTH_
       {
-        int result = yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 1, NULL, NULL);
+        int result = yr_parser_emit_push_const(yyscanner, 1);
 
         if (result == ERROR_SUCCESS)
           result = yr_parser_reduce_string_identifier(

--- a/libyara/include/yara/exec.h
+++ b/libyara/include/yara/exec.h
@@ -103,6 +103,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OP_JZ                      58
 #define OP_JZ_P                    59
 
+#define OP_PUSH_8                  60
+#define OP_PUSH_16                 61
+#define OP_PUSH_32                 62
+#define OP_PUSH_U                  63
 
 #define _OP_EQ            0
 #define _OP_NEQ           1

--- a/libyara/include/yara/parser.h
+++ b/libyara/include/yara/parser.h
@@ -72,6 +72,11 @@ int yr_parser_emit_with_arg_reloc(
     YR_ARENA_REF* argument_ref);
 
 
+int yr_parser_emit_push_const(
+    yyscan_t yyscanner,
+    uint64_t argument);
+
+
 int yr_parser_check_types(
     YR_COMPILER* compiler,
     YR_OBJECT_FUNCTION* function,

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -247,6 +247,49 @@ int yr_parser_emit_pushes_for_strings(
 }
 
 
+int yr_parser_emit_push_const(
+    yyscan_t yyscanner,
+    uint64_t argument)
+{
+  uint64_t u = (uint64_t)argument;
+  uint8_t buf[9];
+  int bufsz = 1;
+  if (u == YR_UNDEFINED)
+  {
+    buf[0] = OP_PUSH_U;
+  }
+  else if (u <= 0xff)
+  {
+    buf[0] = OP_PUSH_8;
+    bufsz += sizeof(uint8_t);
+    buf[1] = (uint8_t)argument;
+  }
+  else if (u <= 0xffff)
+  {
+    buf[0] = OP_PUSH_16;
+    bufsz += sizeof(uint16_t);
+    *((uint16_t*)(buf+1)) = (uint16_t)argument;
+  }
+  else if (u <= 0xffffffff)
+  {
+    buf[0] = OP_PUSH_32;
+    bufsz += sizeof(uint32_t);
+    *((uint32_t*)(buf+1)) = (uint32_t)argument;
+  }
+  else {
+    buf[0] = OP_PUSH;
+    bufsz += sizeof(uint64_t);
+    *((uint64_t*)(buf+1)) = (uint64_t)argument;
+  }
+  return yr_arena_write_data(
+      yyget_extra(yyscanner)->arena,
+      YR_CODE_SECTION,
+      buf,
+      bufsz,
+      NULL);
+}
+
+
 int yr_parser_check_types(
     YR_COMPILER* compiler,
     YR_OBJECT_FUNCTION* function,


### PR DESCRIPTION
Here's another space-saving idea I might have mentioned in my talk at the ReversingLabs event:

PUSH operations that do not involve pointers into the arena often contain small positive values or `YR_UNDEFINED`. I have added some instructions for uint8, uint16, uint32, and the special undef case.

One could probably do with 16 bits for encoding `mem[]` elements, but the `_M` instructions are far less common.

Branch instructions, on the other hand, are quite frequent and most of their offsets are small, so it might make sense to add variants that use an int8 operand.