### PR TITLE
Make compiled rules smaller by not saving the same string twice.

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -268,13 +268,13 @@ YR_API int yr_compiler_create(
   result = yr_hash_table_create(5000, &new_compiler->rules_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(5000, &new_compiler->objects_table);
+    result = yr_hash_table_create(1000, &new_compiler->objects_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(5000, &new_compiler->strings_table);
+    result = yr_hash_table_create(10000, &new_compiler->strings_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(5000, &new_compiler->sz_table);
+    result = yr_hash_table_create(10000, &new_compiler->sz_table);
 
   if (result == ERROR_SUCCESS)
     result = yr_arena_create(

--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -265,16 +265,16 @@ YR_API int yr_compiler_create(
   new_compiler->atoms_config.quality_warning_threshold = \
       YR_ATOM_QUALITY_WARNING_THRESHOLD;
 
-  result = yr_hash_table_create(10007, &new_compiler->rules_table);
+  result = yr_hash_table_create(5000, &new_compiler->rules_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(10007, &new_compiler->objects_table);
+    result = yr_hash_table_create(5000, &new_compiler->objects_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(10000, &new_compiler->strings_table);
+    result = yr_hash_table_create(5000, &new_compiler->strings_table);
 
   if (result == ERROR_SUCCESS)
-    result = yr_hash_table_create(50000, &new_compiler->sz_table);
+    result = yr_hash_table_create(5000, &new_compiler->sz_table);
 
   if (result == ERROR_SUCCESS)
     result = yr_arena_create(

--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -675,9 +675,9 @@ static const yytype_uint16 yyrline[] =
     1732,  1731,  1777,  1776,  1820,  1827,  1834,  1841,  1848,  1855,
     1862,  1866,  1874,  1894,  1922,  1996,  2024,  2033,  2042,  2066,
     2081,  2101,  2100,  2106,  2118,  2119,  2124,  2131,  2142,  2146,
-    2151,  2160,  2164,  2172,  2184,  2198,  2206,  2213,  2239,  2251,
-    2263,  2279,  2291,  2307,  2350,  2371,  2406,  2441,  2475,  2500,
-    2517,  2527,  2537,  2547,  2557,  2577,  2597
+    2151,  2160,  2164,  2172,  2184,  2198,  2206,  2213,  2238,  2250,
+    2262,  2278,  2290,  2306,  2349,  2370,  2405,  2440,  2474,  2499,
+    2516,  2526,  2536,  2546,  2556,  2576,  2596
 };
 #endif
 
@@ -1950,10 +1950,10 @@ yyreduce:
         char* tag = (char*) yr_arena_ref_to_ptr(
             compiler->arena, &(yyval.tag));
 
-	// Search for duplicated tags. Tags are written one after
-	// the other, with zeroes in between (i.e: tag1/0tag2/0tag3)
-	// that's why can use tag < new_tag as the condition for the
-	// loop.
+        // Search for duplicated tags. Tags are written one after
+        // the other, with zeroes in between (i.e: tag1/0tag2/0tag3)
+        // that's why can use tag < new_tag as the condition for the
+        // loop.
         while (tag < new_tag)
         {
           if (strcmp(tag, new_tag) == 0)
@@ -2517,8 +2517,8 @@ yyreduce:
           {
             YR_ARENA_REF ref;
 
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, (yyvsp[0].c_string), &ref);
+            result = _yr_compiler_store_string(
+                compiler, (yyvsp[0].c_string), &ref);
 
             if (result == ERROR_SUCCESS)
               result = yr_parser_emit_with_arg_reloc(
@@ -2585,8 +2585,8 @@ yyreduce:
           {
             YR_ARENA_REF ref;
 
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, (yyvsp[0].c_string), &ref);
+            result = _yr_compiler_store_string(
+                compiler, (yyvsp[0].c_string), &ref);
 
             if (result == ERROR_SUCCESS)
               result = yr_parser_emit_with_arg_reloc(
@@ -2700,8 +2700,8 @@ yyreduce:
               compiler, object_as_function((yyvsp[-3].expression).value.object), (yyvsp[-1].c_string));
 
           if (result == ERROR_SUCCESS)
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, (yyvsp[-1].c_string), &ref);
+            result = _yr_compiler_store_string(
+                compiler, (yyvsp[-1].c_string), &ref);
 
           if (result == ERROR_SUCCESS)
             result = yr_parser_emit_with_arg_reloc(
@@ -3940,9 +3940,8 @@ yyreduce:
     {
         YR_ARENA_REF ref;
 
-        int result = yr_arena_write_data(
-            compiler->arena,
-            YR_SZ_POOL,
+        int result = _yr_compiler_store_data(
+            compiler,
             (yyvsp[0].sized_string),
             (yyvsp[0].sized_string)->length + sizeof(SIZED_STRING),
             &ref);
@@ -3962,11 +3961,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_STRING;
         (yyval.expression).value.sized_string_ref = ref;
       }
-#line 3966 "grammar.c" /* yacc.c:1663  */
+#line 3965 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 128:
-#line 2240 "grammar.y" /* yacc.c:1663  */
+#line 2239 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[0].c_string), OP_COUNT, YR_UNDEFINED);
@@ -3978,11 +3977,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = YR_UNDEFINED;
       }
-#line 3982 "grammar.c" /* yacc.c:1663  */
+#line 3981 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 129:
-#line 2252 "grammar.y" /* yacc.c:1663  */
+#line 2251 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_OFFSET, YR_UNDEFINED);
@@ -3994,11 +3993,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = YR_UNDEFINED;
       }
-#line 3998 "grammar.c" /* yacc.c:1663  */
+#line 3997 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 130:
-#line 2264 "grammar.y" /* yacc.c:1663  */
+#line 2263 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -4014,11 +4013,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = YR_UNDEFINED;
       }
-#line 4018 "grammar.c" /* yacc.c:1663  */
+#line 4017 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 131:
-#line 2280 "grammar.y" /* yacc.c:1663  */
+#line 2279 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_string_identifier(
             yyscanner, (yyvsp[-3].c_string), OP_LENGTH, YR_UNDEFINED);
@@ -4030,11 +4029,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = YR_UNDEFINED;
       }
-#line 4034 "grammar.c" /* yacc.c:1663  */
+#line 4033 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 132:
-#line 2292 "grammar.y" /* yacc.c:1663  */
+#line 2291 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_emit_with_arg(
             yyscanner, OP_PUSH, 1, NULL, NULL);
@@ -4050,11 +4049,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = YR_UNDEFINED;
       }
-#line 4054 "grammar.c" /* yacc.c:1663  */
+#line 4053 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 133:
-#line 2308 "grammar.y" /* yacc.c:1663  */
+#line 2307 "grammar.y" /* yacc.c:1663  */
     {
         int result = ERROR_SUCCESS;
 
@@ -4097,11 +4096,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4101 "grammar.c" /* yacc.c:1663  */
+#line 4100 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 134:
-#line 2351 "grammar.y" /* yacc.c:1663  */
+#line 2350 "grammar.y" /* yacc.c:1663  */
     {
         int result = ERROR_SUCCESS;
 
@@ -4122,11 +4121,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4126 "grammar.c" /* yacc.c:1663  */
+#line 4125 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 135:
-#line 2372 "grammar.y" /* yacc.c:1663  */
+#line 2371 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_operation(
             yyscanner, "+", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -4161,11 +4160,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4165 "grammar.c" /* yacc.c:1663  */
+#line 4164 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 136:
-#line 2407 "grammar.y" /* yacc.c:1663  */
+#line 2406 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_operation(
             yyscanner, "-", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -4200,11 +4199,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4204 "grammar.c" /* yacc.c:1663  */
+#line 4203 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 137:
-#line 2442 "grammar.y" /* yacc.c:1663  */
+#line 2441 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_operation(
             yyscanner, "*", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -4238,11 +4237,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4242 "grammar.c" /* yacc.c:1663  */
+#line 4241 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 138:
-#line 2476 "grammar.y" /* yacc.c:1663  */
+#line 2475 "grammar.y" /* yacc.c:1663  */
     {
         int result = yr_parser_reduce_operation(
             yyscanner, "\\", (yyvsp[-2].expression), (yyvsp[0].expression));
@@ -4267,11 +4266,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4271 "grammar.c" /* yacc.c:1663  */
+#line 4270 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 139:
-#line 2501 "grammar.y" /* yacc.c:1663  */
+#line 2500 "grammar.y" /* yacc.c:1663  */
     {
         check_type((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "%");
         check_type((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "%");
@@ -4288,11 +4287,11 @@ yyreduce:
           fail_if_error(ERROR_DIVISION_BY_ZERO);
         }
       }
-#line 4292 "grammar.c" /* yacc.c:1663  */
+#line 4291 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 140:
-#line 2518 "grammar.y" /* yacc.c:1663  */
+#line 2517 "grammar.y" /* yacc.c:1663  */
     {
         check_type((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         check_type((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -4302,11 +4301,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(^, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 4306 "grammar.c" /* yacc.c:1663  */
+#line 4305 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 141:
-#line 2528 "grammar.y" /* yacc.c:1663  */
+#line 2527 "grammar.y" /* yacc.c:1663  */
     {
         check_type((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "^");
         check_type((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "^");
@@ -4316,11 +4315,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(&, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 4320 "grammar.c" /* yacc.c:1663  */
+#line 4319 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 142:
-#line 2538 "grammar.y" /* yacc.c:1663  */
+#line 2537 "grammar.y" /* yacc.c:1663  */
     {
         check_type((yyvsp[-2].expression), EXPRESSION_TYPE_INTEGER, "|");
         check_type((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "|");
@@ -4330,11 +4329,11 @@ yyreduce:
         (yyval.expression).type = EXPRESSION_TYPE_INTEGER;
         (yyval.expression).value.integer = OPERATION(|, (yyvsp[-2].expression).value.integer, (yyvsp[0].expression).value.integer);
       }
-#line 4334 "grammar.c" /* yacc.c:1663  */
+#line 4333 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 143:
-#line 2548 "grammar.y" /* yacc.c:1663  */
+#line 2547 "grammar.y" /* yacc.c:1663  */
     {
         check_type((yyvsp[0].expression), EXPRESSION_TYPE_INTEGER, "~");
 
@@ -4344,11 +4343,11 @@ yyreduce:
         (yyval.expression).value.integer = ((yyvsp[0].expression).value.integer == YR_UNDEFINED) ?
             YR_UNDEFINED : ~((yyvsp[0].expression).value.integer);
       }
-#line 4348 "grammar.c" /* yacc.c:1663  */
+#line 4347 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 144:
-#line 2558 "grammar.y" /* yacc.c:1663  */
+#line 2557 "grammar.y" /* yacc.c:1663  */
     {
         int result;
 
@@ -4368,11 +4367,11 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4372 "grammar.c" /* yacc.c:1663  */
+#line 4371 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 145:
-#line 2578 "grammar.y" /* yacc.c:1663  */
+#line 2577 "grammar.y" /* yacc.c:1663  */
     {
         int result;
 
@@ -4392,19 +4391,19 @@ yyreduce:
 
         fail_if_error(result);
       }
-#line 4396 "grammar.c" /* yacc.c:1663  */
+#line 4395 "grammar.c" /* yacc.c:1663  */
     break;
 
   case 146:
-#line 2598 "grammar.y" /* yacc.c:1663  */
+#line 2597 "grammar.y" /* yacc.c:1663  */
     {
         (yyval.expression) = (yyvsp[0].expression);
       }
-#line 4404 "grammar.c" /* yacc.c:1663  */
+#line 4403 "grammar.c" /* yacc.c:1663  */
     break;
 
 
-#line 4408 "grammar.c" /* yacc.c:1663  */
+#line 4407 "grammar.c" /* yacc.c:1663  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4632,5 +4631,4 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 2603 "grammar.y" /* yacc.c:1907  */
-
+#line 2602 "grammar.y" /* yacc.c:1907  */

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -474,10 +474,10 @@ tag_list
         char* tag = (char*) yr_arena_ref_to_ptr(
             compiler->arena, &$<tag>$);
 
-	// Search for duplicated tags. Tags are written one after
-	// the other, with zeroes in between (i.e: tag1/0tag2/0tag3)
-	// that's why can use tag < new_tag as the condition for the
-	// loop.
+        // Search for duplicated tags. Tags are written one after
+        // the other, with zeroes in between (i.e: tag1/0tag2/0tag3)
+        // that's why can use tag < new_tag as the condition for the
+        // loop.
         while (tag < new_tag)
         {
           if (strcmp(tag, new_tag) == 0)
@@ -909,8 +909,8 @@ identifier
           {
             YR_ARENA_REF ref;
 
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, $1, &ref);
+            result = _yr_compiler_store_string(
+                compiler, $1, &ref);
 
             if (result == ERROR_SUCCESS)
               result = yr_parser_emit_with_arg_reloc(
@@ -973,8 +973,8 @@ identifier
           {
             YR_ARENA_REF ref;
 
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, $3, &ref);
+            result = _yr_compiler_store_string(
+                compiler, $3, &ref);
 
             if (result == ERROR_SUCCESS)
               result = yr_parser_emit_with_arg_reloc(
@@ -1081,8 +1081,8 @@ identifier
               compiler, object_as_function($1.value.object), $3);
 
           if (result == ERROR_SUCCESS)
-            result = yr_arena_write_string(
-                compiler->arena, YR_SZ_POOL, $3, &ref);
+            result = _yr_compiler_store_string(
+                compiler, $3, &ref);
 
           if (result == ERROR_SUCCESS)
             result = yr_parser_emit_with_arg_reloc(
@@ -2214,9 +2214,8 @@ primary_expression
       {
         YR_ARENA_REF ref;
 
-        int result = yr_arena_write_data(
-            compiler->arena,
-            YR_SZ_POOL,
+        int result = _yr_compiler_store_data(
+            compiler,
             $1,
             $1->length + sizeof(SIZED_STRING),
             &ref);

--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -367,9 +367,38 @@ YR_API int yr_hash_table_add(
 }
 
 
-YR_API uint32_t yr_hash_table_add_uint32(
+YR_API int yr_hash_table_add_uint32(
     YR_HASH_TABLE* table,
     const char* key,
+    const char* ns,
+    uint32_t value)
+{
+  return yr_hash_table_add_uint32_raw_key(
+      table,
+      (void*) key,
+      strlen(key),
+      ns,
+      value);
+}
+
+
+YR_API uint32_t yr_hash_table_lookup_uint32(
+    YR_HASH_TABLE* table,
+    const char* key,
+    const char* ns)
+{
+  return yr_hash_table_lookup_uint32_raw_key(
+      table,
+      (void*) key,
+      strlen(key),
+      ns);
+}
+
+
+YR_API int yr_hash_table_add_uint32_raw_key(
+    YR_HASH_TABLE* table,
+    const void* key,
+    size_t key_length,
     const char* ns,
     uint32_t value)
 {
@@ -380,17 +409,18 @@ YR_API uint32_t yr_hash_table_add_uint32(
   // Add +1 to the value in order to avoid putting a NULL pointer in the
   // hash table once the integer is casted to a pointer. This is undone
   // by yr_hash_table_lookup_uint32.
-  return yr_hash_table_add(
-      table, key, ns, (void*) (size_t) (value + 1));
+  return yr_hash_table_add_raw_key(
+      table, key, key_length, ns, (void*) (size_t) (value + 1));
 }
 
 
-YR_API uint32_t yr_hash_table_lookup_uint32(
+YR_API uint32_t yr_hash_table_lookup_uint32_raw_key(
     YR_HASH_TABLE* table,
-    const char* key,
+    const void* key,
+    size_t key_length,
     const char* ns)
 {
-  void* ptr = yr_hash_table_lookup(table, key, ns);
+  void* ptr = yr_hash_table_lookup_raw_key(table, key, key_length, ns);
 
   if (ptr == NULL)
     return UINT32_MAX;

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -243,6 +243,13 @@ typedef struct _YR_COMPILER
   YR_HASH_TABLE*    objects_table;
   YR_HASH_TABLE*    strings_table;
 
+  // Hash table that contains all the strings that has been written to the
+  // YR_SZ_POOL buffer in the compiler's arena. Values in the hash table are
+  // the offset within the YR_SZ_POOL where the string resides. This allows to
+  // know is some string has already been written in order to reuse instead of
+  // writting it again.
+  YR_HASH_TABLE*    sz_table;
+
   YR_FIXUP*         fixup_stack_head;
 
   int               num_namespaces;
@@ -310,6 +317,19 @@ const char* _yr_compiler_default_include_callback(
 
 YR_RULE* _yr_compiler_get_rule_by_idx(
     YR_COMPILER* compiler, uint32_t rule_idx);
+
+
+int _yr_compiler_store_string(
+    YR_COMPILER* compiler,
+    const char* string,
+    YR_ARENA_REF* ref);
+
+
+int _yr_compiler_store_data(
+    YR_COMPILER* compiler,
+    const void* data,
+    size_t data_length,
+    YR_ARENA_REF* ref);
 
 
 YR_API int yr_compiler_create(

--- a/libyara/include/yara/hash.h
+++ b/libyara/include/yara/hash.h
@@ -99,6 +99,19 @@ YR_API int yr_hash_table_add(
     void* value);
 
 
+YR_API int yr_hash_table_add_uint32(
+    YR_HASH_TABLE* table,
+    const char* key,
+    const char* ns,
+    uint32_t value);
+
+
+YR_API uint32_t yr_hash_table_lookup_uint32(
+    YR_HASH_TABLE* table,
+    const char* key,
+    const char* ns);
+
+
 YR_API void* yr_hash_table_lookup_raw_key(
     YR_HASH_TABLE* table,
     const void* key,
@@ -121,16 +134,18 @@ YR_API int yr_hash_table_add_raw_key(
     void* value);
 
 
-YR_API uint32_t yr_hash_table_add_uint32(
+YR_API int yr_hash_table_add_uint32_raw_key(
     YR_HASH_TABLE* table,
-    const char* key,
+    const void* key,
+    size_t key_length,
     const char* ns,
     uint32_t value);
 
 
-YR_API uint32_t yr_hash_table_lookup_uint32(
+YR_API uint32_t yr_hash_table_lookup_uint32_raw_key(
     YR_HASH_TABLE* table,
-    const char* key,
+    const void* key,
+    size_t key_length,
     const char* ns);
 
 #endif

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -383,11 +383,8 @@ static int _yr_parser_write_string(
 
   YR_ARENA_REF ref;
 
-  FAIL_ON_ERROR(yr_arena_write_string(
-      compiler->arena,
-      YR_SZ_POOL,
-      identifier,
-      &ref));
+  FAIL_ON_ERROR(_yr_compiler_store_string(
+      compiler, identifier, &ref));
 
   string->identifier = (const char*) yr_arena_ref_to_ptr(
       compiler->arena, &ref);
@@ -429,9 +426,8 @@ static int _yr_parser_write_string(
 
   if (modifier.flags & STRING_FLAGS_LITERAL)
   {
-    result = yr_arena_write_data(
-        compiler->arena,
-        YR_SZ_POOL,
+    result = _yr_compiler_store_data(
+        compiler,
         literal_string->c_string,
         literal_string->length + 1,   // +1 to include terminating NULL
         &ref);
@@ -890,9 +886,8 @@ int yr_parser_reduce_rule_declaration_phase_1(
 
   YR_ARENA_REF ref;
 
-  FAIL_ON_ERROR(yr_arena_write_string(
-      compiler->arena,
-      YR_SZ_POOL,
+  FAIL_ON_ERROR(_yr_compiler_store_string(
+      compiler,
       identifier,
       &ref));
 
@@ -1154,9 +1149,8 @@ int yr_parser_reduce_meta_declaration(
   meta->type = type;
   meta->integer = integer;
 
-  FAIL_ON_ERROR(yr_arena_write_string(
-      compiler->arena,
-      YR_SZ_POOL,
+  FAIL_ON_ERROR(_yr_compiler_store_string(
+      compiler,
       identifier,
       &ref));
 
@@ -1164,9 +1158,8 @@ int yr_parser_reduce_meta_declaration(
 
   if (string != NULL)
   {
-    FAIL_ON_ERROR(yr_arena_write_string(
-        compiler->arena,
-        YR_SZ_POOL,
+    FAIL_ON_ERROR(_yr_compiler_store_string(
+        compiler,
         string,
         &ref));
 
@@ -1249,9 +1242,8 @@ int yr_parser_reduce_import(
   if (result != ERROR_SUCCESS)
     return result;
 
-  FAIL_ON_ERROR(yr_arena_write_string(
-      compiler->arena,
-      YR_SZ_POOL,
+  FAIL_ON_ERROR(_yr_compiler_store_string(
+      compiler,
       module_name->c_string,
       &ref));
 


### PR DESCRIPTION
Before this change if the identifier $a was used in 100 rules, the text string  "$a" would appear 100 times in the compiled rules. After this change it is saved once and referenced from multiple places. The same happens with module names, literal strings used in the rules and so on.