### PR TITLE
py docs- correct rst link to yara.Rules match method

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -398,7 +398,7 @@ Reference
 
 .. py:class:: Match
 
-  Objects returned by :py:method:`yara.Rules.match`, representing a match.
+  Objects returned by :py:meth:`yara.Rules.match`, representing a match.
 
   .. py:attribute:: rule
 


### PR DESCRIPTION
keyword for methods in sphinx links is `meth` - https://stackoverflow.com/questions/22700606/how-would-i-cross-reference-a-function-generated-by-autodoc-in-sphinx 

fixes #1307, #1308 regression