### PR TITLE
Makefile.am: remove hardcoded static lib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ yara_SOURCES = \
   cli/threading.h \
   cli/yara.c
 
-yara_LDADD = libyara/.libs/libyara.a #-Llibyara/.libs -lyara
+yara_LDADD = -Llibyara/.libs -lyara
 
 yarac_SOURCES = \
    cli/args.c \


### PR DESCRIPTION
When compiling without static libraries the recently
introduced change prevented compilation.
As it looks like a forgotten debug settings, revert this
pariticular line

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>