### PR TITLE
Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libyara/include/yara/pe_utils.h
+++ b/libyara/include/yara/pe_utils.h
@@ -102,7 +102,7 @@ char *ord_lookup(
 
 #if HAVE_LIBCRYPTO
 #include <openssl/asn1.h>
-time_t ASN1_get_time_t(ASN1_TIME* time);
+time_t ASN1_get_time_t(const ASN1_TIME* time);
 #endif
 
 #endif

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -44,8 +44,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define X509_getm_notBefore X509_get_notBefore
-#define X509_getm_notAfter X509_get_notAfter
+#define X509_get0_notBefore X509_get_notBefore
+#define X509_get0_notAfter X509_get_notAfter
 #endif
 #endif
 
@@ -1433,10 +1433,10 @@ void _parse_pkcs7(
       }
     }
 
-    date_time = ASN1_get_time_t(X509_get_notBefore(cert));
+    date_time = ASN1_get_time_t(X509_get0_notBefore(cert));
     set_integer(date_time, pe->object, "signatures[%i].not_before", *counter);
 
-    date_time = ASN1_get_time_t(X509_get_notAfter(cert));
+    date_time = ASN1_get_time_t(X509_get0_notAfter(cert));
     set_integer(date_time, pe->object, "signatures[%i].not_after", *counter);
 
     (*counter)++;

--- a/libyara/modules/pe/pe_utils.c
+++ b/libyara/modules/pe/pe_utils.c
@@ -307,7 +307,7 @@ time_t timegm(
 // and cleaned up. Also uses timegm(3) instead of mktime(3).
 
 time_t ASN1_get_time_t(
-  	ASN1_TIME* time)
+  	const ASN1_TIME* time)
 {
   struct tm t;
   const char* str = (const char*) time->data;


### PR DESCRIPTION
The previous commit was totally broken. It was still using deprecated
APIs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>