### PR TITLE
Fix rsrc with bad RVA.

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -707,13 +707,16 @@ static int pe_collect_resources(
 {
   DWORD length;
 
+  set_integer(
+        yr_le32toh(rsrc_data->OffsetToData),
+        pe->object,
+        "resources[%i].rva",
+        pe->resources);
+
   int64_t offset = pe_rva_to_offset(pe, yr_le32toh(rsrc_data->OffsetToData));
 
   if (offset < 0)
-    return RESOURCE_CALLBACK_CONTINUE;
-
-  if (!fits_in_pe(pe, pe->data + offset, yr_le32toh(rsrc_data->Size)))
-    return RESOURCE_CALLBACK_CONTINUE;
+    offset = YR_UNDEFINED;
 
   set_integer(
         offset,
@@ -2937,6 +2940,7 @@ begin_declarations;
   end_struct("resource_version");
 
   begin_struct_array("resources");
+    declare_integer("rva");
     declare_integer("offset");
     declare_integer("length");
     declare_integer("type");


### PR DESCRIPTION
In some cases the resource data has an RVA which does not map to a file offset.
Prior to this change we would stop parsing that resource when this is found,
which means we are losing useful information like the length and type/name
strings (if they exist).

I checked how tools like pe-studio and CFF explorer handle this case and they
just display the RVA with an unknown offset.

I think it is useful to not stop parsing if the RVA does not map to a file
offset. This commit makes it so "invalid" RVAs are set as YR_UNDEFINED and we
continue parsing. I'm also adding support for setting the RVA, because it is
useful to know in some cases.

I was careful to verify that in the case of parsing version information
resources that function does check that the RVA maps to a legitimate file offset
before parsing, so this is safe to do.