### PR TITLE
Remove the FIELD_OFFSET macro and use the offsetof() operator instead.

### DIFF
--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -67,9 +67,6 @@ typedef int32_t   LONG;
 typedef uint32_t  ULONG;
 typedef uint64_t  ULONGLONG;
 
-
-#define FIELD_OFFSET(type, field)    ((size_t)&(((type *)0)->field))
-
 #ifndef _MAC
 
 #define IMAGE_DOS_SIGNATURE                 0x5A4D      // MZ
@@ -317,8 +314,8 @@ typedef struct _IMAGE_NT_HEADERS64 {
 // the same either way.
 
 #define IMAGE_FIRST_SECTION( ntheader ) ((PIMAGE_SECTION_HEADER) \
-    ((BYTE*)ntheader + \
-     FIELD_OFFSET( IMAGE_NT_HEADERS32, OptionalHeader ) + \
+    ((BYTE*) ntheader + \
+     offsetof(IMAGE_NT_HEADERS32, OptionalHeader) + \
      yr_le16toh(((PIMAGE_NT_HEADERS32)(ntheader))->FileHeader.SizeOfOptionalHeader) \
     ))
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -291,7 +291,7 @@ static void pe_parse_debug_directory(
   int i, dcount;
   size_t pdb_path_len;
   char* pdb_path = NULL;
-  
+
   data_dir = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_DEBUG);
 
@@ -319,16 +319,16 @@ static void pe_parse_debug_directory(
   {
     debug_dir = (PIMAGE_DEBUG_DIRECTORY) \
         (pe->data + debug_dir_offset + i * sizeof(IMAGE_DEBUG_DIRECTORY));
-    
+
     if (!struct_fits_in_pe(pe, debug_dir, IMAGE_DEBUG_DIRECTORY))
       break;
-  
+
     if (yr_le32toh(debug_dir->Type) != IMAGE_DEBUG_TYPE_CODEVIEW)
       continue;
-    
+
     if (yr_le32toh(debug_dir->AddressOfRawData) == 0)
       continue;
-    
+
     pcv_hdr_offset = pe_rva_to_offset(
         pe, yr_le32toh(debug_dir->AddressOfRawData));
 
@@ -343,14 +343,14 @@ static void pe_parse_debug_directory(
     if (yr_le32toh(cv_hdr->dwSignature) == CVINFO_PDB20_CVSIGNATURE)
     {
       PCV_INFO_PDB20 pdb20 = (PCV_INFO_PDB20) cv_hdr;
-      
+
       if (struct_fits_in_pe(pe, pdb20, CV_INFO_PDB20))
         pdb_path = (char*) (pdb20->PdbFileName);
     }
     else if (yr_le32toh(cv_hdr->dwSignature) == CVINFO_PDB70_CVSIGNATURE)
     {
       PCV_INFO_PDB70 pdb70 = (PCV_INFO_PDB70) cv_hdr;
-      
+
       if (struct_fits_in_pe(pe, pdb70, CV_INFO_PDB70))
         pdb_path = (char*) (pdb70->PdbFileName);
     }
@@ -367,7 +367,7 @@ static void pe_parse_debug_directory(
       }
     }
   }
-  
+
   return;
 }
 
@@ -3368,7 +3368,7 @@ int module_load(
         pe_parse_header(pe, block->base, context->flags);
         pe_parse_rich_signature(pe, block->base);
         pe_parse_debug_directory(pe);
-        
+
         #if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
         pe_parse_certificates(pe);
         #endif


### PR DESCRIPTION
The FIELD_OFFSET was dereferencing a null pointer in order to compute the offset of a field within the structure, but dereferencing a null pointer is considered undefined behavior in C and triggers the undefined behavior sanitizer (UBSAN).