### PR TITLE
Implement -N (--no-follow-symlinks).

### DIFF
--- a/cli/args.c
+++ b/cli/args.c
@@ -101,7 +101,7 @@ args_error_type_t args_parse_option(
   switch (opt->type)
   {
     case ARGS_OPT_BOOLEAN:
-      *(bool*) opt->value = true;
+      *(bool*) opt->value = !(*(bool*) opt->value);
       break;
 
     case ARGS_OPT_INTEGER:


### PR DESCRIPTION
Implement a -N flag which causes yara to not follow any symlinks when scanning,
regardless of the recursive option.