### PR TITLE
Review all calls to YR_DEBUG_FPRINTF and make the following changes:

### DIFF
--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -39,7 +39,7 @@ YR_API int yr_process_open_iterator(
     int pid,
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(pid=%d) {}\n", __FUNCTION__, pid);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s(pid=%d)\n", __FUNCTION__, pid);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) \
       yr_malloc(sizeof(YR_PROC_ITERATOR_CTX));
@@ -70,7 +70,7 @@ YR_API int yr_process_open_iterator(
 YR_API int yr_process_close_iterator(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) iterator->context;
 

--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -39,7 +39,7 @@ YR_API int yr_process_open_iterator(
     int pid,
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(pid=%d)\n", __FUNCTION__, pid);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s(pid=%d) {}\n", __FUNCTION__, pid);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) \
       yr_malloc(sizeof(YR_PROC_ITERATOR_CTX));
@@ -70,7 +70,7 @@ YR_API int yr_process_open_iterator(
 YR_API int yr_process_close_iterator(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) iterator->context;
 

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -142,7 +142,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() = %p\n", __FUNCTION__, result);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} = %p\n", __FUNCTION__, result);
 
   return result;
 }
@@ -165,7 +165,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
     context->current_block.size = end - begin;
 
     YR_DEBUG_FPRINTF(2, stderr,
-        "+ %s() // .base=0x%" PRIx64 " .size=%lu\n",
+        "+ %s() {} // .base=0x%" PRIx64 " .size=%lu\n",
         __FUNCTION__, context->current_block.base, context->current_block.size);
 
     return &context->current_block;
@@ -180,7 +180,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 YR_API YR_MEMORY_BLOCK* yr_process_get_first_memory_block(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} \n", __FUNCTION__);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) iterator->context;
   YR_PROC_INFO* proc_info = (YR_PROC_INFO*) context->proc_info;

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -142,7 +142,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} = %p\n", __FUNCTION__, result);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() = %p\n", __FUNCTION__, result);
 
   return result;
 }
@@ -164,13 +164,14 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
     context->current_block.base = begin;
     context->current_block.size = end - begin;
 
-    YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} // .base=0x%lx .size=%'lu\n",
-      __FUNCTION__, context->current_block.base, context->current_block.size);
+    YR_DEBUG_FPRINTF(2, stderr,
+        "+ %s() // .base=0x%" PRIx64 " .size=%lu\n",
+        __FUNCTION__, context->current_block.base, context->current_block.size);
 
     return &context->current_block;
   }
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} = NULL\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() = NULL\n", __FUNCTION__);
 
   return NULL;
 }
@@ -179,7 +180,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 YR_API YR_MEMORY_BLOCK* yr_process_get_first_memory_block(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
 
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) iterator->context;
   YR_PROC_INFO* proc_info = (YR_PROC_INFO*) context->proc_info;

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -209,7 +209,9 @@ YR_API int yr_rules_scan_mem(
     void* user_data,
     int timeout)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(buffer=%p buffer_size=%'ld timeout=%'d) {}\n", __FUNCTION__, buffer, buffer_size, timeout);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(buffer=%p buffer_size=%zu timeout=%d)\n",
+      __FUNCTION__, buffer, buffer_size, timeout);
 
   YR_SCANNER* scanner;
   int result;
@@ -296,7 +298,8 @@ YR_API int yr_rules_scan_proc(
     void* user_data,
     int timeout)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(pid=%'d timeout=%'d) {}\n", __FUNCTION__, pid, timeout);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(pid=%d timeout=%d)\n", __FUNCTION__, pid, timeout);
 
   YR_MEMORY_BLOCK_ITERATOR iterator;
 

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -210,7 +210,7 @@ YR_API int yr_rules_scan_mem(
     int timeout)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(buffer=%p buffer_size=%zu timeout=%d)\n",
+      "+ %s(buffer=%p buffer_size=%zu timeout=%d) {}\n",
       __FUNCTION__, buffer, buffer_size, timeout);
 
   YR_SCANNER* scanner;
@@ -299,7 +299,7 @@ YR_API int yr_rules_scan_proc(
     int timeout)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(pid=%d timeout=%d)\n", __FUNCTION__, pid, timeout);
+      "+ %s(pid=%d timeout=%d) {}\n", __FUNCTION__, pid, timeout);
 
   YR_MEMORY_BLOCK_ITERATOR iterator;
 

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -88,7 +88,7 @@ static int _yr_scan_xor_compare(
   _exit:;
 
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      "+ %s(data_size=%zu string_length=%zu) {} = %d\n",
       __FUNCTION__, data_size, string_length, result);
 
   return result;
@@ -194,7 +194,7 @@ static int _yr_scan_wcompare(
   _exit:;
 
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      "+ %s(data_size=%zu string_length=%zu) {} = %d\n",
       __FUNCTION__, data_size, string_length, result);
 
   return result;
@@ -230,7 +230,7 @@ static int _yr_scan_wicompare(
   _exit:;
 
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      "+ %s(data_size=%zu string_length=%zu) {} = %d\n",
       __FUNCTION__, data_size, string_length, result);
 
   return result;
@@ -333,7 +333,7 @@ static int _yr_scan_add_match_to_list(
   _exit:;
 
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(replace_if_exists=%d) = %d //"
+      "+ %s(replace_if_exists=%d) {} = %d //"
       " match->base=0x%" PRIx64
       " match->offset=%" PRIi64
       " matches_list->count=%u += %u\n",
@@ -395,7 +395,7 @@ static int _yr_scan_verify_chained_string_match(
 {
   YR_DEBUG_FPRINTF(2, stderr,
       "+ %s (match_data=%p match_base=%" PRIx64
-      " match_offset=0x%" PRIx64 " match_length=%'d)\n",
+      " match_offset=0x%" PRIx64 " match_length=%'d) {} \n",
       __FUNCTION__,
       match_data,
       match_base,
@@ -745,7 +745,7 @@ static int _yr_scan_match_callback(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "} // %s() = %d\n", __FUNCTION__, result);
+  YR_DEBUG_FPRINTF(2, stderr, "} // %s() {} = %d\n", __FUNCTION__, result);
 
   return result;
 }
@@ -772,7 +772,7 @@ static int _yr_scan_verify_re_match(
     size_t offset)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu) {}\n",
       __FUNCTION__, data, data_size, data_base, offset);
 
   CALLBACK_ARGS callback_args;
@@ -875,7 +875,7 @@ static int _yr_scan_verify_literal_match(
     size_t offset)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu) {}\n",
       __FUNCTION__, data, data_size, data_base, offset);
 
   int flags = 0;
@@ -984,7 +984,7 @@ int yr_scan_verify_match(
     size_t offset)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu) {}\n",
       __FUNCTION__, data, data_size, data_base, offset);
 
   YR_STRING* string = ac_match->string;

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -87,8 +87,9 @@ static int _yr_scan_xor_compare(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data_size=%'lu string_length=%'ld) {} = %d\n",
-    __FUNCTION__, data_size, string_length, result);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      __FUNCTION__, data_size, string_length, result);
 
   return result;
 }
@@ -192,8 +193,9 @@ static int _yr_scan_wcompare(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data_size=%'lu string_length=%'ld) {} = %d\n",
-    __FUNCTION__, data_size, string_length, result);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      __FUNCTION__, data_size, string_length, result);
 
   return result;
 }
@@ -227,8 +229,9 @@ static int _yr_scan_wicompare(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data_size=%'lu string_length=%'ld) {} = %d\n",
-    __FUNCTION__, data_size, string_length, result);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data_size=%zu string_length=%zu) = %d\n",
+      __FUNCTION__, data_size, string_length, result);
 
   return result;
 }
@@ -329,10 +332,18 @@ static int _yr_scan_add_match_to_list(
 
   _exit:;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(replace_if_exists=%d) {} = %d // "
-    "match->base=0x%lx match->offset=%'lu matches_list->count=%'u += %'u\n",
-    __FUNCTION__, replace_if_exists, result, match->base, match->offset, count_orig,
-    matches_list->count - count_orig);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(replace_if_exists=%d) = %d //"
+      " match->base=0x%" PRIx64
+      " match->offset=%" PRIi64
+      " matches_list->count=%u += %u\n",
+      __FUNCTION__,
+      replace_if_exists,
+      result,
+      match->base,
+      match->offset,
+      count_orig,
+      matches_list->count - count_orig);
 
   return result;
 }
@@ -382,9 +393,14 @@ static int _yr_scan_verify_chained_string_match(
     uint64_t match_offset,
     int32_t match_length)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s"
-    "(match_data=%p match_base=%lx match_offset=0x%'lu match_length=%'d) {}\n",
-    __FUNCTION__, match_data, match_base, match_offset, match_length);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s (match_data=%p match_base=%" PRIx64
+      " match_offset=0x%" PRIx64 " match_length=%'d)\n",
+      __FUNCTION__,
+      match_data,
+      match_base,
+      match_offset,
+      match_length);
 
   YR_STRING* string;
   YR_MATCH* match;
@@ -612,18 +628,21 @@ static int _yr_scan_match_callback(
 
   size_t match_offset = match_data - callback_args->data;
 
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(match_data=%p match_length=%'d) { // "
-    "match_offset=%'ld args->data=%p args->string.length=%'u "
-    "args->data_base=0x%lx args->data_size=%'lu args->forward_matches=%'u\n",
-    __FUNCTION__,
-    match_data,
-    match_length,
-    match_offset,
-    callback_args->data,
-    callback_args->string->length,
-    callback_args->data_base,
-    callback_args->data_size,
-    callback_args->forward_matches);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(match_data=%p match_length=%d) { //"
+      " match_offset=%ld args->data=%p args->string.length=%u"
+      " args->data_base=0x%" PRIx64
+      " args->data_size=%zu"
+      " args->forward_matches=%'u\n",
+      __FUNCTION__,
+      match_data,
+      match_length,
+      match_offset,
+      callback_args->data,
+      callback_args->string->length,
+      callback_args->data_base,
+      callback_args->data_size,
+      callback_args->forward_matches);
 
   // total match length is the sum of backward and forward matches.
   match_length += callback_args->forward_matches;
@@ -752,8 +771,9 @@ static int _yr_scan_verify_re_match(
     uint64_t data_base,
     size_t offset)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data=%p data_size=%'lu data_base=0x%lx offset=%'ld) {}\n",
-    __FUNCTION__, data, data_size, data_base, offset);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      __FUNCTION__, data, data_size, data_base, offset);
 
   CALLBACK_ARGS callback_args;
   RE_EXEC_FUNC exec;
@@ -854,8 +874,9 @@ static int _yr_scan_verify_literal_match(
     uint64_t data_base,
     size_t offset)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data=%p data_size=%'lu data_base=0x%lx offset=%'ld) {}\n",
-    __FUNCTION__, data, data_size, data_base, offset);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      __FUNCTION__, data, data_size, data_base, offset);
 
   int flags = 0;
   int forward_matches = 0;
@@ -962,8 +983,9 @@ int yr_scan_verify_match(
     uint64_t data_base,
     size_t offset)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(data=%p data_size=%'lu data_base=0x%lx offset=%'ld)\n",
-    __FUNCTION__, data, data_size, data_base, offset);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(data=%p data_size=%zu data_base=0x%" PRIx64 " offset=%zu)\n",
+      __FUNCTION__, data, data_size, data_base, offset);
 
   YR_STRING* string = ac_match->string;
 

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -49,7 +49,7 @@ static int _yr_scanner_scan_mem_block(
     YR_MEMORY_BLOCK* block)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(block_data=%p block->base=0x%" PRIx64 " block->size=%zu)\n",
+      "+ %s(block_data=%p block->base=0x%" PRIx64 " block->size=%zu) {}\n",
       __FUNCTION__, block_data, block->base, block->size);
 
   YR_RULES* rules = scanner->rules;
@@ -75,7 +75,7 @@ static int _yr_scanner_scan_mem_block(
     if (0 != state)
       YR_DEBUG_FPRINTF(2, stderr,
           "- match_table[state=%u]=%'u i=%'ld "
-          "block_data=%p block->base=0x%" PRIx64 " // %s()\n",
+          "block_data=%p block->base=0x%" PRIx64 " // %s() {}\n",
           state, match_table[state], i, block_data, block->base, __FUNCTION__);
     #endif
 
@@ -175,7 +175,7 @@ YR_API int yr_scanner_create(
     YR_RULES* rules,
     YR_SCANNER** scanner)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} \n", __FUNCTION__);
 
   YR_EXTERNAL_VARIABLE* external;
   YR_SCANNER* new_scanner;
@@ -257,7 +257,7 @@ YR_API int yr_scanner_create(
 YR_API void yr_scanner_destroy(
     YR_SCANNER* scanner)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} \n", __FUNCTION__);
 
   RE_FIBER* fiber;
   RE_FIBER* next_fiber;
@@ -399,7 +399,7 @@ YR_API int yr_scanner_scan_mem_blocks(
     YR_SCANNER* scanner,
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} \n", __FUNCTION__);
 
   YR_RULES* rules;
   YR_RULE* rule;

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -48,8 +48,9 @@ static int _yr_scanner_scan_mem_block(
     const uint8_t* block_data,
     YR_MEMORY_BLOCK* block)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(block_data=%p block->base=0x%lx block->size=%'lu) {}\n",
-    __FUNCTION__, block_data, block->base, block->size);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(block_data=%p block->base=0x%" PRIx64 " block->size=%zu)\n",
+      __FUNCTION__, block_data, block->base, block->size);
 
   YR_RULES* rules = scanner->rules;
   YR_AC_TRANSITION* transition_table = rules->ac_transition_table;
@@ -72,9 +73,10 @@ static int _yr_scanner_scan_mem_block(
 
     #if 2 == YR_DEBUG_VERBOSITY
     if (0 != state)
-      YR_DEBUG_FPRINTF(2, stderr, "- match_table[state=%u]=%'u i=%'ld "
-        "block_data=%p block->base=0x%lx // %s()\n",
-        state, match_table[state], i, block_data, block->base, __FUNCTION__);
+      YR_DEBUG_FPRINTF(2, stderr,
+          "- match_table[state=%u]=%'u i=%'ld "
+          "block_data=%p block->base=0x%" PRIx64 " // %s()\n",
+          state, match_table[state], i, block_data, block->base, __FUNCTION__);
     #endif
 
     if (match_table[state] != 0)
@@ -173,7 +175,7 @@ YR_API int yr_scanner_create(
     YR_RULES* rules,
     YR_SCANNER** scanner)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
 
   YR_EXTERNAL_VARIABLE* external;
   YR_SCANNER* new_scanner;
@@ -255,7 +257,7 @@ YR_API int yr_scanner_create(
 YR_API void yr_scanner_destroy(
     YR_SCANNER* scanner)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
 
   RE_FIBER* fiber;
   RE_FIBER* next_fiber;
@@ -397,7 +399,7 @@ YR_API int yr_scanner_scan_mem_blocks(
     YR_SCANNER* scanner,
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr, "+ %s()\n", __FUNCTION__);
 
   YR_RULES* rules;
   YR_RULE* rule;
@@ -569,8 +571,9 @@ static int __yr_scanner_scan_mem(
     const uint8_t* buffer,
     size_t buffer_size)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s(buffer=%p buffer_size=%'ld) {}\n",
-    __FUNCTION__, buffer, buffer_size);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(buffer=%p buffer_size=%zu)\n",
+      __FUNCTION__, buffer, buffer_size);
 
   YR_MEMORY_BLOCK block;
   YR_MEMORY_BLOCK_ITERATOR iterator;

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static void test_boolean_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: true }", NULL);
@@ -69,7 +69,7 @@ static void test_boolean_operators()
 
 static void test_comparison_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: 2 > 1 }", NULL);
@@ -177,7 +177,7 @@ static void test_comparison_operators()
 
 static void test_arithmetic_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: (1 + 1) * 2 == (9 - 1) \\ 2 }", NULL);
@@ -306,7 +306,7 @@ static void test_arithmetic_operators()
 
 static void test_bitwise_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: 0x55 | 0xAA == 0xFF }",
@@ -361,7 +361,7 @@ static void test_bitwise_operators()
 
 static void test_string_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: \"foobarbaz\" contains \"bar\" }",
@@ -447,7 +447,7 @@ static void test_string_operators()
 
 static void test_syntax()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_error(
       "rule test { strings: $a = \"a\" $a = \"a\" condition: all of them }",
@@ -482,7 +482,7 @@ static void test_syntax()
 
 static void test_anonymous_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $ = \"a\" $ = \"b\" condition: all of them }",
@@ -500,7 +500,7 @@ static void test_anonymous_strings()
 
 static void test_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   char* str = TEXT_1024_BYTES "---- abc ---- xyz";
   uint8_t blob[] = TEXT_1024_BYTES "---- a\0b\0c\0 -\0-\0-\0-\0x\0y\0z\0";
@@ -1099,7 +1099,7 @@ static void test_strings()
 
 static void test_wildcard_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test {\n\
@@ -1115,7 +1115,7 @@ static void test_wildcard_strings()
 
 static void test_hex_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -1346,7 +1346,7 @@ static void test_hex_strings()
 
 static void test_count()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" condition: #a == 2 }",
@@ -1360,7 +1360,7 @@ static void test_count()
 
 static void test_at()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { \
@@ -1390,7 +1390,7 @@ static void test_at()
 
 static void test_in()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -1408,7 +1408,7 @@ static void test_in()
 
 static void test_offset()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" condition: @a == 2 }",
@@ -1430,7 +1430,7 @@ static void test_offset()
 
 static void test_length()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = /m.*?ssi/ condition: !a == 5 }",
@@ -1480,7 +1480,7 @@ static void test_length()
 
 static void test_of()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" $b = \"mis\" $c = \"oops\" "
@@ -1536,7 +1536,7 @@ static void test_of()
 
 void test_for()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { \
@@ -1791,7 +1791,7 @@ void test_for()
 
 void test_re()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = /ssi/ condition: $a }",
@@ -2250,7 +2250,7 @@ void test_re()
 
 static void test_entrypoint()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -2278,7 +2278,7 @@ static void test_entrypoint()
 
 static void test_filesize()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   char rule[80];
 
@@ -2296,7 +2296,7 @@ static void test_filesize()
 
 static void test_comments()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test {\n\
@@ -2352,7 +2352,7 @@ static void test_comments()
 
 static void test_matches_operator()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: \"foo\" matches /foo/ }",
@@ -2394,7 +2394,7 @@ static void test_matches_operator()
 
 static void test_global_rules()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "global private rule global_rule { \
@@ -2420,7 +2420,7 @@ static void test_global_rules()
 
 static void test_modules()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "import \"tests\" \
@@ -2617,7 +2617,7 @@ static void test_modules()
 
 static void test_time_module()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
     assert_true_rule(
         "import \"time\" \
@@ -2629,7 +2629,7 @@ static void test_time_module()
 #if defined(HASH_MODULE)
 static void test_hash_module()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   uint8_t blob[] = {0x61, 0x62, 0x63, 0x64, 0x65};
 
@@ -2686,7 +2686,7 @@ static void test_hash_module()
 
 void test_integer_functions()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: uint8(0) == 0xAA}",
@@ -2716,7 +2716,7 @@ void test_integer_functions()
 
 void test_include_files()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "include \"tests/data/baz.yar\" rule t { condition: baz }",
@@ -2730,7 +2730,7 @@ void test_include_files()
 
 void test_tags()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_true_rule(
       "rule test : tag1 { condition: true}",
@@ -2748,7 +2748,7 @@ void test_tags()
 
 void test_process_scan()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   int pid = fork();
   int status = 0;
@@ -2835,7 +2835,7 @@ void test_process_scan()
 
 void test_performance_warnings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
 
   assert_warning(
       "rule test { \
@@ -2991,6 +2991,7 @@ int main(int argc, char** argv)
   _yr_scanner_scan_mem = &_yr_test_single_or_multi_block_scan_mem;
 
   uint64_t last_yr_test_count_get_block;
+
   for (int i = 1; i <= 2; i ++)
   {
     if (2 == i)
@@ -3007,10 +3008,10 @@ int main(int argc, char** argv)
     }
 
     YR_DEBUG_FPRINTF(1, stderr, "- // run all rule tests: pass %d: "
-      "split data into blocks of max %'lu bytes "
-      "(0 means single / unlimited block size; default) "
-      "with %'lu bytes overlapping the previous block\n",
-      i, yr_test_mem_block_size, yr_test_mem_block_size_overlap);
+        "split data into blocks of max %" PRId64 " bytes "
+        "(0 means single / unlimited block size; default) "
+        "with %" PRId64 " bytes overlapping the previous block\n",
+        i, yr_test_mem_block_size, yr_test_mem_block_size_overlap);
 
     yr_test_count_get_block = 0;
 
@@ -3060,9 +3061,9 @@ int main(int argc, char** argv)
     test_time_module();
     test_performance_warnings();
 
-    YR_DEBUG_FPRINTF(1, stderr, "- // yr_test_count_get_block=%'lu "
-      "is the number of times the above tests got a first or next block\n",
-      yr_test_count_get_block);
+    YR_DEBUG_FPRINTF(1, stderr, "- // yr_test_count_get_block=%" PRId64
+        "is the number of times the above tests got a first or next block\n",
+        yr_test_count_get_block);
 
     if (2 == i)
       assert(yr_test_count_get_block > last_yr_test_count_get_block);

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static void test_boolean_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: true }", NULL);
@@ -69,7 +69,7 @@ static void test_boolean_operators()
 
 static void test_comparison_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: 2 > 1 }", NULL);
@@ -177,7 +177,7 @@ static void test_comparison_operators()
 
 static void test_arithmetic_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: (1 + 1) * 2 == (9 - 1) \\ 2 }", NULL);
@@ -306,7 +306,7 @@ static void test_arithmetic_operators()
 
 static void test_bitwise_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: 0x55 | 0xAA == 0xFF }",
@@ -361,7 +361,7 @@ static void test_bitwise_operators()
 
 static void test_string_operators()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: \"foobarbaz\" contains \"bar\" }",
@@ -447,7 +447,7 @@ static void test_string_operators()
 
 static void test_syntax()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_error(
       "rule test { strings: $a = \"a\" $a = \"a\" condition: all of them }",
@@ -482,7 +482,7 @@ static void test_syntax()
 
 static void test_anonymous_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $ = \"a\" $ = \"b\" condition: all of them }",
@@ -500,7 +500,7 @@ static void test_anonymous_strings()
 
 static void test_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   char* str = TEXT_1024_BYTES "---- abc ---- xyz";
   uint8_t blob[] = TEXT_1024_BYTES "---- a\0b\0c\0 -\0-\0-\0-\0x\0y\0z\0";
@@ -1099,7 +1099,7 @@ static void test_strings()
 
 static void test_wildcard_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test {\n\
@@ -1115,7 +1115,7 @@ static void test_wildcard_strings()
 
 static void test_hex_strings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -1346,7 +1346,7 @@ static void test_hex_strings()
 
 static void test_count()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" condition: #a == 2 }",
@@ -1360,7 +1360,7 @@ static void test_count()
 
 static void test_at()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { \
@@ -1390,7 +1390,7 @@ static void test_at()
 
 static void test_in()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -1408,7 +1408,7 @@ static void test_in()
 
 static void test_offset()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" condition: @a == 2 }",
@@ -1430,7 +1430,7 @@ static void test_offset()
 
 static void test_length()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = /m.*?ssi/ condition: !a == 5 }",
@@ -1480,7 +1480,7 @@ static void test_length()
 
 static void test_of()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" $b = \"mis\" $c = \"oops\" "
@@ -1536,7 +1536,7 @@ static void test_of()
 
 void test_for()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { \
@@ -1791,7 +1791,7 @@ void test_for()
 
 void test_re()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { strings: $a = /ssi/ condition: $a }",
@@ -2250,7 +2250,7 @@ void test_re()
 
 static void test_entrypoint()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule_blob(
       "rule test { \
@@ -2278,7 +2278,7 @@ static void test_entrypoint()
 
 static void test_filesize()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   char rule[80];
 
@@ -2296,7 +2296,7 @@ static void test_filesize()
 
 static void test_comments()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test {\n\
@@ -2352,7 +2352,7 @@ static void test_comments()
 
 static void test_matches_operator()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: \"foo\" matches /foo/ }",
@@ -2394,7 +2394,7 @@ static void test_matches_operator()
 
 static void test_global_rules()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "global private rule global_rule { \
@@ -2420,7 +2420,7 @@ static void test_global_rules()
 
 static void test_modules()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "import \"tests\" \
@@ -2617,7 +2617,7 @@ static void test_modules()
 
 static void test_time_module()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
     assert_true_rule(
         "import \"time\" \
@@ -2629,7 +2629,7 @@ static void test_time_module()
 #if defined(HASH_MODULE)
 static void test_hash_module()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   uint8_t blob[] = {0x61, 0x62, 0x63, 0x64, 0x65};
 
@@ -2686,7 +2686,7 @@ static void test_hash_module()
 
 void test_integer_functions()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test { condition: uint8(0) == 0xAA}",
@@ -2716,7 +2716,7 @@ void test_integer_functions()
 
 void test_include_files()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "include \"tests/data/baz.yar\" rule t { condition: baz }",
@@ -2730,7 +2730,7 @@ void test_include_files()
 
 void test_tags()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_true_rule(
       "rule test : tag1 { condition: true}",
@@ -2748,7 +2748,7 @@ void test_tags()
 
 void test_process_scan()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   int pid = fork();
   int status = 0;
@@ -2835,7 +2835,7 @@ void test_process_scan()
 
 void test_performance_warnings()
 {
-  YR_DEBUG_FPRINTF(1, stderr, "+ %s()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() {} \n", __FUNCTION__);
 
   assert_warning(
       "rule test { \

--- a/tests/util.c
+++ b/tests/util.c
@@ -115,14 +115,15 @@ static YR_MEMORY_BLOCK* _yr_test_multi_block_get_next_block(
   }
 
   YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} = %p // "
-    ".base=(0x%lx or %'lu) of (0x%lx or %'lu) .size=%'lu, both including %'lu block overlap%s\n",
-    __FUNCTION__, result,
-    context->current_block.base,
-    context->current_block.base,
-    context->buffer_size,
-    context->buffer_size,
-    context->current_block.size,
-    overlap, overlap ? "" : " (note: 1st block overlap always 0)");
+      ".base=(0x%" PRIx64" or %" PRId64 ") of "
+      "(0x%lx or %'lu) .size=%'lu, both including %" PRId64 " block overlap%s\n",
+      __FUNCTION__, result,
+      context->current_block.base,
+      context->current_block.base,
+      context->buffer_size,
+      context->buffer_size,
+      context->current_block.size,
+      overlap, overlap ? "" : " (note: 1st block overlap always 0)");
 
   return result;
 }
@@ -131,8 +132,9 @@ static YR_MEMORY_BLOCK* _yr_test_multi_block_get_next_block(
 static YR_MEMORY_BLOCK* _yr_test_multi_block_get_first_block(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} // "
-    "wrapping _yr_test_multi_block_get_next_block()\n", __FUNCTION__);
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s() // wrapping _yr_test_multi_block_get_next_block()\n",
+      __FUNCTION__);
 
   yr_test_count_get_block ++;
 
@@ -149,14 +151,18 @@ static const uint8_t* _yr_test_multi_block_fetch_block_data(
   YR_PROC_ITERATOR_CTX* context = (YR_PROC_ITERATOR_CTX*) block->context;
 
   #if YR_DEBUG_VERBOSITY > 0
-  uint64_t overlap = context->current_block.base > 0 ? yr_test_mem_block_size_overlap : 0;
+  uint64_t overlap = context->current_block.base > 0 ?
+      yr_test_mem_block_size_overlap : 0;
   #endif
-  YR_DEBUG_FPRINTF(2, stderr, "+ %s() {} = %p = %p + 0x%lx base including %'lu overlap%s\n",
-    __FUNCTION__,
-    context->buffer + context->current_block.base - overlap,
-    context->buffer,
-    context->current_block.base,
-    overlap, overlap ? "" : " (note: 1st block overlap always 0)");
+  YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s() = %p = %p + 0x%" PRIx64
+      " base including %" PRId64
+      " overlap%s\n",
+      __FUNCTION__,
+      context->buffer + context->current_block.base - overlap,
+      context->buffer,
+      context->current_block.base,
+      overlap, overlap ? "" : " (note: 1st block overlap always 0)");
 
   return context->buffer + context->current_block.base;
 }
@@ -175,8 +181,8 @@ YR_API int _yr_test_single_or_multi_block_scan_mem(
 
   if (yr_test_mem_block_size)
   {
-    YR_DEBUG_FPRINTF(2, stderr, "+ %s(buffer=%p buffer_size=%'lu) {} // "
-      "yr_test_mem_block_size=%'lu\n",
+    YR_DEBUG_FPRINTF(2, stderr,
+      "+ %s(buffer=%p buffer_size=%zu) // yr_test_mem_block_size=%" PRId64 "\n",
        __FUNCTION__,
        buffer,
        buffer_size,

--- a/tests/util.c
+++ b/tests/util.c
@@ -133,7 +133,7 @@ static YR_MEMORY_BLOCK* _yr_test_multi_block_get_first_block(
     YR_MEMORY_BLOCK_ITERATOR* iterator)
 {
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s() // wrapping _yr_test_multi_block_get_next_block()\n",
+      "+ %s() {} // wrapping _yr_test_multi_block_get_next_block()\n",
       __FUNCTION__);
 
   yr_test_count_get_block ++;
@@ -155,7 +155,7 @@ static const uint8_t* _yr_test_multi_block_fetch_block_data(
       yr_test_mem_block_size_overlap : 0;
   #endif
   YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s() = %p = %p + 0x%" PRIx64
+      "+ %s() {} = %p = %p + 0x%" PRIx64
       " base including %" PRId64
       " overlap%s\n",
       __FUNCTION__,
@@ -182,7 +182,8 @@ YR_API int _yr_test_single_or_multi_block_scan_mem(
   if (yr_test_mem_block_size)
   {
     YR_DEBUG_FPRINTF(2, stderr,
-      "+ %s(buffer=%p buffer_size=%zu) // yr_test_mem_block_size=%" PRId64 "\n",
+      "+ %s(buffer=%p buffer_size=%zu) {}"
+      " // yr_test_mem_block_size=%" PRId64 "\n",
        __FUNCTION__,
        buffer,
        buffer_size,


### PR DESCRIPTION
* Use PRIx64 and PRIi64 for printing 64-bits values, which is more portable.
* Use %zu for printing size_t types.
* Remove the empty {} at the end of printed messages, as they don't provide that much information and clutter the format string
* Don't use ' in format strings for thousand separators as this is not very portable (https://stackoverflow.com/questions/10234766/warning-using-icc-and-printf-with-thousands-grouping-format-apostrophe)