### PR TITLE
Fix linux compiler warnings and refactor common test code

### DIFF
--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -799,9 +799,7 @@ void test_issue_920()
 
 int main(int argc, char** argv)
 {
-  char *top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-    chdir(top_srcdir);
+  chdir_if_env_top_srcdir();
 
   test_disabled_rules();
   test_file_descriptor();

--- a/tests/test-dotnet.c
+++ b/tests/test-dotnet.c
@@ -6,9 +6,7 @@
 
 int main(int argc, char** argv)
 {
-  char *top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-    chdir(top_srcdir);
+  chdir_if_env_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-macho.c
+++ b/tests/test-macho.c
@@ -6,9 +6,7 @@
 
 int main(int argc, char** argv)
 {
-  char *top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-    chdir(top_srcdir);
+  chdir_if_env_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -6,9 +6,7 @@
 
 int main(int argc, char** argv)
 {
-  char *top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-    chdir(top_srcdir);
+  chdir_if_env_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2978,9 +2978,7 @@ void test_performance_warnings()
 
 int main(int argc, char** argv)
 {
-  char *top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-    chdir(top_srcdir);
+  chdir_if_env_top_srcdir();
 
   yr_initialize();
 

--- a/tests/util.c
+++ b/tests/util.c
@@ -216,6 +216,17 @@ YR_API int _yr_test_single_or_multi_block_scan_mem(
 }
 
 
+void chdir_if_env_top_srcdir(void)
+{
+  char *top_srcdir = getenv("TOP_SRCDIR");
+  if (top_srcdir)
+  {
+    int result = chdir(top_srcdir);
+    assert_true_expr(0 == result);
+  }
+}
+
+
 //
 // A YR_CALLBACK_FUNC that counts the number of matching and non-matching rules
 // during a scan. user_data must point to a COUNTERS structure.

--- a/tests/util.h
+++ b/tests/util.h
@@ -52,6 +52,8 @@ extern YR_API int _yr_test_single_or_multi_block_scan_mem(
     const uint8_t* buffer,
     size_t buffer_size);
 
+extern void chdir_if_env_top_srcdir(void);
+
 struct COUNTERS
 {
   int rules_matching;


### PR DESCRIPTION
During the Linux build then these warnings appear, and this PR eliminates them and refactors the test code slightly:

```
tests/test-api.c: In function ‘main’:
tests/test-api.c:804:5: warning: ignoring return value of ‘chdir’, declared with attribute warn_unused_result [-Wunused-result]
  804 |     chdir(top_srcdir);
      |     ^~~~~~~~~~~~~~~~~
tests/test-pe.c: In function ‘main’:
tests/test-pe.c:11:5: warning: ignoring return value of ‘chdir’, declared with attribute warn_unused_result [-Wunused-result]
   11 |     chdir(top_srcdir);
      |     ^~~~~~~~~~~~~~~~~
tests/test-rules.c: In function ‘main’:
tests/test-rules.c:2983:5: warning: ignoring return value of ‘chdir’, declared with attribute warn_unused_result [-Wunused-result]
 2983 |     chdir(top_srcdir);
      |     ^~~~~~~~~~~~~~~~~
```