### PR TITLE
Fix issue #1358.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ for:
       APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
   test_script:
-  - cmd: c:/projects/yara/windows/vs2015/Release/test-alignment.exe
+  - cmd: c:/projects/yara/windows/vs2015/%CONFIGURATION%/test-alignment.exe
 
 -
   matrix:
@@ -92,7 +92,7 @@ for:
     verbosity: minimal
 
   test_script:
-  - cmd: c:/projects/yara/windows/vs2015/Debug/test-alignment.exe
+  - cmd: c:/projects/yara/windows/vs2015/%CONFIGURATION%/test-alignment.exe
 
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ for:
       APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
   test_script:
-  - windows/vs2015/Release/test-alignment.exe
+  - cmd: windows/vs2015/Release/test-alignment.exe
 
 -
   matrix:
@@ -92,7 +92,7 @@ for:
     verbosity: minimal
 
   test_script:
-  - windows/vs2015/Debug/test-alignment.exe
+  - cmd: windows/vs2015/Debug/test-alignment.exe
 
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,8 @@ for:
     on:
       APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
-  test: off
+  test_script:
+  - windows/vs2015/Release/test-alignment.exe
 
 -
   matrix:
@@ -90,7 +91,9 @@ for:
     project: windows/vs2015/yara.sln
     verbosity: minimal
 
-  test: off
+  test_script:
+  - windows/vs2015/Debug/test-alignment.exe
+
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This
 # allows connecting to the remote machine and debug issues.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ for:
       APPVEYOR_REPO_TAG: true        # deploy on tag push only
 
   test_script:
-  - cmd: windows/vs2015/Release/test-alignment.exe
+  - cmd: c:/projects/yara/windows/vs2015/Release/test-alignment.exe
 
 -
   matrix:
@@ -92,7 +92,7 @@ for:
     verbosity: minimal
 
   test_script:
-  - cmd: windows/vs2015/Debug/test-alignment.exe
+  - cmd: c:/projects/yara/windows/vs2015/Debug/test-alignment.exe
 
 
 # Uncomment the lines below for enabling Remote Desktop in the Appveyor. This

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -250,7 +250,11 @@ struct YR_NAMESPACE
 
   // Index of this namespace in the array of YR_NAMESPACE structures stored
   // in YR_NAMESPACES_TABLE.
-  uint32_t idx;
+  //
+  // YR_ALIGN(8) forces the idx field to be treated as a 8-bytes field
+  // and therefore the struct's size is 16 bytes. This is necessary only for
+  // 32-bits versions of YARA compiled with Visual Studio. See: #1358.
+  YR_ALIGN(8) uint32_t idx;
 };
 
 

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -369,7 +369,11 @@ struct YR_AC_MATCH
   // position in the input is 6 (the "b" after the "r"), but the match is at
   // position 3. The backtrack field indicates how many bytes the scanner has
   // to go back to find the point where the match actually start.
-  uint16_t backtrack;
+  //
+  // YR_ALIGN(8) forces the backtrack field to be treated as a 8-bytes field
+  // and therefore the struct's size is 40 bytes. This is necessary only for
+  // 32-bits versions of YARA compiled with Visual Studio. See: #1358.
+  YR_ALIGN(8) uint16_t backtrack;
 };
 
 #pragma pack(pop)

--- a/windows/vs2015/test-alignment/test-alignment.vcxproj
+++ b/windows/vs2015/test-alignment/test-alignment.vcxproj
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{76A5B2B8-8844-4278-A33E-CE95261AF6A1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>testalignment</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\tests\test-alignment.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows/vs2015/yara.sln
+++ b/windows/vs2015/yara.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libyara", "libyara\libyara.vcxproj", "{E236CE39-D8F3-4DB6-985C-F2794FF17746}"
 EndProject
@@ -11,6 +11,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "yara", "yara\yara.vcxproj",
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "yarac", "yarac\yarac.vcxproj", "{7C72350B-AA5B-41AD-8957-CE3924A7F11B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E236CE39-D8F3-4DB6-985C-F2794FF17746} = {E236CE39-D8F3-4DB6-985C-F2794FF17746}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-alignment", "test-alignment\test-alignment.vcxproj", "{76A5B2B8-8844-4278-A33E-CE95261AF6A1}"
 	ProjectSection(ProjectDependencies) = postProject
 		{E236CE39-D8F3-4DB6-985C-F2794FF17746} = {E236CE39-D8F3-4DB6-985C-F2794FF17746}
 	EndProjectSection
@@ -47,6 +52,14 @@ Global
 		{7C72350B-AA5B-41AD-8957-CE3924A7F11B}.Release|x64.Build.0 = Release|x64
 		{7C72350B-AA5B-41AD-8957-CE3924A7F11B}.Release|x86.ActiveCfg = Release|Win32
 		{7C72350B-AA5B-41AD-8957-CE3924A7F11B}.Release|x86.Build.0 = Release|Win32
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Debug|x64.ActiveCfg = Debug|x64
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Debug|x64.Build.0 = Debug|x64
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Debug|x86.ActiveCfg = Debug|Win32
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Debug|x86.Build.0 = Debug|Win32
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x64.ActiveCfg = Release|x64
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x64.Build.0 = Release|x64
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x86.ActiveCfg = Release|Win32
+		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The root cause of this issue was that the size of YR_AC_MATCH structure was 36 instead of 49 bytes when compiling for 32-bits with Visual Studio. This caused that rules compiled with a 64-bit version of YARA, or even a 32-bit version for Linux, were invalid when loaded with the 32-bits Windows version.