### PR TITLE
Do not directly include stdbool.h

### DIFF
--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -30,8 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_TYPES_H
 #define YR_TYPES_H
 
-#include <stdbool.h>
-
 #include <yara/arena.h>
 #include <yara/bitmask.h>
 #include <yara/limits.h>


### PR DESCRIPTION
There's a special handling for bool type in utils.h which checks that
stdbool.h is really in the system and uses it, or it defines its own
bool type. All uses of bool type should go through there instead of
direct include of stdbool.h as it can cause issues with compilation
units having different sizes of bool type if they are mixed together.