### PR TITLE
feat: Compatibility to Windows XP

### DIFF
--- a/libyara/modules/pe/pe_utils.c
+++ b/libyara/modules/pe/pe_utils.c
@@ -254,7 +254,7 @@ int64_t pe_rva_to_offset(PE* pe, uint64_t rva)
 
 
 #if !HAVE_TIMEGM
-#if HAVE__MKGMTIME
+#if HAVE__MKGMTIME && !defined(__MINGW32__)
 #define timegm _mkgmtime
 #else
 


### PR DESCRIPTION
Don't use strnlen from the standard library on Windows as it is
not available on old systems like Windows XP. Instead, use the
OpenSSL version, or, if that's not available, create your own.
Similarly don't use strtok_s or _mkgmtime.