### PR TITLE
test-rules: fixed indent

### DIFF
--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -38,7 +38,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "blob.h"
 #include "util.h"
 
-
 static void test_boolean_operators()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -57,7 +56,6 @@ static void test_boolean_operators()
 
   assert_false_rule("rule test { condition: false or false }", NULL);
 }
-
 
 static void test_comparison_operators()
 {
@@ -240,7 +238,6 @@ static void test_arithmetic_operators()
       ERROR_INTEGER_OVERFLOW);
 }
 
-
 static void test_bitwise_operators()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -272,7 +269,6 @@ static void test_bitwise_operators()
 
   assert_false_rule("rule test { condition: 1 | 3 ^ 3 == (1 | 3) ^ 3}", NULL);
 }
-
 
 static void test_string_operators()
 {
@@ -338,7 +334,6 @@ static void test_string_operators()
       "rule test { condition: \"foobarbaz\" endswith \"ba\" }", NULL);
 }
 
-
 static void test_syntax()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -371,7 +366,6 @@ static void test_syntax()
   assert_error("rule test rule test", ERROR_DUPLICATED_IDENTIFIER);
 }
 
-
 static void test_anonymous_strings()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -380,7 +374,6 @@ static void test_anonymous_strings()
       "rule test { strings: $ = \"a\" $ = \"b\" condition: all of them }",
       "ab");
 }
-
 
 #define TEXT_0063_BYTES \
   "[ 123456789 123456789 123456789 123456789 123456789 123456789 ]"
@@ -395,7 +388,6 @@ static void test_anonymous_strings()
 #define TEXT_1024_BYTES                                       \
   TEXT_0256_BYTES_001 TEXT_0256_BYTES_002 TEXT_0256_BYTES_003 \
       TEXT_0256_BYTES_004
-
 
 static void test_strings()
 {
@@ -1005,7 +997,6 @@ static void test_strings()
       "tests/data/base64");
 }
 
-
 static void test_wildcard_strings()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -1022,7 +1013,6 @@ static void test_wildcard_strings()
       "B\x00"
       "C\x00 ---- xyz");
 }
-
 
 static void test_hex_strings()
 {
@@ -1112,7 +1102,6 @@ static void test_hex_strings()
         strings: $a = { 31 32 [-] 33 34 [-] 38 39 } private \
         condition: $a }",
       "1234567890");
-
 
   assert_true_rule(
       "rule test { \
@@ -1254,7 +1243,6 @@ static void test_hex_strings()
   /* TODO: tests.py:551 ff. */
 }
 
-
 static void test_count()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -1266,7 +1254,6 @@ static void test_count()
       "rule test { strings: $a = \"ssi\" private condition: #a == 2 }",
       "mississippi");
 }
-
 
 static void test_at()
 {
@@ -1297,7 +1284,6 @@ static void test_at()
       PE32_FILE);
 }
 
-
 static void test_in()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -1314,7 +1300,6 @@ static void test_in()
         condition: $a in (entrypoint .. entrypoint + 1) }",
       PE32_FILE);
 }
-
 
 static void test_offset()
 {
@@ -1335,7 +1320,6 @@ static void test_offset()
       "rule test { strings: $a = \"ssi\" condition: @a[2] == 5 }",
       "mississippi");
 }
-
 
 static void test_length()
 {
@@ -1385,7 +1369,6 @@ static void test_length()
       "11}",
       "mississippi");
 }
-
 
 static void test_of()
 {
@@ -1437,7 +1420,6 @@ static void test_of()
 
   assert_error("rule test { condition: all of them }", ERROR_UNDEFINED_STRING);
 }
-
 
 void test_for()
 {
@@ -1579,7 +1561,6 @@ void test_for()
       }",
       NULL);
 
-
   assert_false_rule(
       "import \"tests\" \
       rule test { \
@@ -1676,7 +1657,6 @@ void test_for()
       }",
       ERROR_WRONG_TYPE);
 
-
   assert_false_rule(
       "rule test { \
         condition: \
@@ -1692,7 +1672,6 @@ void test_for()
       }",
       NULL);
 }
-
 
 void test_re()
 {
@@ -2141,7 +2120,6 @@ void test_re()
       "abc\xE0\x22");
 }
 
-
 static void test_entrypoint()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2167,7 +2145,6 @@ static void test_entrypoint()
   assert_false_rule("rule test { condition: entrypoint >= 0 }", NULL);
 }
 
-
 static void test_filesize()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2182,7 +2159,6 @@ static void test_filesize()
 
   assert_true_rule_blob(rule, PE32_FILE);
 }
-
 
 static void test_comments()
 {
@@ -2267,7 +2243,6 @@ static void test_matches_operator()
       "rule test { condition: \"foo\\nbar\" matches /foo.*bar/ }", NULL);
 }
 
-
 static void test_global_rules()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2292,7 +2267,6 @@ static void test_global_rules()
       }",
       NULL);
 }
-
 
 static void test_modules()
 {
@@ -2438,7 +2412,6 @@ static void test_modules()
       }",
       NULL);
 
-
   assert_false_rule(
       "import \"tests\" \
       rule test { condition: tests.struct_array[0].i == 1  \
@@ -2486,7 +2459,6 @@ static void test_modules()
   assert_error("import \"\"", ERROR_INVALID_MODULE_NAME);
 }
 
-
 static void test_time_module()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2496,7 +2468,6 @@ static void test_time_module()
         rule test { condition: time.now() > 0 }",
       NULL);
 }
-
 
 #if defined(HASH_MODULE)
 static void test_hash_module()
@@ -2604,7 +2575,6 @@ static void test_hash_module()
 }
 #endif
 
-
 void test_integer_functions()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2628,7 +2598,6 @@ void test_integer_functions()
       "rule test { condition: uint32be(0) == 0xAABBCCDD}", "\xaa\xbb\xcc\xdd");
 }
 
-
 void test_include_files()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
@@ -2639,7 +2608,6 @@ void test_include_files()
   assert_true_rule(
       "include \"tests/data/foo.yar\" rule t { condition: foo }", NULL);
 }
-
 
 void test_tags()
 {
@@ -2653,7 +2621,6 @@ void test_tags()
       "rule test : tag1 tag1 { condition: true}",
       ERROR_DUPLICATED_TAG_IDENTIFIER);
 }
-
 
 void test_process_scan()
 {
@@ -2751,134 +2718,119 @@ void test_process_scan()
   }
 }
 
-
 void test_performance_warnings()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {}\n", __FUNCTION__);
 
   assert_warning("rule test { \
         strings: $a = { 01 } \
-        condition: $a }")
+        condition: $a }");
 
-      assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 ?? } \
-        condition: $a }")
+        condition: $a }");
 
-          assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 ?? ?? } \
-        condition: $a }")
+        condition: $a }");
 
-              assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 ?? ?? 02 } \
-        condition: $a }")
+        condition: $a }");
 
-                  assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 ?? ?2 03 } \
-        condition: $a }")
+        condition: $a }");
 
-                      assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 ?? 02 1? } \
-        condition: $a }")
+        condition: $a }");
 
-                          assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 1? 2? 3? } \
-        condition: $a }")
+        condition: $a }");
 
-                              assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 1? 2? 3? 04 } \
-        condition: $a }")
+        condition: $a }");
 
-                                  assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 1? ?? 03 } \
-        condition: $a }")
+        condition: $a }");
 
-                                      assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 00 01 } \
-        condition: $a }")
+        condition: $a }");
 
-                                          assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 01 00 } \
-        condition: $a }")
+        condition: $a }");
 
-                                              assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 00 00 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                  assert_warning("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 00 00 00 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                      assert_no_warnings(
-                                                          "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 00 00 01 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                          assert_warning(
-                                                              "rule test { \
+  assert_warning("rule test { \
         strings: $a = { 00 00 00 00 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                              assert_no_warnings(
-                                                                  "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 00 00 00 01 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                  assert_warning(
-                                                                      "rule test { \
+  assert_warning("rule test { \
         strings: $a = { FF FF FF FF } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                      assert_no_warnings(
-                                                                          "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 00 00 01 02 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                          assert_no_warnings(
-                                                                              "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 00 01 02 03 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                              assert_no_warnings(
-                                                                                  "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 01 02 03 04 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                                  assert_no_warnings(
-                                                                                      "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 01 02 03 } \
         condition: $a }")
 
-                                                                                      assert_no_warnings(
-                                                                                          "rule test { \
+      assert_no_warnings("rule test { \
         strings: $a = { 20 01 02 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                                          assert_no_warnings(
-                                                                                              "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 01 02 } \
-        condition: $a }")
+        condition: $a }");
 
-                                                                                              assert_no_warnings(
-                                                                                                  "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = \"foo\" wide \
-        condition: $a }")
+        condition: $a }");
 
-                                                                                                  assert_no_warnings(
-                                                                                                      "rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = \"MZ\" \
-        condition: $a }")
+        condition: $a }");
 
-                                                                                                      assert_warning(
-                                                                                                          "rule test { \
+  assert_warning("rule test { \
         strings: $a = \"                    \" xor(0x20) \
-        condition: $a }")
+        condition: $a }");
 
-      // This will eventually xor with 0x41 and should cause a warning.
-      assert_warning("rule test { \
+  // This will eventually xor with 0x41 and should cause a warning.
+  assert_warning("rule test { \
         strings: $a = \"AAAAAAAAAAAAAAAAAAAA\" xor \
-        condition: $a }")
+        condition: $a }");
 }
-
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
I noticed the `assert_warning` in `test-rules.c` has a growing indent due to a new clang-format. I also checked the other files, but it seems this is the only one with this problem.