### PR TITLE
Fix copy/paste mistake in lexer.l

### DIFF
--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -2074,7 +2074,7 @@ YY_RULE_SETUP
 #line 598 "lexer.l"
 {
 
-  lex_check_space_ok("\t", yyextra->lex_buf_len, YR_LEX_BUF_SIZE);
+  lex_check_space_ok("\r", yyextra->lex_buf_len, YR_LEX_BUF_SIZE);
   *yyextra->lex_buf_ptr++ = '\r';
   yyextra->lex_buf_len++;
 }

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -597,7 +597,7 @@ u?int(8|16|32)(be)? {
 
 <str>\\r   {
 
-  lex_check_space_ok("\t", yyextra->lex_buf_len, YR_LEX_BUF_SIZE);
+  lex_check_space_ok("\r", yyextra->lex_buf_len, YR_LEX_BUF_SIZE);
   *yyextra->lex_buf_ptr++ = '\r';
   yyextra->lex_buf_len++;
 }


### PR DESCRIPTION
Looks like this is a harmless copy/paste mistake added in 7a5b3a29cc381b75c42114c17779bee9ea10a79e.