### PR TITLE
Implement pe.entry_point_raw.

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -165,6 +165,8 @@ Reference
 
     Entry point raw value from the optional header of the PE. This value is not
     converted to a file offset or an RVA.
+    
+    .. versionadded:: 4.1.0
 
 .. c:type:: base_of_code
 

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -157,9 +157,14 @@ Reference
 
 .. c:type:: entry_point
 
-    Entry point raw offset or virtual address depending on whether YARA is
+    Entry point file offset or virtual address depending on whether YARA is
     scanning a file or process memory respectively. This is equivalent to the
     deprecated ``entrypoint`` keyword.
+
+.. c:type:: entry_point_raw
+
+    Entry point raw value from the optional header of the PE. This value is not
+    converted to a file offset or an RVA.
 
 .. c:type:: base_of_code
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1583,6 +1583,11 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
       "entry_point");
 
   set_integer(
+      yr_le32toh(OptionalHeader(pe, AddressOfEntryPoint)),
+      pe->object,
+      "entry_point_raw");
+
+  set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, ImageBase))
                        : yr_le32toh(OptionalHeader(pe, ImageBase)),
       pe->object,
@@ -2765,6 +2770,7 @@ begin_declarations
   declare_integer("characteristics");
 
   declare_integer("entry_point");
+  declare_integer("entry_point_raw");
   declare_integer("image_base");
   declare_integer("number_of_rva_and_sizes");
 

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -96,6 +96,14 @@ int main(int argc, char** argv)
       "import \"pe\" \
       rule test { \
         condition: \
+          pe.entry_point_raw == 0x1380 \
+      }",
+      "tests/data/mtxex.dll");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
           pe.linker_version.major == 2 and \
           pe.linker_version.minor == 26 \
       }",


### PR DESCRIPTION
Add pe.entry_point_raw which is the raw value of the entry point field from the
optional header. This value is NOT converted to a file offset or a virtual
address, and is just the raw bytes taken straight from the header.

This allows you to use the entry point as it is specified in the file without
having to jump through hoops to parse it by hand in your condition.