### PR TITLE
Don't use environment variables for controlling block size in tests.

### DIFF
--- a/tests/test-async.c
+++ b/tests/test-async.c
@@ -338,14 +338,8 @@ int main(int argc, char** argv)
 
   assert_true_expr(strlen(TEXT_1024_BYTES) == 1024);
 
-  yr_test_mem_block_size = getenv("YR_TEST_MEM_BLOCK_SIZE")
-                               ? atoi(getenv("YR_TEST_MEM_BLOCK_SIZE"))
-                               : 1024;
-
-  yr_test_mem_block_size_overlap = getenv("YR_TEST_MEM_BLOCK_SIZE_OVERLAP")
-                                       ? atoi(getenv(
-                                             "YR_TEST_MEM_BLOCK_SIZE_OVERLAP"))
-                                       : 256;
+  yr_test_mem_block_size = 1024;
+  yr_test_mem_block_size_overlap = 256;
 
   assert(yr_test_mem_block_size_overlap <= yr_test_mem_block_size);
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2908,13 +2908,8 @@ int main(int argc, char** argv)
     // your module should be prepared to handle that." [1]
     // [1]
     // https://yara.readthedocs.io/en/stable/writingmodules.html#accessing-the-scanned-data
-    yr_test_mem_block_size = getenv("YR_TEST_MEM_BLOCK_SIZE")
-                                 ? atoi(getenv("YR_TEST_MEM_BLOCK_SIZE"))
-                                 : 1024;
-    yr_test_mem_block_size_overlap =
-        getenv("YR_TEST_MEM_BLOCK_SIZE_OVERLAP")
-            ? atoi(getenv("YR_TEST_MEM_BLOCK_SIZE_OVERLAP"))
-            : 256;
+    yr_test_mem_block_size = 1024;
+    yr_test_mem_block_size_overlap = 256;
     assert(yr_test_mem_block_size_overlap <= yr_test_mem_block_size);
     break;
   }

--- a/tests/util.h
+++ b/tests/util.h
@@ -45,7 +45,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern char compile_error[1024];
 extern int warnings;
 
-// Default is 0 for production, which means use 1 block for contiguous memory.
 // For testing, 1024 means split contiguous memory into max 1024 byte blocks.
 // See https://github.com/VirusTotal/yara/issues/1356
 extern uint64_t yr_test_mem_block_size;


### PR DESCRIPTION
If yr_test_mem_block_size is changed to something else test-async breaks, so being able to change this value with an environment variable is not very useful if the tests can't adapt to different sizes.