### PR TITLE
Sandbox: Fix loop in `CollectMatches()`

### DIFF
--- a/bazel/yara_deps.bzl
+++ b/bazel/yara_deps.bzl
@@ -27,11 +27,9 @@
 
 """Load dependencies needed to compile YARA as a 3rd-party consumer."""
 
-
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
 
 def yara_deps():
     """Loads common dependencies needed to compile YARA."""

--- a/sandbox/collect_matches.cc
+++ b/sandbox/collect_matches.cc
@@ -71,7 +71,6 @@ int CollectMatches(
       meta->set_bytes_value(rule_meta->string);
       break;
     }
-    ++rule_meta;
   }
 
   return ERROR_SUCCESS;


### PR DESCRIPTION
The `CollectMatches()` function uses the `yr_rule_metas_foreach()`
macro iterate over the rule metadata. The macro expands to a for-loop
that already increments the loop variable, so we should not do this
again.

Drive-by:
- Run Buildifier on `bazel/yara_deps.bzl`, deleting a few empty lines

Signed-off-by: Christian Blichmann <cblichmann@google.com>