### PR TITLE
Add convention checker for portable modifiers

### DIFF
--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -1142,7 +1142,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, void *yyscanne
   unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %" PRIu64 "):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
@@ -1671,7 +1671,7 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
+      YYDPRINTF ((stderr, "Stack size increased to %" PRIu64 "\n",
                   (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)

--- a/libyara/hex_grammar.c
+++ b/libyara/hex_grammar.c
@@ -705,7 +705,7 @@ static void yy_reduce_print(
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF(
-      stderr, "Reducing stack by rule %d (line %lu):\n", yyrule - 1, yylno);
+      stderr, "Reducing stack by rule %d (line %" PRIu64 "):\n", yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
   {
@@ -1213,7 +1213,7 @@ yysetstate:
 
     YYDPRINTF(
         (stderr,
-         "Stack size increased to %lu\n",
+         "Stack size increased to %" PRIu64 "\n",
          (unsigned long int) yystacksize));
 
     if (yyss + yystacksize - 1 <= yyssp)

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -169,7 +169,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
   YR_DEBUG_FPRINTF(
       2,
       stderr,
-      "- %s() {} = %p // .base=0x%" PRIx64 " .size=%lu\n",
+      "- %s() {} = %p // .base=0x%" PRIx64 " .size=%" PRIu64 "\n",
       __FUNCTION__,
       result,
       context->current_block.base,

--- a/libyara/re_grammar.c
+++ b/libyara/re_grammar.c
@@ -735,7 +735,7 @@ static void yy_reduce_print(
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF(
-      stderr, "Reducing stack by rule %d (line %lu):\n", yyrule - 1, yylno);
+      stderr, "Reducing stack by rule %d (line %" PRIu64 "):\n", yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
   {
@@ -1225,7 +1225,7 @@ yysetstate:
 
     YYDPRINTF(
         (stderr,
-         "Stack size increased to %lu\n",
+         "Stack size increased to %" PRIu64 "\n",
          (unsigned long int) yystacksize));
 
     if (yyss + yystacksize - 1 <= yyssp)

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -632,7 +632,7 @@ static int _yr_scan_match_callback(
       2,
       stderr,
       "+ %s(match_data=%p match_length=%d) { //"
-      " match_offset=%ld args->data=%p args->string.length=%u"
+      " match_offset=%" PRId64 " args->data=%p args->string.length=%u"
       " args->data_base=0x%" PRIx64 " args->data_size=%zu"
       " args->forward_matches=%'u\n",
       __FUNCTION__,

--- a/tests/convention-portable-modifiers
+++ b/tests/convention-portable-modifiers
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# pseudo code:
+# - find all .[ch] files in libyara/
+# - grep for non-portable modifiers
+
+set -e
+find . -type f | egrep "\.[ch]$" | xargs egrep --line-number "\%\'{0,1}l[dux]" | perl -lane '
+  printf qq[- convention: non-portable modifier: %s\n], $_;
+  $single_quote = chr(0x27);
+  s~\%$single_quote{0,1}l([dux])~\%" PRI${1}64 "~g;
+  printf qq[- convention:     portable modifier: %s\n], $_;
+  $violation_count ++;
+  sub END {
+    if ($violation_count > 0) {
+      printf qq[- convention: non-portable modifier: %u instances found above; please fix\n], $violation_count;
+      exit(1);
+    }
+    printf qq[- convention: non-portable modifier: none found\n];
+  }'
+
+exit 0

--- a/tests/util.c
+++ b/tests/util.c
@@ -193,7 +193,8 @@ static YR_MEMORY_BLOCK* _yr_test_multi_block_get_next_block(
       stderr,
       "- %s() {} = %p // "
       ".base=(0x%" PRIx64 " or %" PRId64 ") of "
-      "(0x%lx or %'lu) .size=%'lu, both including %" PRId64
+      "(0x%" PRIx64 " or %" PRIu64 ") .size=%" PRIu64
+      ", both including %" PRId64
       " block overlap%s\n",
       __FUNCTION__,
       result,


### PR DESCRIPTION
E.g.:
```
$ make clean ; ./tests/convention-portable-modifiers && make --jobs `nproc` check CC="gcc -DYR_DEBUG_VERBOSITY=2" YR_DEBUG_VERBOSITY=2
```