### PR TITLE
Move global yr_cryptprov definition from header to to C file

### DIFF
--- a/libyara/crypto.h
+++ b/libyara/crypto.h
@@ -60,7 +60,7 @@ typedef SHA256_CTX yr_sha256_ctx;
 
 #include <wincrypt.h>
 
-HCRYPTPROV yr_cryptprov;
+extern HCRYPTPROV yr_cryptprov;
 
 typedef HCRYPTHASH yr_md5_ctx;
 typedef HCRYPTHASH yr_sha1_ctx;

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -102,6 +102,12 @@ static void _locking_function(int mode, int n, const char *file, int line)
 
 #endif
 
+#if defined(HAVE_WINCRYPT_H)
+
+HCRYPTPROV yr_cryptprov;
+
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 // Should be called by main thread before using any other
 // function from libyara.


### PR DESCRIPTION
This fixes build failures of Microsoft Crypto API support with GCC 10
as observed on Debian/unstable (gcc-mingw-w64/10.2.0-18+24) and on
MSYS2 (mingw-w64-x86_64-gcc/10.2.0-6):

```
/usr/bin/x86_64-w64-mingw32-ld: /BUILDPATH/libyara/.libs/libyara.a(pe.o):pe.c:(.bss+0x0): multiple definition of `yr_cryptprov'; /BUILDPATH/libyara/.libs/libyara.a(libyara.o):libyara.c:(.bss+0x208): first defined here
/usr/bin/x86_64-w64-mingw32-ld: /BUILDPATH/libyara/.libs/libyara.a(hash.o):hash.c:(.bss+0x0): multiple definition of `yr_cryptprov'; /BUILDPATH/libyara/.libs/libyara.a(libyara.o):libyara.c:(.bss+0x208): first defined here
```