### PR TITLE
pe: add signature[i].algorithm_oid

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -746,7 +746,26 @@ Reference
 
     .. c:member:: algorithm
 
-        Algorithm used for this signature. Usually "sha1WithRSAEncryption".
+        String representation of the algorithm used for this
+	signature. Usually "sha1WithRSAEncryption". It depends on the
+	X.509 and PKCS#7 implementationss and possibly their versions,
+	consider using algorithm_oid instead.
+
+    .. c:member:: algorithm_oid
+
+        Object ID of the algorithm used for this signature, expressed
+        in numeric ASN.1 dot notation. The name contained in
+        algorithm is derived from this value. The object id is
+        expected to be stable across X.509 and PKCS#7 implementations
+        and their versions.
+
+	For example, when using the current OpenSSL-based implementation::
+
+	    algorithm_oid == "1.2.840.113549.1.1.11"
+
+	is functionally equivalent to::
+
+            algorithm == "sha1WithRSAEncryption"
 
     .. c:member:: serial
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1246,7 +1246,7 @@ void _parse_pkcs7(PE* pe, PKCS7* pkcs7, int* counter)
 {
   int i, j;
   time_t date_time;
-  const char* sig_alg;
+  int sig_nid;
   char buffer[256];
   int bytes;
   int idx;
@@ -1302,9 +1302,10 @@ void _parse_pkcs7(PE* pe, PKCS7* pkcs7, int* counter)
         "signatures[%i].version",
         *counter);
 
-    sig_alg = OBJ_nid2ln(X509_get_signature_nid(cert));
-
-    set_string(sig_alg, pe->object, "signatures[%i].algorithm", *counter);
+    sig_nid = X509_get_signature_nid(cert);
+    set_string(OBJ_nid2ln(sig_nid), pe->object, "signatures[%i].algorithm", *counter);
+    OBJ_obj2txt(buffer, sizeof(buffer), OBJ_nid2obj(sig_nid), 1);
+    set_string(buffer, pe->object, "signatures[%i].algorithm_oid", *counter);
 
     serial = X509_get_serialNumber(cert);
 
@@ -2920,6 +2921,7 @@ begin_declarations
     declare_string("subject");
     declare_integer("version");
     declare_string("algorithm");
+    declare_string("algorithm_oid");
     declare_string("serial");
     declare_integer("not_before");
     declare_integer("not_after");


### PR DESCRIPTION
Certificate signature algorithms are encoded using object identifiers
whose text representations depend on the cryptographic library. For
stable YARA rules, it is wiser to rely on the OID, so let's provide
it.

For example, while OpenSSL 1.1.1d resolves 1.2.840.113549.1.1.11 to
"sha256WithRSAEncryption" (or "RSA-SHA256" for the short name), the
only string representation I have gotten out of the Windows CryptoAPI
is "sha256RSA".