### PR TITLE
build: Add yara/yarac -> libyara dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ yara_SOURCES = \
   cli/yara.c
 
 yara_LDADD = -Llibyara/.libs -lyara
+yara_DEPENDENCIES = libyara/.libs/libyara.la
 
 yarac_SOURCES = \
    cli/args.c \
@@ -51,6 +52,7 @@ yarac_SOURCES = \
    cli/yarac.c
 
 yarac_LDADD = -Llibyara/.libs -lyara
+yarac_DEPENDENCIES = libyara/.libs/libyara.la
 
 test_alignment_SOURCES = tests/test-alignment.c
 test_arena_SOURCES = tests/test-arena.c


### PR DESCRIPTION
Rebuilding by typing "make" did not rebuild static yarac
or yara if changes had been made to the library.

This is fixed by adding explicit dependencies.