### PR TITLE
Feature: Add dynsym objects to ELF module

### DIFF
--- a/tests/test-elf.c
+++ b/tests/test-elf.c
@@ -126,6 +126,29 @@ int main(int argc, char** argv)
       "import \"elf\" \
       rule test { \
         condition: \
+          for any i in (0..elf.dynsym_entries): ( \
+            elf.dynsym[i].shndx == 11 and \
+            elf.dynsym[i].value == 0x400910 and \
+            elf.dynsym[i].name == \"_fini\") \
+      }",
+      ELF32_MIPS_FILE);
+
+  assert_true_rule_blob(
+      "import \"elf\" \
+      rule test { \
+        condition: \
+          elf.dynsym[9].name == \"__RLD_MAP\" and \
+          elf.dynsym[9].type == elf.STT_OBJECT and \
+          elf.dynsym[9].bind == elf.STB_GLOBAL and \
+          elf.dynsym[9].value == 0x411000 and \
+          elf.dynsym[9].size == 0 \
+      }",
+      ELF32_MIPS_FILE);
+
+  assert_true_rule_blob(
+      "import \"elf\" \
+      rule test { \
+        condition: \
           elf.dynamic[4].type == elf.DT_STRTAB and \
           elf.dynamic[4].val == 0x400484\
       }",


### PR DESCRIPTION
This pull request expands the ELF module in **exposing the dynamic symbol table**.

And I want to expose dynamic symbol table since _symbol table_ is deferent from _dynamic symbol table_,

the issue `https://github.com/VirusTotal/yara/pull/1395#issuecomment-748930851`  has mentioned this problem.

For example, we can't find `.symtab` section if the binary has been stripped symbols, and this is common in some dynamic libraries like Glibc.

But `.dynsym` always been required when we compile dynamical linked binaries. 

In this pull request feature, you can use dynamic table like _symtab_ methods:

```yara
import "elf"

rule elf_test {
    meta: 
        description = "elf_test"
    condition:
        for any i in (0 .. elf.dynsym_entries): (
            elf.dynsym[i].type == elf.STT_FUNC and
            elf.dynsym[i].name == "__asan_unregister_globals"
        ) 
}
```

# Reference

> `dynsym_entries` : Number of entries in the dynamic symbol table found in the ELF file.

> `dynsym` : A zero-based array of dynamic symbol objects, one for each entry in found in the ELF's DYNSYM. Individual  symbol objects can be accessed by using the [] operator. Each symbol object has the following attributes:

| Attribute | Describe                                                     |
| --------- | ------------------------------------------------------------ |
| name      | The symbol's name.                                           |
| value     | A value associated with the symbol. Generally a virtual address. |
| size      | The symbol's size.                                           |
| type      | The type of symbol. Built values are: `STT_NOTYPE`,`STT_OBJECT`, `STT_FUNC`, `STT_SECTION`, `STT_FILE`, `STT_COMMON`, `STT_TLS` |
| bind      | The binding of the symbol. Builtin values are: `STB_LOCAL`, `STB_GLOBAL`, `STB_WEAK` |
| shndx     | The section index which the symbol is associated with.       |

