### PR TITLE
Fix tiny typo in Yara.Match docs

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -437,7 +437,7 @@ Reference
 
   .. py:attribute:: tags
 
-    Array of strings containig the tags associated to the matching rule.
+    Array of strings containing the tags associated to the matching rule.
 
   .. py:attribute:: meta
 


### PR DESCRIPTION
Sorry for the tiny pull request, just happened to catch this as I was reading for my own purposes. make any changes you need to, and I hope that I haven’t screwed something up.