### PR TITLE
Fix overlay docs.

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -589,7 +589,7 @@ Reference
         Overlay section size. This is 0 for PE files that don't have overlaid
         data and undefined for non-PE files.
 
-    *Example: uint8(0x0d) at pe.overlay.offset and pe.overlay.size > 1024*
+    *Example: uint8(pe.overlay.offset) == 0x0d and pe.overlay.size > 1024*
 
 .. c:type:: number_of_resources
 


### PR DESCRIPTION
Fix a bug in the overlay docs so that the example is syntactically valid.

Fixes #1455