### PR TITLE
Fix build failure for test programs on gcc-10

### DIFF
--- a/tests/util.h
+++ b/tests/util.h
@@ -127,7 +127,7 @@ int do_nothing(
     void* message_data,
     void* user_data);
 
-int matches_blob_uses_default_iterator;
+extern int matches_blob_uses_default_iterator;
 
 int matches_blob(
     char* rule,


### PR DESCRIPTION
Previously, gcc (Debian 10.2.1-6) 10.2.1 20210110 gave the following error message:

/usr/bin/ld: tests/util.o:(.data+0x0): multiple definition of `matches_blob_uses_default_iterator'; tests/test-arena.o:(.bss+0x0): first defined here