### PR TITLE
Tests: Set top_srcdir variable instead of changing directory

### DIFF
--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -118,7 +118,7 @@ void test_file_descriptor()
     exit(1);
   }
 #else
-  int fd = open("tests/data/baz.yar", O_RDONLY);
+  int fd = open(prefix_top_srcdir("tests/data/baz.yar"), O_RDONLY);
   if (fd < 0)
   {
     perror("open");
@@ -830,7 +830,7 @@ void test_runtime_warnings() {
 
   yr_compiler_destroy(compiler);
 
-  if (yr_rules_scan_file(rules, "tests/data/x.txt", 0, count, &counters, 0) != ERROR_SUCCESS) {
+  if (yr_rules_scan_file(rules, prefix_top_srcdir("tests/data/x.txt"), 0, count, &counters, 0) != ERROR_SUCCESS) {
     yr_rules_destroy(rules);
     perror("yr_rules_scan_file");
     exit(EXIT_FAILURE);
@@ -853,7 +853,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, argv[0]);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
 
   test_disabled_rules();
   test_file_descriptor();

--- a/tests/test-async.c
+++ b/tests/test-async.c
@@ -327,7 +327,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, argv[0]);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-dotnet.c
+++ b/tests/test-dotnet.c
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, argv[0]);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-macho.c
+++ b/tests/test-macho.c
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, argv[0]);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-pb.c
+++ b/tests/test-pb.c
@@ -38,6 +38,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, __FILE__);
 
+  init_top_srcdir();
   yr_initialize();
 
   assert_true_rule_module_data_file(

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { // in %s\n", __FUNCTION__, argv[0]);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
 
   yr_initialize();
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2737,11 +2737,20 @@ void test_include_files()
 {
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() {\n", __FUNCTION__);
 
-  assert_true_rule(
-      "include \"tests/data/baz.yar\" rule t { condition: baz }", NULL);
+  char rule[4096];
+  snprintf(
+      rule,
+      sizeof(rule),
+      "include \"%s/tests/data/baz.yar\" rule t { condition: baz }",
+      top_srcdir);
+  assert_true_rule(rule, NULL);
 
-  assert_true_rule(
-      "include \"tests/data/foo.yar\" rule t { condition: foo }", NULL);
+  snprintf(
+      rule,
+      sizeof(rule),
+      "include \"%s/tests/data/foo.yar\" rule t { condition: foo }",
+      top_srcdir);
+  assert_true_rule(rule, NULL);
 
   YR_DEBUG_FPRINTF(1, stderr, "} // %s()\n", __FUNCTION__);
 }
@@ -3129,7 +3138,7 @@ int main(int argc, char** argv)
   YR_DEBUG_INITIALIZE();
   YR_DEBUG_FPRINTF(1, stderr, "+ %s() { \n", __FUNCTION__);
 
-  chdir_if_env_top_srcdir();
+  init_top_srcdir();
   yr_initialize();
 
   assert_true_expr(strlen(TEXT_1024_BYTES) == 1024);

--- a/tests/util.c
+++ b/tests/util.c
@@ -292,14 +292,20 @@ void init_test_iterator(
   }
 }
 
-void chdir_if_env_top_srcdir(void)
+char* top_srcdir;
+
+void init_top_srcdir(void)
 {
-  char* top_srcdir = getenv("TOP_SRCDIR");
-  if (top_srcdir)
-  {
-    int result = chdir(top_srcdir);
-    assert_true_expr(0 == result);
-  }
+  top_srcdir = getenv("TOP_SRCDIR");
+  if (!top_srcdir)
+    top_srcdir = ".";
+}
+
+char* prefix_top_srcdir(char* dir)
+{
+  static char buf[4096];
+  snprintf(buf, sizeof(buf), "%s/%s", top_srcdir, dir);
+  return buf;
 }
 
 //

--- a/tests/util.h
+++ b/tests/util.h
@@ -79,8 +79,11 @@ struct YR_TEST_ITERATOR_CTX
   int blocks_returned_successfully;
 };
 
+extern char* top_srcdir;
 
-extern void chdir_if_env_top_srcdir(void);
+extern void init_top_srcdir(void);
+
+extern char* prefix_top_srcdir(char* dir);
 
 struct COUNTERS
 {
@@ -209,7 +212,7 @@ void assert_hex_atoms(
   do {                                                                  \
     char* buf;                                                          \
     size_t sz;                                                          \
-    if ((sz = read_file(filename, &buf)) == -1) {                       \
+    if ((sz = read_file(prefix_top_srcdir(filename), &buf)) == -1) {    \
       fprintf(stderr, "%s:%d: cannot read file '%s'\n",                 \
               __FILE__, __LINE__, filename);                            \
       exit(EXIT_FAILURE);                                               \
@@ -252,7 +255,7 @@ void assert_hex_atoms(
   do {                                                                  \
     char* buf;                                                          \
     size_t sz;                                                          \
-    if ((sz = read_file(filename, &buf)) == -1) {                       \
+    if ((sz = read_file(prefix_top_srcdir(filename), &buf)) == -1) {    \
       fprintf(stderr, "%s:%d: cannot read file '%s'\n",                 \
               __FILE__, __LINE__, filename);                            \
       exit(EXIT_FAILURE);                                               \
@@ -270,7 +273,7 @@ void assert_hex_atoms(
   do {                                                                  \
     char* buf;                                                          \
     size_t sz;                                                          \
-    if ((sz = read_file(filename, &buf)) == -1) {                       \
+    if ((sz = read_file(prefix_top_srcdir(filename), &buf)) == -1) {    \
       fprintf(stderr, "%s:%d: cannot read file '%s'\n",                 \
               __FILE__, __LINE__, filename);                            \
       exit(EXIT_FAILURE);                                               \


### PR DESCRIPTION
I stumbled across the current behavior (`$TOP_SRCDIR` set -> chdir) that I introduced a couple of years ago. I tried adding a test case that involves a helper program is built in `$builddir`, of course. This patch should make behavior somewhat clearer  and less surprising.

Other than getting rid of the chdir and fixing up paths, there are no functional changes.