### PR TITLE
Reduce memory pressure caused by Linux process scanning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,9 @@ yarac_SOURCES = \
 yarac_LDADD = -Llibyara/.libs -lyara
 yarac_DEPENDENCIES = libyara/.libs/libyara.la
 
+tests_mapper_SOURCES = tests/mapper.c
+tests_mapper_CFLAGS = -O0
+
 test_alignment_SOURCES = tests/test-alignment.c tests/util.c
 test_alignment_LDADD = libyara/.libs/libyara.a
 test_arena_SOURCES = tests/test-arena.c tests/util.c
@@ -62,6 +65,9 @@ test_atoms_SOURCES = tests/test-atoms.c tests/util.c
 test_atoms_LDADD = libyara/.libs/libyara.a
 test_rules_SOURCES = tests/test-rules.c tests/util.c
 test_rules_LDADD = libyara/.libs/libyara.a
+if POSIX
+EXTRA_test_rules_DEPENDENCIES = tests/mapper$(EXEEXT)
+endif
 test_pe_SOURCES = tests/test-pe.c tests/util.c
 test_pe_LDADD = libyara/.libs/libyara.a
 test_elf_SOURCES = tests/test-elf.c tests/util.c
@@ -82,7 +88,7 @@ test_async_SOURCES = tests/test-async.c tests/util.c
 test_async_LDADD = libyara/.libs/libyara.a
 
 TESTS = $(check_PROGRAMS)
-TESTS_ENVIRONMENT = TOP_SRCDIR=$(top_srcdir)
+TESTS_ENVIRONMENT = TOP_SRCDIR=$(top_srcdir) TOP_BUILDDIR=$(top_builddir)
 
 check_PROGRAMS = \
   test-arena \
@@ -98,6 +104,9 @@ check_PROGRAMS = \
   test-stack \
   test-re-split \
   test-async
+
+EXTRA_PROGRAMS = tests/mapper
+CLEANFILES = tests/mapper$(EXEEXT)
 
 if POSIX
 # The -fsanitize=address option makes test-exception fail. Include the test

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -78,6 +78,12 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "mapper",
+    srcs = ["mapper.c"],
+    copts = ["-O0"],
+)
+
 cc_test(
     name = "test_rules",
     srcs = ["test-rules.c"],
@@ -96,6 +102,7 @@ cc_test(
         ":blob",
         ":util",
         "@//:libyara",
+        ":mapper",
     ],
 )
 

--- a/tests/mapper.c
+++ b/tests/mapper.c
@@ -1,0 +1,61 @@
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+char str[] = "!dlrow ,olleH";
+int fd;
+
+char* map_file(char* path)
+{
+  if ((fd = open(path, O_RDONLY)) < 0)
+  {
+    fprintf(stderr, "open: %s: %s\n", path, strerror(errno));
+    exit(1);
+  }
+  char* rv = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+  if (rv == NULL)
+  {
+    fprintf(stderr, "mmap: %s: failed: %s\n", path, strerror(errno));
+    exit(1);
+  }
+  close(fd);
+  return rv;
+}
+
+int main(int argc, char** argv)
+{
+  char* buf;
+  if (argc < 2)
+  {
+    fprintf(stderr, "no argument\n");
+    exit(1);
+  }
+  else if (strcmp(argv[1], "open") == 0)
+  {
+    if (argc < 3)
+      exit(1);
+    printf("%s: %s %s\n", argv[0], argv[1], argv[2]);
+    buf = map_file(argv[2]);
+  }
+  else if (strcmp(argv[1], "patch") == 0)
+  {
+    if (argc < 3)
+      exit(1);
+    printf("%s: %s %s\n", argv[0], argv[1], argv[2]);
+    buf = map_file(argv[2]);
+    for (int i = 0; i < sizeof(str) - 1; i++) buf[i] = str[sizeof(str) - i - 2];
+  }
+  else
+  {
+    fprintf(stderr, "unknown argument <%s>\n", argv[1]);
+    exit(1);
+  }
+  sleep(3600);
+}


### PR DESCRIPTION
Reading memory pages from /proc/$PID/mem has the unpleasant side                                                                            
effect of forcing otherwise unused process memory pages into the                                                                            
target process VM, considerably increasing the target process'                                                                              
resident set size.                                                                                                                          
                                                                                                                                            
As a typical example, many programs only make use of a subset of code                                                                       
from shared libraries that they are linked against. The solution                                                                            
consists of replicating memory mappings mappings from files if they                                                                         
are direcly available through the filesystem. All information needed                                                                        
to find the file (and to determine if it is indeed identical to the                                                                         
file mapped by the target process) is available from /proc/$PID/maps.                                                                       
Only pages that may have been changed according to /proc/$PID/pagemap                                                                       
are then read via /proc/$PID/mem to overwrite the local mapping.                                                                            
                                                                                                                                            
Mappings whose underlying filesystem object has changed read from                                                                           
/proc/$PID/mem as before.                                                                                                                   
                                                                                                                                            
Mappings that are not backed by a regular file (block devices, stack                                                                        
or heap sections, etc.) are assumed to behave like zeroed-out files                                                                         
and otherwise treated the same.