### PR TITLE
fix: undeclared variable c

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -161,10 +161,13 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 
   // If we haven't read the whole line, skip over the rest.
   if (strrchr(buffer, '\n') == NULL)
+  {
+    int c;
     do
     {
-      int c = fgetc(proc_info->maps);
+      c = fgetc(proc_info->maps);
     } while (c >= 0 && c != '\n');
+  }
 
   iterator->last_error = ERROR_SUCCESS;
 


### PR DESCRIPTION
I was trying to compile the current master on linux and it failed because of an undeclared variable c. I fixed the issue in the loop, without further investigating what the loop or the code around it actually does. yara now builds again without errors.