### PR TITLE
test-rules: Increase sleep duration of spawned shell process

### DIFF
--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2792,7 +2792,7 @@ void test_process_scan()
             "/bin/sh",
             "/bin/sh",
             "-c",
-            "VAR='Hello, world!'; sleep 5; true",
+            "VAR='Hello, world!'; sleep 600; true",
             NULL) == -1)
       exit(1);
   }


### PR DESCRIPTION
This will not increase the usual time the test takes because the sleep
is interrupted with a SIGALRM after the scan.

Close: #1474