### PR TITLE
Fix OpenBSD include order to correct unknown type errors and broken compilation

### DIFF
--- a/libyara/proc/openbsd.c
+++ b/libyara/proc/openbsd.c
@@ -29,11 +29,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(USE_OPENBSD_PROC)
 
-#include <errno.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/sysctl.h>
-#include <sys/types.h>
 #include <sys/wait.h>
+#include <errno.h>
+
 #include <yara/error.h>
 #include <yara/mem.h>
 #include <yara/proc.h>


### PR DESCRIPTION
After 4.0.5, the proc/openbsd.c has had the list of includes sorted in alphabetical order, which breaks compilation with numerous `unknown type name` errors. This fix reverts back the ordering and allows compilation to complete successfully. Tested OK on OpenBSD 6.9.