### PR TITLE
Fix table syntax of writingrules.rsf

### DIFF
--- a/docs/writingrules.rst
+++ b/docs/writingrules.rst
@@ -33,51 +33,46 @@ keywords are reserved and cannot be used as an identifier:
      - base64
      - base64wide
      - condition
-     - contains
-   * - endswith
+   * - contains
+     - endswith
      - entrypoint
      - false
      - filesize
      - for
      - fullword
      - global
-     - import
+   * - import
      - icontains
-   * - iendswith
+     - iendswith
      - in
      - include
      - int16
      - int16be
      - int32
-     - int32be
+   * - int32be
      - int8
      - int8be
-   * - istartswith
+     - istartswith
      - matches
      - meta
      - nocase
      - not
-     - of
+   * - of
      - or
      - private
      - rule
-   * - startswith
+     - startswith
      - strings
      - them
      - true
-     - uint16
+   * - uint16
      - uint16be
      - uint32
      - uint32be
-   * - uint8
+     - uint8
      - uint8be
      - wide
      - xor
-     -
-     -
-     -
-     -
-     -
 
 Rules are generally composed of two sections: strings definition and condition.
 The strings definition section can be omitted if the rule doesn't rely on any


### PR DESCRIPTION
I fixed syntax of table in writingrules.rst
・“YARA keywords” table has syntax error, and it table couldn't see on the document page.
・I changed that some '*' positions.