### PR TITLE
Fix bitwise shift UB in filemap_fd on windows

### DIFF
--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -80,7 +80,7 @@ YR_API int yr_filemap_map(const char* file_path, YR_MAPPED_FILE* pmapped_file)
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -110,7 +110,7 @@ YR_API int yr_filemap_map_fd(
     return ERROR_COULD_NOT_OPEN_FILE;
   }
 
-  if (offset > (off_t) file_size)
+  if (offset > (uint64_t) file_size)
     return ERROR_COULD_NOT_MAP_FILE;
 
   if (size == 0)
@@ -179,7 +179,7 @@ YR_API int yr_filemap_map_fd(
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -257,7 +257,7 @@ YR_API int yr_filemap_map_fd(
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -291,7 +291,7 @@ YR_API int yr_filemap_map_ex(
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {

--- a/libyara/include/yara/filemap.h
+++ b/libyara/include/yara/filemap.h
@@ -61,14 +61,14 @@ YR_API int yr_filemap_map(const char* file_path, YR_MAPPED_FILE* pmapped_file);
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file);
 
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file);
 


### PR DESCRIPTION
Fixes #1302

This changes every `off_t` to a `uint64_t` so we know for sure the file offset is always 64 bits.