### PR TITLE
Fix table syntax of writingrules.rsf (#1488)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ for:
     verbosity: minimal
 
   after_build:
-  - cmd: 7z a yara-%APPVEYOR_BUILD_VERSION%-%ARTIFACT_POSTFIX%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\*.exe
+  - cmd: 7z a yara-%APPVEYOR_BUILD_VERSION%-%ARTIFACT_POSTFIX%.zip %APPVEYOR_BUILD_FOLDER%\windows\%TARGET%\%CONFIGURATION%\yara*.exe
 
   artifacts:
   - path: yara-$(APPVEYOR_BUILD_VERSION)-$(ARTIFACT_POSTFIX).zip

--- a/docs/modules/elf.rst
+++ b/docs/modules/elf.rst
@@ -60,6 +60,7 @@ Reference
 
     Integer with one of the following values:
 
+    .. c:type:: EM_NONE
     .. c:type:: EM_M32
     .. c:type:: EM_SPARC
     .. c:type:: EM_386

--- a/docs/writingrules.rst
+++ b/docs/writingrules.rst
@@ -33,51 +33,46 @@ keywords are reserved and cannot be used as an identifier:
      - base64
      - base64wide
      - condition
-     - contains
-   * - endswith
+   * - contains
+     - endswith
      - entrypoint
      - false
      - filesize
      - for
      - fullword
      - global
-     - import
+   * - import
      - icontains
-   * - iendswith
+     - iendswith
      - in
      - include
      - int16
      - int16be
      - int32
-     - int32be
+   * - int32be
      - int8
      - int8be
-   * - istartswith
+     - istartswith
      - matches
      - meta
      - nocase
      - not
-     - of
+   * - of
      - or
      - private
      - rule
-   * - startswith
+     - startswith
      - strings
      - them
      - true
-     - uint16
+   * - uint16
      - uint16be
      - uint32
      - uint32be
-   * - uint8
+     - uint8
      - uint8be
      - wide
      - xor
-     -
-     -
-     -
-     -
-     -
 
 Rules are generally composed of two sections: strings definition and condition.
 The strings definition section can be omitted if the rule doesn't rely on any

--- a/docs/writingrules.rst
+++ b/docs/writingrules.rst
@@ -458,7 +458,7 @@ Base64 strings
 The ``base64`` modifier can be used to search for strings that have been base64
 encoded. A good explanation of the technique is at:
 
-https://www.leeholmes.com/blog/2019/12/10/searching-for-content-in-base-64-strings-2/
+https://www.leeholmes.com/searching-for-content-in-base-64-strings/
 
 The following rule will search for the three base64 permutations of the string
 "This program cannot":

--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -80,7 +80,7 @@ YR_API int yr_filemap_map(const char* file_path, YR_MAPPED_FILE* pmapped_file)
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -110,7 +110,7 @@ YR_API int yr_filemap_map_fd(
     return ERROR_COULD_NOT_OPEN_FILE;
   }
 
-  if (offset > (off_t) file_size)
+  if (offset > (uint64_t) file_size)
     return ERROR_COULD_NOT_MAP_FILE;
 
   if (size == 0)
@@ -179,7 +179,7 @@ YR_API int yr_filemap_map_fd(
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -257,7 +257,7 @@ YR_API int yr_filemap_map_fd(
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -291,7 +291,7 @@ YR_API int yr_filemap_map_ex(
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {

--- a/libyara/include/yara/filemap.h
+++ b/libyara/include/yara/filemap.h
@@ -61,14 +61,14 @@ YR_API int yr_filemap_map(const char* file_path, YR_MAPPED_FILE* pmapped_file);
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file);
 
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    uint64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file);
 

--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -209,17 +209,23 @@ int macho_offset_to_rva(uint64_t offset, uint64_t* result, YR_OBJECT* object)
 
 // Get entry point address from LC_UNIXTHREAD load command.
 void macho_handle_unixthread(
-    const uint8_t* command,
+    const uint8_t* data,
+    size_t size,
     YR_OBJECT* object,
     YR_SCAN_CONTEXT* context)
 {
   int should_swap = should_swap_bytes(get_integer(object, "magic"));
   bool is64 = false;
 
-  uint32_t command_size = ((yr_thread_command_t*) command)->cmdsize;
+  if (size < sizeof(yr_thread_command_t))
+    return;
 
-  // command_size should be greater than the size of yr_thread_command_t, if
-  // not the file is corrupt.
+  // command_size is the size indicated in yr_thread_command_t structure, but
+  // limited to the data's size because we can't rely on the structure having a
+  // valid size.
+  uint32_t command_size = yr_min(size, ((yr_thread_command_t*) data)->cmdsize);
+
+  // command_size should be at least the size of yr_thread_command_t.
   if (command_size < sizeof(yr_thread_command_t))
     return;
 
@@ -230,7 +236,7 @@ void macho_handle_unixthread(
 
   // The structure that contains the thread state starts where
   // yr_thread_command_t ends.
-  const void* thread_state = command + sizeof(yr_thread_command_t);
+  const void* thread_state = data + sizeof(yr_thread_command_t);
 
   uint64_t address = 0;
 
@@ -323,13 +329,17 @@ void macho_handle_unixthread(
 // Get entry point offset and stack-size from LC_MAIN load command.
 
 void macho_handle_main(
-    void* command,
+    void* data,
+    size_t size,
     YR_OBJECT* object,
     YR_SCAN_CONTEXT* context)
 {
   yr_entry_point_command_t ep_command;
 
-  memcpy(&ep_command, command, sizeof(yr_entry_point_command_t));
+  if (size < sizeof(yr_entry_point_command_t))
+    return;
+
+  memcpy(&ep_command, data, sizeof(yr_entry_point_command_t));
 
   if (should_swap_bytes(get_integer(object, "magic")))
     swap_entry_point_command(&ep_command);
@@ -352,15 +362,19 @@ void macho_handle_main(
 // Load segment and its sections.
 
 void macho_handle_segment(
-    const uint8_t* command,
+    const uint8_t* data,
+    size_t size,
     const unsigned i,
     YR_OBJECT* object)
 {
-  int should_swap = should_swap_bytes(get_integer(object, "magic"));
+  if (size < sizeof(yr_segment_command_32_t))
+    return;
 
   yr_segment_command_32_t sg;
 
-  memcpy(&sg, command, sizeof(yr_segment_command_32_t));
+  memcpy(&sg, data, sizeof(yr_segment_command_32_t));
+
+  int should_swap = should_swap_bytes(get_integer(object, "magic"));
 
   if (should_swap)
     swap_segment_command(&sg);
@@ -381,7 +395,7 @@ void macho_handle_segment(
 
   // The array of yr_section_32_t starts where yr_segment_command_32_t ends.
   yr_section_32_t* sections =
-      (yr_section_32_t*) (command + sizeof(yr_segment_command_32_t));
+      (yr_section_32_t*) (data + sizeof(yr_segment_command_32_t));
 
   for (unsigned j = 0; j < sg.nsects; ++j)
   {
@@ -436,15 +450,19 @@ void macho_handle_segment(
 }
 
 void macho_handle_segment_64(
-    const uint8_t* command,
+    const uint8_t* data,
+    size_t size,
     const unsigned i,
     YR_OBJECT* object)
 {
-  int should_swap = should_swap_bytes(get_integer(object, "magic"));
+  if (size < sizeof(yr_segment_command_64_t))
+    return;
 
   yr_segment_command_64_t sg;
 
-  memcpy(&sg, command, sizeof(yr_segment_command_64_t));
+  memcpy(&sg, data, sizeof(yr_segment_command_64_t));
+
+  int should_swap = should_swap_bytes(get_integer(object, "magic"));
 
   if (should_swap)
     swap_segment_command_64(&sg);
@@ -468,13 +486,13 @@ void macho_handle_segment_64(
   for (unsigned j = 0; j < sg.nsects; ++j)
   {
     parsed_size += sizeof(yr_section_64_t);
+
     if (sg.cmdsize < parsed_size)
       break;
 
     memcpy(
         &sec,
-        command + sizeof(yr_segment_command_64_t) +
-            (j * sizeof(yr_section_64_t)),
+        data + sizeof(yr_segment_command_64_t) + (j * sizeof(yr_section_64_t)),
         sizeof(yr_section_64_t));
 
     if (should_swap)
@@ -587,12 +605,10 @@ void macho_parse_file(
     switch (command_struct.cmd)
     {
     case LC_SEGMENT:
-      if (command_struct.cmdsize >= sizeof(yr_segment_command_32_t))
-        macho_handle_segment(command, seg_count++, object);
+      macho_handle_segment(command, size - parsed_size, seg_count++, object);
       break;
     case LC_SEGMENT_64:
-      if (command_struct.cmdsize >= sizeof(yr_segment_command_64_t))
-        macho_handle_segment_64(command, seg_count++, object);
+      macho_handle_segment_64(command, size - parsed_size, seg_count++, object);
       break;
     }
 
@@ -625,12 +641,10 @@ void macho_parse_file(
     switch (command_struct.cmd)
     {
     case LC_UNIXTHREAD:
-      if (command_struct.cmdsize >= sizeof(yr_thread_command_t))
-        macho_handle_unixthread(command, object, context);
+      macho_handle_unixthread(command, size - parsed_size, object, context);
       break;
     case LC_MAIN:
-      if (command_struct.cmdsize >= sizeof(yr_entry_point_command_t))
-        macho_handle_main(command, object, context);
+      macho_handle_main(command, size - parsed_size, object, context);
       break;
     }
 

--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -218,7 +218,12 @@ void macho_handle_unixthread(
 
   uint32_t command_size = ((yr_thread_command_t*) command)->cmdsize;
 
-  // cmd_size includes the size of yr_thread_command_t and the thread
+  // command_size should be greater than the size of yr_thread_command_t, if
+  // not the file is corrupt.
+  if (command_size < sizeof(yr_thread_command_t))
+    return;
+
+  // command_size includes the size of yr_thread_command_t and the thread
   // state structure that follows, let's compute the size of the thread state
   // structure.
   size_t thread_state_size = command_size - sizeof(yr_thread_command_t);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -928,7 +928,7 @@ static int pe_valid_dll_name(const char* dll_name, size_t n)
   while (l < n && *c != '\0')
   {
     if ((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') ||
-        (*c >= '0' && *c <= '9') || (*c == '_' || *c == '.' || *c == '-'))
+        (*c >= '0' && *c <= '9') || (*c == '_' || *c == '.' || *c == '-' || *c == '+'))
     {
       c++;
       l++;


### PR DESCRIPTION
I fixed syntax of table in writingrules.rst
・“YARA keywords” table has syntax error, and it table couldn't see on the document page.
・I changed that some '*' positions.