### PR TITLE
Check if iterator is YR_UNDEFINED before accessing

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -187,7 +187,7 @@ static int iter_array_next(YR_ITERATOR* self, YR_VALUE_STACK* stack)
   if (stack->sp + 1 >= stack->capacity)
     return ERROR_EXEC_STACK_OVERFLOW;
 
-  if (self->array_it.index < yr_object_array_length(self->array_it.array))
+  if (!IS_UNDEFINED(self->array_it.array) && self->array_it.index < yr_object_array_length(self->array_it.array))
   {
     // Push the false value that indicates that the iterator is not exhausted.
     stack->items[stack->sp++].i = 0;


### PR DESCRIPTION
In certain programs, the iterator will be an undefined value which will cause a SIGSEGV, and result in an `ERROR_COULD_NOT_MAP_FILE`.

I used `SCAN_FLAGS_NO_TRYCATCH` to find this issue.