### PR TITLE
modules/pe: Fixed parsing of rich signature if it starts immediately after MZ header

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -173,7 +173,7 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
   // find the Rich header we need to start at the NT header and work backwards.
   p = (DWORD*) (pe->data + nthdr_offset - 4);
 
-  while (p > (DWORD*) (pe->data + sizeof(IMAGE_DOS_HEADER)))
+  while (p >= (DWORD*) (pe->data + sizeof(IMAGE_DOS_HEADER)))
   {
     if (yr_le32toh(*p) == RICH_RICH)
     {
@@ -194,7 +194,7 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
     return;
 
   // If we have found the key we need to now find the start (DanS).
-  while (p > (DWORD*) (pe->data + sizeof(IMAGE_DOS_HEADER)))
+  while (p >= (DWORD*) (pe->data + sizeof(IMAGE_DOS_HEADER)))
   {
     if (yr_le32toh((*(p) ^ key)) == RICH_DANS)
     {


### PR DESCRIPTION
There are certain samples where Rich signature starts immediately after MZ header. This check just allows this offset to be inspected during the detection loop.

I don't have any files which I can share publicly but I can share privately to confirm that such samples indeed exist and we'd like Rich header to be detected in those. If necessary, I can create some artificial sample and put it right into tests.