### PR TITLE
Add "EM_NONE" at ELF module MACHINE reference

### DIFF
--- a/docs/modules/elf.rst
+++ b/docs/modules/elf.rst
@@ -60,6 +60,7 @@ Reference
 
     Integer with one of the following values:
 
+    .. c:type:: EM_NONE
     .. c:type:: EM_M32
     .. c:type:: EM_SPARC
     .. c:type:: EM_386


### PR DESCRIPTION
I know "EM_NONE" is difined in elf.h.
(https://github.com/VirusTotal/yara/blob/e1360f6cbe3d8daf350018661bc6772bd5b726f2/libyara/include/yara/elf.h)
However this doc has not "EM_NONE".