### PR TITLE
Documentation Spelling Corrections

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -11,16 +11,16 @@ process. ::
   yara [OPTIONS] RULES_FILE TARGET
 
 In YARA 3.8 and below ``RULES_FILE`` was allowed to be a file with rules in source
-form or in compiled form indistinctly. In YARA 3.9 you need to explictly specify
+form or in compiled form indistinctly. In YARA 3.9 you need to explicitly specify
 that ``RULES_FILE`` contains compiled rules by using the -C flag. ::
 
   yara [OPTIONS] -C RULES_FILE TARGET
 
-This is a security measure to prevent users from inadvertenly using compiled
+This is a security measure to prevent users from inadvertently using compiled
 rules coming from a third-party. Using compiled rules from untrusted sources can
 lead to the execution of malicious code in your computer.
 
-For compiling rules beforhand you can use the ``yarac`` tool. This way can save
+For compiling rules beforehand you can use the ``yarac`` tool. This way can save
 time, because for YARA it is faster to load compiled rules than compiling the
 same rules over and over again.
 

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -483,7 +483,7 @@ Reference
 
         Data directory for Delayed Import Table. Structure of the delayed import table
         is linker-dependent. Microsoft version of delayed imports is described
-        in the souces "delayimp.h" and "delayimp.cpp", which can be found
+        in the sources "delayimp.h" and "delayimp.cpp", which can be found
         in MS Visual Studio 2008 CRT sources.
 
     .. c:type:: IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR
@@ -751,9 +751,9 @@ Reference
     .. c:member:: algorithm
 
         String representation of the algorithm used for this
-	signature. Usually "sha1WithRSAEncryption". It depends on the
-	X.509 and PKCS#7 implementationss and possibly their versions,
-	consider using algorithm_oid instead.
+    signature. Usually "sha1WithRSAEncryption". It depends on the
+    X.509 and PKCS#7 implementations and possibly their versions,
+    consider using algorithm_oid instead.
 
     .. c:member:: algorithm_oid
 
@@ -763,11 +763,11 @@ Reference
         expected to be stable across X.509 and PKCS#7 implementations
         and their versions.
 
-	For example, when using the current OpenSSL-based implementation::
+    For example, when using the current OpenSSL-based implementation::
 
-	    algorithm_oid == "1.2.840.113549.1.1.11"
+        algorithm_oid == "1.2.840.113549.1.1.11"
 
-	is functionally equivalent to::
+    is functionally equivalent to::
 
             algorithm == "sha1WithRSAEncryption"
 

--- a/docs/writingrules.rst
+++ b/docs/writingrules.rst
@@ -924,7 +924,7 @@ Again, numbers are decimal by default.
 
 You can also get the offset or virtual address of the i-th occurrence of string
 $a by using @a[i]. The indexes are one-based, so the first occurrence would be
-@a[1] the second one @a[2] and so on. If you provide an index greater then the
+@a[1] the second one @a[2] and so on. If you provide an index greater than the
 number of occurrences of the string, the result will be a NaN (Not A Number)
 value.
 

--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -387,7 +387,7 @@ Reference
   Instances of this class are returned by :py:func:`yara.compile` and represents
   a set of compiled rules.
 
-  .. py:method:: match(filepath, pid, data, externals=None, callback=None, fast=False, timeout=None, modules_data=None, modules_callback=None, which_callbacks=CALLBACK_ALL)
+  .. py:method:: match(filepath, pid, data, externals=None, callback=None, fast=False, timeout=None, modules_data=None, modules_callback=None, warnings_callback=None, which_callbacks=CALLBACK_ALL)
 
     Scan a file, process memory or data string.
 
@@ -407,6 +407,7 @@ Reference
       are module names and values are *bytes* objects containing the additional
       data.
     :param function modules_callback: Callback function invoked for each module.
+    :param function warnings_callback: Callback function invoked for warning, like ``yara.CALLBACK_TOO_MANY_MATCHES``.
     :param int which_callbacks: An integer that indicates in which cases the
       callback function must be called. Possible values are ``yara.CALLBACK_ALL``,
       ``yara.CALLBACK_MATCHES`` and ``yara.CALLBACK_NON_MATCHES``.


### PR DESCRIPTION
Made a few minor corrections.
- Add warnings_callbacks to Python Rules class summary
- Spelling corrections
- Consistent indents in documentation