### PR TITLE
load_files() problem with memory fix

### DIFF
--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -552,7 +552,7 @@ int yr_arena_load_stream(YR_STREAM* stream, YR_ARENA** arena)
 
   YR_ARENA* new_arena;
 
-  FAIL_ON_ERROR(yr_arena_create(hdr.num_buffers, 1048576, &new_arena))
+  FAIL_ON_ERROR(yr_arena_create(hdr.num_buffers, 10485, &new_arena))
 
   for (int i = 0; i < hdr.num_buffers; ++i)
   {


### PR DESCRIPTION
When loading compiled rules with Yara, the memory usage increase above the expected amount.
The problem is the initial size of each buffer in the arena in function ` yr_arena_load_stream`.
I tested several values and selected one that yielded the best results.

Ruleset 1:

- ruleset: 75 files, 728 MB
- loading with Yara: around 1941 MB
- loading with this PR: around 932 MB

Ruleset 2:

- Compiled rules: 4,8 GB
- loading with Yara: around 30 GB
- loading with this PR: around 11,3 GB

At Avast, we are using this change for some time now, without any problem so far.