### PR TITLE
Fix pe RVA to offset

### DIFF
--- a/libyara/modules/pe/pe_utils.c
+++ b/libyara/modules/pe/pe_utils.c
@@ -188,6 +188,7 @@ int64_t pe_rva_to_offset(PE* pe, uint64_t rva)
       }
 
       if (rva >= yr_le32toh(section->VirtualAddress) &&
+          rva - yr_le32toh(section->VirtualAddress) < yr_le32toh(section->Misc.VirtualSize) &&
           section_rva <= yr_le32toh(section->VirtualAddress))
       {
         // Round section_offset


### PR DESCRIPTION
Yara chosen section with biggest `VirtualAddress` which was lower than RVA. But YARA should also check that RVA is in section. 

Sample:
* `6c2667352d228ef6ad9fc0a6e0365e93693356775ce1baecfde2e3b7e502033e`