### PR TITLE
Fix typo from `pe.SECTION_FARDATA` to `SECTION_MEM_FARDATA`

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -619,7 +619,7 @@ Reference
     .. c:type:: SECTION_LNK_COMDAT
     .. c:type:: SECTION_NO_DEFER_SPEC_EXC
     .. c:type:: SECTION_GPREL
-    .. c:type:: SECTION_FARDATA
+    .. c:type:: SECTION_MEM_FARDATA
     .. c:type:: SECTION_MEM_PURGEABLE
     .. c:type:: SECTION_MEM_16BIT
     .. c:type:: SECTION_LNK_NRELOC_OVFL

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -2796,7 +2796,7 @@ begin_declarations
   declare_integer("SECTION_LNK_COMDAT");
   declare_integer("SECTION_NO_DEFER_SPEC_EXC");
   declare_integer("SECTION_GPREL");
-  declare_integer("SECTION_FARDATA");
+  declare_integer("SECTION_MEM_FARDATA");
   declare_integer("SECTION_MEM_PURGEABLE");
   declare_integer("SECTION_MEM_16BIT");
   declare_integer("SECTION_MEM_LOCKED");
@@ -3303,7 +3303,7 @@ int module_load(
   set_integer(IMAGE_SCN_GPREL, module_object, "SECTION_GPREL");
   set_integer(
       IMAGE_SCN_MEM_FARDATA, module_object,
-      "SECTION_FARDATA");
+      "SECTION_MEM_FARDATA");
   set_integer(
       IMAGE_SCN_MEM_PURGEABLE, module_object,
       "SECTION_MEM_PURGEABLE");


### PR DESCRIPTION
After VirusTotal/Yara#1520 was merged I discovered typo. (My fault)

Variable `pe.SECTION_FARDATA` should be named `pe.SECTION_MEM_FARDATA`. (This variable is created from windows enum `IMAGE_SCN_MEM_FARDATA`)