### PR TITLE
Accept any Machine in PE header

### DIFF
--- a/libyara/modules/pe/pe_utils.c
+++ b/libyara/modules/pe/pe_utils.c
@@ -81,44 +81,6 @@ PIMAGE_NT_HEADERS32 pe_get_header(const uint8_t* data, size_t data_size)
   if (data_size < headers_size)
     return NULL;
 
-  if (yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_UNKNOWN &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_AM33 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_AMD64 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_ARM &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_ARMNT &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_ARM64 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_EBC &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_I386 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_IA64 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_M32R &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_MIPS16 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_MIPSFPU &&
-      yr_le16toh(pe_header->FileHeader.Machine) !=
-          IMAGE_FILE_MACHINE_MIPSFPU16 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_POWERPC &&
-      yr_le16toh(pe_header->FileHeader.Machine) !=
-          IMAGE_FILE_MACHINE_POWERPCFP &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_R4000 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_SH3 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_SH3DSP &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_SH4 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_SH5 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_THUMB &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_WCEMIPSV2 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_TARGET_HOST &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_R3000 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_R10000 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_ALPHA &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_SH3E &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_ALPHA64 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_AXP64 &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_TRICORE &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_CEF &&
-      yr_le16toh(pe_header->FileHeader.Machine) != IMAGE_FILE_MACHINE_CEE)
-  {
-    return NULL;
-  }
-
   return pe_header;
 }
 


### PR DESCRIPTION
YARA should generally accept any Machine in PE header and not just those which are known by enums. According to [this](https://github.com/dotnet/runtime/issues/36364) , this header value is getting XORed for different platforms with arbitrary platform IDs so we can generally say that you can have any machine ID you want.