### PR TITLE
Escape `PKG_CHECK_MODULES`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,7 +184,7 @@ AC_ARG_ENABLE([pb-tests],
     # AS_IF([test "x${PROTOC_GEN_YARA}" == "x"],
     #    [AC_MSG_ERROR([please install https://github.com/VirusTotal/protoc-gen-yara])])
     PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c >= 1.0.0])
-    AC_CHECK_LIB(protobuf-c, protobuf_c_message_unpack,,
+    AC_CHECK_LIB([protobuf-c], protobuf_c_message_unpack,,
       AC_MSG_ERROR([please install libprotobuf-c library]))
     CFLAGS="$CFLAGS -DPB_TESTS_MODULE"
     PC_REQUIRES_PRIVATE="$PC_REQUIRES_PRIVATE libprotobuf-c"

--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ AC_ARG_ENABLE([pb-tests],
     # AC_CHECK_PROG(PROTOC_GEN_YARA, protoc-gen-yara, protoc-gen-yara)
     # AS_IF([test "x${PROTOC_GEN_YARA}" == "x"],
     #    [AC_MSG_ERROR([please install https://github.com/VirusTotal/protoc-gen-yara])])
-    PKG_CHECK_MODULES(PROTOBUF_C, libprotobuf-c >= 1.0.0)
+    PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c >= 1.0.0])
     AC_CHECK_LIB(protobuf-c, protobuf_c_message_unpack,,
       AC_MSG_ERROR([please install libprotobuf-c library]))
     CFLAGS="$CFLAGS -DPB_TESTS_MODULE"


### PR DESCRIPTION
This small changes allows to fix an issues https://github.com/avast/retdec/issues/990 and probably https://github.com/VirusTotal/yara/issues/1171

The root cause of this issues is different shell which is used. Some simple shell like dsh I belive can't survive on this line without escaping, some modern like bash easly can.

Thus at § 3.5 at https://autotools.io/pkgconfig/pkg_check_modules.html it is cleare suggested to escape by `[...]`.