### PR TITLE
Fix edge case with pid check.

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1551,12 +1551,17 @@ int _tmain(int argc, const char_t** argv)
     yr_scanner_set_flags(scanner, flags);
     yr_scanner_set_timeout(scanner, timeout);
 
-    long pid = _tcstol(argv[argc - 1], NULL, 10);
+    // Assume the last argument is a file first. This assures we try to process
+    // files that start with numbers first.
+    result = scan_file(scanner, argv[argc - 1]);
+    if (result == ERROR_COULD_NOT_OPEN_FILE) {
+      // Is it a PID? To be a PID it must be made up entirely of digits.
+      char *endptr = NULL;
+      long pid = _tcstol(argv[argc - 1], &endptr, 10);
 
-    if (pid != 0)
-      result = yr_scanner_scan_proc(scanner, (int) pid);
-    else
-      result = scan_file(scanner, argv[argc - 1]);
+      if (pid != 0 && argv[argc - 1] != NULL && *endptr == '\x00')
+        result = yr_scanner_scan_proc(scanner, (int) pid);
+    }
 
     if (result != ERROR_SUCCESS)
     {


### PR DESCRIPTION
A common use case (I've run into this many times, as have some friends) is to
run yara against a file named after the hash of the content. If the hash happens
to start with a number yara.c treats it as a PID, and will fail. The workaround
is to prefix the file with "./" (or whatever the equivalent is on Windows) so
that the strol() check fails.

This diff switches the behavior so it treats the argument as a file first, and
only if that can't be opened is it then checked for a PID. Further, to ensure the
PID check is accurate I extended it so that the entire argument must be
converted. If there are any characters left after the conversion then it is not
a valid PID and we will not attempt to scan it as it is (by definition) not a
valid file nor a valid PID.