### PR TITLE
Expose YR_DEBUG_VERBOSITY in configure script.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([yara], [4.1.0], [vmalvarez@virustotal.com])
+AC_INIT([yara], [4.1.1], [vmalvarez@virustotal.com])
 
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([cli/yara.c])
@@ -119,6 +119,14 @@ AC_ARG_ENABLE([profiling],
   [if test x$enableval = xyes; then
     profiling_enabled=true
     CFLAGS="$CFLAGS -DYR_PROFILING_ENABLED"
+  fi])
+
+AC_ARG_WITH([debug-verbose],
+  [AS_HELP_STRING([--with-debug-verbose=[[NUM]]], [Turn on runtime debugging information])],
+  [if test $withval -gt 0; then
+    AC_DEFINE_UNQUOTED([YR_DEBUG_VERBOSITY], [$withval])
+   else
+    AC_MSG_ERROR([debug verbosity must be greater than 0])
   fi])
 
 AC_ARG_ENABLE([cuckoo],

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -635,7 +635,7 @@ static int _yr_scan_match_callback(
       2,
       stderr,
       "+ %s(match_data=%p match_length=%d) { //"
-      " match_offset=%" PRId64 " args->data=%p args->string.length=%u"
+      " match_offset=%zu args->data=%p args->string.length=%u"
       " args->data_base=0x%" PRIx64 " args->data_size=%zu"
       " args->forward_matches=%'u\n",
       __FUNCTION__,


### PR DESCRIPTION
Add a --with-debug-verbose option to the configure script which takes a number
greater than 0 as an argument. This gives us the flexibility to make verbosity
of this useful debugging information greater than it's current maximum (2)
without needing to modify the configure script.

Currently the maximum is 2, which gets you a lot of useful runtime debugging
information. A value of 1 is only used in tests. It may be worth it to consider
reworking this system so the numbers describe how much information you want.
For example, 1 could just be function entry and exit, 2 could add arguments to
it. I'll leave changing that up to a future diff if it is desired.

While here, fix a warning in the scanner from using an incorrect format string:

scan.c:644:7: warning: format specifies type 'long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
      match_offset,
      ^~~~~~~~~~~~~
./include/yara/globals.h:100:29: note: expanded from macro 'YR_DEBUG_FPRINTF'
    fprintf(STREAM, FORMAT, __VA_ARGS__);                      \
                    ~~~~~~  ^~~~~~~~~~~
1 warning generated.