### PR TITLE
Fullword fix

### DIFF
--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -99,3 +99,5 @@ int strcmp_w(const char* w_str, const char* str);
 size_t strlcpy_w(char* dst, const char* w_src, size_t n);
 
 #endif
+
+int yr_isalnum(const uint8_t* s);

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -102,7 +102,7 @@ static bool _yr_re_is_char_in_class(
 
 static bool _yr_re_is_word_char(const uint8_t* input, uint8_t character_size)
 {
-  int result = ((isalnum(*input) || (*input) == '_'));
+  int result = ((yr_isalnum(input) || (*input) == '_'));
 
   if (character_size == 2)
     result = result && (*(input + 1) == 0);

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/rules.h>
 #include <yara/scan.h>
 #include <yara/stopwatch.h>
+#include <yara/strutils.h>
 #include <yara/types.h>
 #include <yara/utils.h>
 
@@ -659,21 +660,21 @@ static int _yr_scan_match_callback(
     if (flags & RE_FLAGS_WIDE)
     {
       if (match_offset >= 2 && *(match_data - 1) == 0 &&
-          isalnum(*(match_data - 2)))
+          yr_isalnum(match_data - 2))
         goto _exit;  // return ERROR_SUCCESS;
 
       if (match_offset + match_length + 1 < callback_args->data_size &&
           *(match_data + match_length + 1) == 0 &&
-          isalnum(*(match_data + match_length)))
+          yr_isalnum(match_data + match_length))
         goto _exit;  // return ERROR_SUCCESS;
     }
     else
     {
-      if (match_offset >= 1 && isalnum(*(match_data - 1)))
+      if (match_offset >= 1 && yr_isalnum(match_data - 1))
         goto _exit;  // return ERROR_SUCCESS;
 
       if (match_offset + match_length < callback_args->data_size &&
-          isalnum(*(match_data + match_length)))
+          yr_isalnum(match_data + match_length))
         goto _exit;  // return ERROR_SUCCESS;
     }
   }

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -239,3 +239,10 @@ void* memmem(
   return NULL;
 }
 #endif
+
+
+int yr_isalnum(const uint8_t* s) {
+  return (*s >= 0x30 && *s <= 0x39) ||
+         (*s >= 0x41 && *s <= 0x5a) ||
+         (*s >= 0x61 && *s <= 0x7a);
+}

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -241,7 +241,8 @@ void* memmem(
 #endif
 
 
-int yr_isalnum(const uint8_t* s) {
+int yr_isalnum(const uint8_t* s)
+{
   return (*s >= 0x30 && *s <= 0x39) ||
          (*s >= 0x41 && *s <= 0x5a) ||
          (*s >= 0x61 && *s <= 0x7a);


### PR DESCRIPTION
Fix https://github.com/VirusTotal/yara-python/issues/184, which turned out to be because isalnum() is locale aware. When running yara-python on MacOS it considers certain byte values to be alphanumeric when I think the intention is to only consider [0-9a-zA-z]. See the details of the issue for a simple script which reproduces it.

Since this only appears under MacOS I didn't have a good way to write a test case but I did test it. The test is in https://gist.github.com/wxsBSD/2e9b270552122cd865cdafe01989fdca - this shows that both "fullword" on a text string and "\w and \W" both work as expected under MacOS now.