### PR TITLE
Add a math.abs()

### DIFF
--- a/docs/modules/math.rst
+++ b/docs/modules/math.rst
@@ -118,3 +118,11 @@ file and create signatures based on those results.
     Returns 0 or 1, it's useful when writing a score based rule.
 
     *Example: math.to_number(SubRule1) \* 60 + math.to_number(SubRule2) \* 20 + math.to_number(SubRule3) \* 70 > 80*
+
+.. c:function:: abs(int)
+
+    .. versionadded:: 4.2.0
+
+    Returns the absolute value of the signed integer.
+
+    *Example: math.abs(@a - @b) == 1*

--- a/libyara/modules/math/math.c
+++ b/libyara/modules/math/math.c
@@ -597,6 +597,11 @@ define_function(to_number)
   return_integer(integer_argument(1) ? 1 : 0);
 }
 
+define_function(yr_math_abs)
+{
+  return_integer(llabs(integer_argument(1)));
+}
+
 begin_declarations
   declare_float("MEAN_BYTES");
   declare_function("in_range", "fff", "i", in_range);
@@ -613,6 +618,7 @@ begin_declarations
   declare_function("min", "ii", "i", min);
   declare_function("max", "ii", "i", max);
   declare_function("to_number", "b", "i", to_number);
+  declare_function("abs", "i", "i", yr_math_abs);
 end_declarations
 
 int module_initialize(YR_MODULE* module)

--- a/tests/test-math.c
+++ b/tests/test-math.c
@@ -44,6 +44,25 @@ int main(int argc, char** argv)
       }",
       "A");
 
+  assert_true_rule_blob(
+      "import \"math\" \
+      rule test { \
+        condition: \
+          math.abs(-1) == 1 \
+      }",
+      "A");
+
+  assert_true_rule_blob(
+      "import \"math\" \
+      rule test { \
+        strings: \
+          $a = \"A\" \
+          $b = \"B\" \
+        condition: \
+          math.abs(@a - @b) == 1 \
+      }",
+      "AB");
+
   yr_finalize();
 
   YR_DEBUG_FPRINTF(


### PR DESCRIPTION
As mentioned in #1454, this makes checking the distance between two matches
regardless of the order of matches easier.