### PR TITLE
Default number_of_imported_functions to 0.

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1037,6 +1037,7 @@ static IMPORTED_DLL* pe_parse_imports(PE* pe)
 
   // Default to 0 imports until we know there are any
   set_integer(0, pe->object, "number_of_imports");
+  set_integer(0, pe->object, "number_of_imported_functions");
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_IMPORT);
 


### PR DESCRIPTION
This fixes a minor issue noticed by @tlansec where we were not setting `pe.number_of_imported_functions` to zero.

Fixes #1511 