### PR TITLE
Make Yara Buildable Again

### DIFF
--- a/windows/vs2017/yara/yara.vcxproj
+++ b/windows/vs2017/yara/yara.vcxproj
@@ -175,6 +175,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\cli\args.c" />
+    <ClCompile Include="..\..\..\cli\common.c" />
     <ClCompile Include="..\..\..\cli\threading.c" />
     <ClCompile Include="..\..\..\cli\yara.c" />
   </ItemGroup>

--- a/windows/vs2017/yarac/yarac.vcxproj
+++ b/windows/vs2017/yarac/yarac.vcxproj
@@ -172,6 +172,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\cli\args.c" />
+    <ClCompile Include="..\..\..\cli\common.c" />
     <ClCompile Include="..\..\..\cli\yarac.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
The `common.c` source file was missing in the VS 2017 workspaces. This pull requests fixes the problem.