### PR TITLE
Fix loading module

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1272,6 +1272,8 @@ static int load_modules_data()
 
     if (module_data != NULL)
     {
+      module_data->module_name = modules_data[i];
+
       int result = yr_filemap_map(equal_sign + 1, &module_data->mapped_file);
 
       if (result != ERROR_SUCCESS)


### PR DESCRIPTION
In this [PR](https://github.com/VirusTotal/yara/commit/57057e86e80dd6188300c82fd593d03d9f13d508#diff-f0f5b121e1aeadeb103fe21f37104b03ccc049ce58ca98fadd5e78015cc8e75eL1235), the following line was accidently removed:

`module_data->module_name = modules_data[i];`

This is causing `ERROR_COULD_NOT_MAP_FILE` when using the cuckoo module.