### PR TITLE
few small bugfixes

### DIFF
--- a/cli/common.c
+++ b/cli/common.c
@@ -71,6 +71,7 @@ char* unicode_to_ansi(const char_t* str)
 }
 #endif
 
+#ifndef MINLIBYARA
 bool compile_files(YR_COMPILER* compiler, int argc, const char_t** argv)
 {
   for (int i = 0; i < argc - 1; i++)
@@ -204,6 +205,7 @@ int define_external_variables(
 
   return result;
 }
+#endif
 
 bool is_integer(const char* str)
 {

--- a/cli/common.h
+++ b/cli/common.h
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 char* unicode_to_ansi(const char_t* str);
 #endif
 
+#ifndef MINLIBYARA
 bool compile_files(
 	YR_COMPILER* compiler,
 	int argc,
@@ -49,6 +50,7 @@ int define_external_variables(
 	char** ext_vars,
 	YR_RULES* rules,
 	YR_COMPILER* compiler);
+#endif
 
 bool is_integer(const char *str);
 

--- a/cli/minruntime.c
+++ b/cli/minruntime.c
@@ -1,0 +1,102 @@
+
+
+#include <yara/stdinc.h>
+#include <yara/mem.h>
+#include <yara/threading.h>
+#include <yara/stopwatch.h>
+#include <yara/error.h>
+
+HANDLE hHeap;
+
+int yr_heap_alloc(void)
+{
+  hHeap = HeapCreate(0, 0x8000, 0);
+
+  if (hHeap == NULL)
+    return ERROR_INTERNAL_FATAL_ERROR;
+
+  return ERROR_SUCCESS;
+}
+
+int yr_heap_free(void)
+{
+  if (HeapDestroy(hHeap))
+    return ERROR_SUCCESS;
+  else
+    return ERROR_INTERNAL_FATAL_ERROR;
+}
+
+void* yr_calloc(size_t count, size_t size)
+{
+  return (void*) HeapAlloc(hHeap, HEAP_ZERO_MEMORY, count * size);
+}
+
+void* yr_malloc(size_t size)
+{
+  return (void*) HeapAlloc(hHeap, HEAP_ZERO_MEMORY, size);
+}
+
+void* yr_realloc(void* ptr, size_t size)
+{
+  if (ptr == NULL)
+    return (void*) HeapAlloc(hHeap, HEAP_ZERO_MEMORY, size);
+
+  return (void*) HeapReAlloc(hHeap, HEAP_ZERO_MEMORY, ptr, size);
+}
+
+YR_API void yr_free(void* ptr)
+{
+  HeapFree(hHeap, 0, ptr);
+}
+
+
+int yr_thread_storage_create(YR_THREAD_STORAGE_KEY* storage)
+{
+  *storage = TlsAlloc();
+
+  if (*storage == TLS_OUT_OF_INDEXES)
+    return ERROR_INTERNAL_FATAL_ERROR;
+
+  return ERROR_SUCCESS;
+}
+
+
+int yr_thread_storage_destroy(YR_THREAD_STORAGE_KEY* storage)
+{
+  if (TlsFree(*storage) == FALSE)
+    return ERROR_INTERNAL_FATAL_ERROR;
+
+  return ERROR_SUCCESS;
+}
+
+
+int yr_thread_storage_set_value(YR_THREAD_STORAGE_KEY* storage, void* value)
+{
+  if (TlsSetValue(*storage, value) == FALSE)
+    return ERROR_INTERNAL_FATAL_ERROR;
+
+  return ERROR_SUCCESS;
+}
+
+
+void* yr_thread_storage_get_value(YR_THREAD_STORAGE_KEY* storage)
+{
+  return TlsGetValue(*storage);
+}
+
+void yr_stopwatch_start(YR_STOPWATCH* sw)
+{
+  QueryPerformanceFrequency(&sw->frequency);
+  QueryPerformanceCounter(&sw->start);
+}
+
+
+uint64_t yr_stopwatch_elapsed_ns(YR_STOPWATCH* sw)
+{
+  LARGE_INTEGER li;
+
+  QueryPerformanceCounter(&li);
+
+  return (li.QuadPart - sw->start.QuadPart) * 1000000000ULL /
+         sw->frequency.QuadPart;
+}

--- a/cli/minyara.c
+++ b/cli/minyara.c
@@ -1,0 +1,809 @@
+/*
+Copyright (c) 2007-2021. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#if !defined(_WIN32) && !defined(__CYGWIN__)
+
+// for getline(3)
+#define _POSIX_C_SOURCE 200809L
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#else
+
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+
+#define PRIx64 "I64x"
+#define PRId64 "I64d"
+
+#endif
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <yara.h>
+
+#include "args.h"
+#include "common.h"
+#include "threading.h"
+#include "unicode.h"
+
+#define ERROR_COULD_NOT_CREATE_THREAD 100
+
+#ifndef MAX_PATH
+#define MAX_PATH 256
+#endif
+
+#ifndef min
+#define min(x, y) ((x < y) ? (x) : (y))
+#endif
+
+#define MAX_ARGS_TAG         32
+#define MAX_ARGS_IDENTIFIER  32
+#define MAX_ARGS_EXT_VAR     32
+#define MAX_ARGS_MODULE_DATA 32
+#define MAX_QUEUED_FILES     64
+
+#define exit_with_code(code) \
+  {                          \
+    result = code;           \
+    goto _exit;              \
+  }
+
+typedef struct _MODULE_DATA
+{
+  const char* module_name;
+  YR_MAPPED_FILE mapped_file;
+  struct _MODULE_DATA* next;
+
+} MODULE_DATA;
+
+typedef struct _CALLBACK_ARGS
+{
+  const char_t* file_path;
+  int current_count;
+
+} CALLBACK_ARGS;
+
+#define MAX_ARGS_TAG         32
+#define MAX_ARGS_IDENTIFIER  32
+#define MAX_ARGS_EXT_VAR     32
+#define MAX_ARGS_MODULE_DATA 32
+
+static char* tags[MAX_ARGS_TAG + 1];
+static char* identifiers[MAX_ARGS_IDENTIFIER + 1];
+
+static bool show_module_data = false;
+static bool show_tags = false;
+static bool show_stats = false;
+static bool show_strings = false;
+static bool show_string_length = false;
+static bool show_meta = false;
+static bool show_namespace = false;
+static bool show_version = false;
+static bool show_help = false;
+static bool ignore_warnings = false;
+static bool fast_scan = false;
+static bool negate = false;
+static bool print_count_only = false;
+static bool fail_on_warnings = false;
+static int total_count = 0;
+static int limit = 0;
+static int timeout = 1000000;
+static int stack_size = DEFAULT_STACK_SIZE;
+static int max_strings_per_rule = DEFAULT_MAX_STRINGS_PER_RULE;
+
+#define USAGE_STRING \
+  "Usage: yara [OPTION]... [NAMESPACE:]COMPILED_RULES_FILE... FILE"
+
+args_option_t options[] = {
+
+    OPT_BOOLEAN(
+        'c',
+        _T("count"),
+        &print_count_only,
+        _T("print only number of matches")),
+
+    OPT_BOOLEAN(
+        0,
+        _T("fail-on-warnings"),
+        &fail_on_warnings,
+        _T("fail on warnings")),
+
+    OPT_BOOLEAN('f', _T("fast-scan"), &fast_scan, _T("fast matching mode")),
+
+    OPT_BOOLEAN('h', _T("help"), &show_help, _T("show this help and exit")),
+
+    OPT_STRING_MULTI(
+        'i',
+        _T("identifier"),
+        &identifiers,
+        MAX_ARGS_IDENTIFIER,
+        _T("print only rules named IDENTIFIER"),
+        _T("IDENTIFIER")),
+
+    OPT_INTEGER(
+        'l',
+        _T("max-rules"),
+        &limit,
+        _T("abort scanning after matching a NUMBER of rules"),
+        _T("NUMBER")),
+
+    OPT_INTEGER(
+        0,
+        _T("max-strings-per-rule"),
+        &max_strings_per_rule,
+        _T("set maximum number of strings per rule (default=10000)"),
+        _T("NUMBER")),
+
+    OPT_BOOLEAN(
+        'n',
+        _T("negate"),
+        &negate,
+        _T("print only not satisfied rules (negate)"),
+        NULL),
+
+    OPT_BOOLEAN(
+        'w',
+        _T("no-warnings"),
+        &ignore_warnings,
+        _T("disable warnings")),
+
+    OPT_BOOLEAN('m', _T("print-meta"), &show_meta, _T("print metadata")),
+
+    OPT_BOOLEAN(
+        'D',
+        _T("print-module-data"),
+        &show_module_data,
+        _T("print module data")),
+
+    OPT_BOOLEAN(
+        'e',
+        _T("print-namespace"),
+        &show_namespace,
+        _T("print rules' namespace")),
+
+    OPT_BOOLEAN(
+        'S',
+        _T("print-stats"),
+        &show_stats,
+        _T("print rules' statistics")),
+
+    OPT_BOOLEAN(
+        's',
+        _T("print-strings"),
+        &show_strings,
+        _T("print matching strings")),
+
+    OPT_BOOLEAN(
+        'L',
+        _T("print-string-length"),
+        &show_string_length,
+        _T("print length of matched strings")),
+
+    OPT_BOOLEAN('g', _T("print-tags"), &show_tags, _T("print tags")),
+
+    OPT_INTEGER(
+        'k',
+        _T("stack-size"),
+        &stack_size,
+        _T("set maximum stack size (default=16384)"),
+        _T("SLOTS")),
+
+    OPT_STRING_MULTI(
+        't',
+        _T("tag"),
+        &tags,
+        MAX_ARGS_TAG,
+        _T("print only rules tagged as TAG"),
+        _T("TAG")),
+
+    OPT_INTEGER(
+        'a',
+        _T("timeout"),
+        &timeout,
+        _T("abort scanning after the given number of SECONDS"),
+        _T("SECONDS")),
+
+    OPT_BOOLEAN(
+        'v',
+        _T("version"),
+        &show_version,
+        _T("show version information")),
+
+    OPT_END(),
+};
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+static int scan_file(YR_SCANNER* scanner, const char_t* filename)
+{
+  YR_FILE_DESCRIPTOR fd = CreateFile(
+      filename,
+      GENERIC_READ,
+      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      NULL,
+      OPEN_EXISTING,
+      FILE_FLAG_SEQUENTIAL_SCAN,
+      NULL);
+
+  if (fd == INVALID_HANDLE_VALUE)
+    return ERROR_COULD_NOT_OPEN_FILE;
+
+  uint32_t len = 0;
+  uint32_t read = 0;
+  GetFileSize(fd, &len);
+  int result = 0;
+  if (len)
+  {
+    uint8_t* data = malloc(len);
+	if (data)
+	{
+        ReadFile(fd, data, len, &read, NULL);
+
+        result = yr_scanner_scan_mem(scanner, data, len);
+
+        free(data);
+    }
+  }
+  CloseHandle(fd);
+
+  return result;
+}
+
+#else
+
+static int scan_file(YR_SCANNER* scanner, const char_t* filename)
+{
+  YR_FILE_DESCRIPTOR fd = open(filename, O_RDONLY);
+
+  if (fd == -1)
+    return ERROR_COULD_NOT_OPEN_FILE;
+
+  int result = yr_scanner_scan_fd(scanner, fd);
+
+  close(fd);
+
+  return result;
+}
+
+#endif
+
+static void print_string(const uint8_t* data, int length)
+{
+  for (int i = 0; i < length; i++)
+  {
+    if (data[i] >= 32 && data[i] <= 126)
+      _tprintf(_T("%c"), data[i]);
+    else
+      _tprintf(_T("\\x%02X"), data[i]);
+  }
+}
+
+static char cescapes[] = {
+    0, 0, 0, 0, 0, 0, 0, 'a', 'b', 't', 'n', 'v', 'f', 'r', 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,   0,   0,   0,   0,   0,   0,   0, 0,
+};
+
+static void print_escaped(const uint8_t* data, size_t length)
+{
+  for (size_t i = 0; i < length; i++)
+  {
+    switch (data[i])
+    {
+    case '\"':
+    case '\'':
+    case '\\':
+      _tprintf(_T("\\%" PF_C), data[i]);
+      break;
+
+    default:
+      if (data[i] >= 127)
+        _tprintf(_T("\\%03o"), data[i]);
+      else if (data[i] >= 32)
+        _tprintf(_T("%" PF_C), data[i]);
+      else if (cescapes[data[i]] != 0)
+        _tprintf(_T("\\%" PF_C), cescapes[data[i]]);
+      else
+        _tprintf(_T("\\%03o"), data[i]);
+    }
+  }
+}
+
+static void print_hex_string(const uint8_t* data, int length)
+{
+  for (int i = 0; i < min(64, length); i++)
+    _tprintf(_T("%s%02X"), (i == 0 ? _T("") : _T(" ")), data[i]);
+
+  if (length > 64)
+    _tprintf(_T(" ..."));
+}
+
+static void print_error(int error)
+{
+  switch (error)
+  {
+  case ERROR_SUCCESS:
+    break;
+  case ERROR_COULD_NOT_ATTACH_TO_PROCESS:
+    fprintf(stderr, "can not attach to process (try running as root)\n");
+    break;
+  case ERROR_INSUFFICIENT_MEMORY:
+    fprintf(stderr, "not enough memory\n");
+    break;
+  case ERROR_SCAN_TIMEOUT:
+    fprintf(stderr, "scanning timed out\n");
+    break;
+  case ERROR_COULD_NOT_OPEN_FILE:
+    fprintf(stderr, "could not open file\n");
+    break;
+  case ERROR_UNSUPPORTED_FILE_VERSION:
+    fprintf(stderr, "rules were compiled with a different version of YARA\n");
+    break;
+  case ERROR_INVALID_FILE:
+    fprintf(stderr, "invalid compiled rules file.\n");
+    break;
+  case ERROR_CORRUPT_FILE:
+    fprintf(stderr, "corrupt compiled rules file.\n");
+    break;
+  case ERROR_EXEC_STACK_OVERFLOW:
+    fprintf(
+        stderr,
+        "stack overflow while evaluating condition "
+        "(see --stack-size argument) \n");
+    break;
+  case ERROR_INVALID_EXTERNAL_VARIABLE_TYPE:
+    fprintf(stderr, "invalid type for external variable\n");
+    break;
+  case ERROR_TOO_MANY_MATCHES:
+    fprintf(stderr, "too many matches\n");
+    break;
+  default:
+    fprintf(stderr, "error: %d\n", error);
+    break;
+  }
+}
+
+static void print_scanner_error(YR_SCANNER* scanner, int error)
+{
+  YR_RULE* rule = yr_scanner_last_error_rule(scanner);
+  YR_STRING* string = yr_scanner_last_error_string(scanner);
+
+  if (rule != NULL && string != NULL)
+  {
+    fprintf(
+        stderr,
+        "string \"%s\" in rule \"%s\" caused ",
+        string->identifier,
+        rule->identifier);
+  }
+  else if (rule != NULL)
+  {
+    fprintf(stderr, "rule \"%s\" caused ", rule->identifier);
+  }
+
+  print_error(error);
+}
+
+static int handle_message(
+    YR_SCAN_CONTEXT* context,
+    int message,
+    YR_RULE* rule,
+    void* data)
+{
+  const char* tag;
+  bool show = true;
+
+  if (tags[0] != NULL)
+  {
+    // The user specified one or more -t <tag> arguments, let's show this rule
+    // only if it's tagged with some of the specified tags.
+
+    show = false;
+
+    for (int i = 0; !show && tags[i] != NULL; i++)
+    {
+      yr_rule_tags_foreach(rule, tag)
+      {
+        if (strcmp(tag, tags[i]) == 0)
+        {
+          show = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (identifiers[0] != NULL)
+  {
+    // The user specified one or more -i <identifier> arguments, let's show
+    // this rule only if it's identifier is among of the provided ones.
+
+    show = false;
+
+    for (int i = 0; !show && identifiers[i] != NULL; i++)
+    {
+      if (strcmp(identifiers[i], rule->identifier) == 0)
+      {
+        show = true;
+        break;
+      }
+    }
+  }
+
+  bool is_matching = (message == CALLBACK_MSG_RULE_MATCHING);
+
+  show = show && ((!negate && is_matching) || (negate && !is_matching));
+
+  if (show && !print_count_only)
+  {
+    if (show_namespace)
+      _tprintf(_T("%" PF_S ":"), rule->ns->name);
+
+    _tprintf(_T("%" PF_S " "), rule->identifier);
+
+    if (show_tags)
+    {
+      _tprintf(_T("["));
+
+      yr_rule_tags_foreach(rule, tag)
+      {
+        // print a comma except for the first tag
+        if (tag != rule->tags)
+          _tprintf(_T(","));
+
+        _tprintf(_T("%" PF_S), tag);
+      }
+
+      _tprintf(_T("] "));
+    }
+
+    // Show meta-data.
+
+    if (show_meta)
+    {
+      YR_META* meta;
+
+      _tprintf(_T("["));
+
+      yr_rule_metas_foreach(rule, meta)
+      {
+        if (meta != rule->metas)
+          _tprintf(_T(","));
+
+        if (meta->type == META_TYPE_INTEGER)
+        {
+          _tprintf(_T("%" PF_S " =%" PRId64), meta->identifier, meta->integer);
+        }
+        else if (meta->type == META_TYPE_BOOLEAN)
+        {
+          _tprintf(
+              _T("%" PF_S "=%" PF_S),
+              meta->identifier,
+              meta->integer ? "true" : "false");
+        }
+        else
+        {
+          _tprintf(_T("%" PF_S "=\""), meta->identifier);
+          print_escaped((uint8_t*) (meta->string), strlen(meta->string));
+          _tprintf(_T("\""));
+        }
+      }
+
+      _tprintf(_T("] "));
+    }
+
+    _tprintf(_T("%s\n"), ((CALLBACK_ARGS*) data)->file_path);
+
+    // Show matched strings.
+
+    if (show_strings || show_string_length)
+    {
+      YR_STRING* string;
+
+      yr_rule_strings_foreach(rule, string)
+      {
+        YR_MATCH* match;
+
+        yr_string_matches_foreach(context, string, match)
+        {
+          if (show_string_length)
+            _tprintf(
+                _T("0x%" PRIx64 ":%d:%" PF_S),
+                match->base + match->offset,
+                match->data_length,
+                string->identifier);
+          else
+            _tprintf(
+                _T("0x%" PRIx64 ":%" PF_S),
+                match->base + match->offset,
+                string->identifier);
+
+          if (show_strings)
+          {
+            _tprintf(_T(": "));
+
+            if (STRING_IS_HEX(string))
+              print_hex_string(match->data, match->data_length);
+            else
+              print_string(match->data, match->data_length);
+          }
+
+          _tprintf(_T("\n"));
+        }
+      }
+    }
+  }
+
+  if (is_matching)
+  {
+    ((CALLBACK_ARGS*) data)->current_count++;
+    total_count++;
+  }
+
+  if (limit != 0 && total_count >= limit)
+    return CALLBACK_ABORT;
+
+  return CALLBACK_CONTINUE;
+}
+
+static int callback(
+    YR_SCAN_CONTEXT* context,
+    int message,
+    void* message_data,
+    void* user_data)
+{
+  YR_STRING* string;
+  YR_RULE* rule;
+  YR_OBJECT* object;
+
+  switch (message)
+  {
+  case CALLBACK_MSG_RULE_MATCHING:
+  case CALLBACK_MSG_RULE_NOT_MATCHING:
+    return handle_message(context, message, (YR_RULE*) message_data, user_data);
+
+  case CALLBACK_MSG_IMPORT_MODULE:
+    return CALLBACK_CONTINUE;
+
+  case CALLBACK_MSG_MODULE_IMPORTED:
+
+    if (show_module_data)
+    {
+      object = (YR_OBJECT*) message_data;
+
+#if defined(_WIN32)
+      // In Windows restore stdout to normal text mode as yr_object_print_data
+      // calls printf which is not supported in UTF-8 mode.
+      _setmode(_fileno(stdout), _O_TEXT);
+#endif
+
+      yr_object_print_data(object, 0, 1);
+      printf("\n");
+
+#if defined(_WIN32)
+      // Go back to UTF-8 mode.
+      _setmode(_fileno(stdout), _O_U8TEXT);
+#endif
+    }
+
+    return CALLBACK_CONTINUE;
+
+  case CALLBACK_MSG_TOO_MANY_MATCHES:
+    if (ignore_warnings)
+      return CALLBACK_CONTINUE;
+
+    string = (YR_STRING*) message_data;
+    rule = &context->rules->rules_table[string->rule_idx];
+
+    fprintf(
+        stderr,
+        "warning: rule \"%s\": too many matches for %s, results for this rule "
+        "may be incorrect\n",
+        rule->identifier,
+        string->identifier);
+
+    if (fail_on_warnings)
+      return CALLBACK_ERROR;
+
+    return CALLBACK_CONTINUE;
+  }
+
+  return CALLBACK_ERROR;
+}
+
+int _tmain(int argc, const char_t** argv)
+{
+  YR_RULES* rules = NULL;
+  YR_SCANNER* scanner = NULL;
+
+  bool arg_is_dir = false;
+  int flags = 0;
+  int result;
+
+  argc = args_parse(options, argc, argv);
+
+  if (show_version)
+  {
+    printf("%s\n", YR_VERSION);
+    return EXIT_SUCCESS;
+  }
+
+  if (show_help)
+  {
+    printf(
+        "YARA %s, the pattern matching swiss army knife.\n"
+        "%s\n\n"
+        "Mandatory arguments to long options are mandatory for "
+        "short options too.\n\n",
+        YR_VERSION,
+        USAGE_STRING);
+
+    args_print_usage(options, 43);
+    printf(
+        "\nSend bug reports and suggestions to: vmalvarez@virustotal.com.\n");
+
+    return EXIT_SUCCESS;
+  }
+
+  if (argc < 2)
+  {
+    // After parsing the command-line options we expect two additional
+    // arguments, the rules file and the target file, directory or pid to
+    // be scanned.
+
+    fprintf(stderr, "yara: wrong number of arguments\n");
+    fprintf(stderr, "%s\n\n", USAGE_STRING);
+    fprintf(stderr, "Try `--help` for more options\n");
+
+    return EXIT_FAILURE;
+  }
+
+#if defined(_WIN32) && defined(_UNICODE)
+  // In Windows set stdout to UTF-8 mode.
+  if (_setmode(_fileno(stdout), _O_U8TEXT) == -1)
+  {
+    return EXIT_FAILURE;
+  }
+#endif
+
+  result = yr_initialize();
+
+  if (result != ERROR_SUCCESS)
+  {
+    fprintf(stderr, "error: initialization error (%d)\n", result);
+    exit_with_code(EXIT_FAILURE);
+  }
+
+  yr_set_configuration(YR_CONFIG_STACK_SIZE, &stack_size);
+  yr_set_configuration(YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
+
+  // Try to load the rules file as a binary file containing
+  // compiled rules first
+
+  {
+    // When a binary file containing compiled rules is provided, yara accepts
+    // only two arguments, the compiled rules file and the target to be scanned.
+
+    if (argc != 2)
+    {
+      fprintf(
+          stderr,
+          "error: can't accept multiple rules files if one of them is in "
+          "compiled form.\n");
+      exit_with_code(EXIT_FAILURE);
+    }
+
+    // Not using yr_rules_load because it does not have support for unicode
+    // file names. Instead use open _tfopen for openning the file and
+    // yr_rules_load_stream for loading the rules from it.
+
+    FILE* fh = _tfopen(argv[0], _T("rb"));
+
+    if (fh != NULL)
+    {
+      YR_STREAM stream;
+
+      stream.user_data = fh;
+      stream.read = (YR_STREAM_READ_FUNC) fread;
+
+      result = yr_rules_load_stream(&stream, &rules);
+
+      fclose(fh);
+    }
+    else
+    {
+      result = ERROR_COULD_NOT_OPEN_FILE;
+    }
+  }
+
+  if (result != ERROR_SUCCESS)
+  {
+    print_error(result);
+    exit_with_code(EXIT_FAILURE);
+  }
+
+  if (fast_scan)
+    flags |= SCAN_FLAGS_FAST_MODE;
+
+
+  {
+    CALLBACK_ARGS user_data = {argv[argc - 1], 0};
+
+    result = yr_scanner_create(rules, &scanner);
+
+    if (result != ERROR_SUCCESS)
+    {
+      _ftprintf(stderr, _T("error: %d\n"), result);
+      exit_with_code(EXIT_FAILURE);
+    }
+
+    yr_scanner_set_callback(scanner, callback, &user_data);
+    yr_scanner_set_flags(scanner, flags);
+    yr_scanner_set_timeout(scanner, timeout);
+
+    // Assume the last argument is a file first. This assures we try to process
+    // files that start with numbers first.
+    result = scan_file(scanner, argv[argc - 1]);
+
+    if (result != ERROR_SUCCESS)
+    {
+      _ftprintf(stderr, _T("error scanning %s: "), argv[argc - 1]);
+      print_scanner_error(scanner, result);
+      exit_with_code(EXIT_FAILURE);
+    }
+
+    if (print_count_only)
+      _tprintf(_T("%d\n"), user_data.current_count);
+
+  }
+
+  result = EXIT_SUCCESS;
+
+_exit:
+
+  if (scanner != NULL)
+    yr_scanner_destroy(scanner);
+
+  if (rules != NULL)
+    yr_rules_destroy(rules);
+
+  yr_finalize();
+
+  args_free(options);
+
+  return result;
+}

--- a/libyara/ahocorasick.c
+++ b/libyara/ahocorasick.c
@@ -27,9 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <stddef.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/ahocorasick.h>
 #include <yara/arena.h>
 #include <yara/compiler.h>

--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -27,8 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdarg.h>
-#include <stddef.h>
+#include <yara/stdinc.h>
+
 #include <yara/arena.h>
 #include <yara/error.h>
 #include <yara/mem.h>

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -77,8 +77,8 @@ will end up using the "Look" atom alone, but in /a(bcd|efg)h/ atoms "bcd" and
 "efg" will be used because "a" and "h" are too short.
 */
 
-#include <assert.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/atoms.h>
 #include <yara/error.h>
 #include <yara/globals.h>

--- a/libyara/base64.c
+++ b/libyara/base64.c
@@ -27,7 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/base64.h>
 #include <yara/error.h>
 #include <yara/mem.h>

--- a/libyara/bitmask.c
+++ b/libyara/bitmask.c
@@ -27,7 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
+#include <yara/stdinc.h>
+
 #include <yara/bitmask.h>
 #include <yara/utils.h>
 

--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -27,19 +27,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/stat.h>
-
-#ifdef _MSC_VER
-#include <io.h>
-#include <share.h>
-#else
-#include <unistd.h>
-#endif
+#include <yara/stdinc.h>
 
 #include <yara/compiler.h>
 #include <yara/error.h>

--- a/libyara/exception.h
+++ b/libyara/exception.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_EXCEPTION_H
 #define YR_EXCEPTION_H
 
-#include <assert.h>
+#include <yara/stdinc.h>
+
 #include <yara/globals.h>
 
 #if _WIN32 || __CYGWIN__

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -27,10 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <float.h>
-#include <math.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara.h>
 #include <yara/arena.h>
 #include <yara/endian.h>

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -41,7 +41,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/object.h>
 #include <yara/re.h>
 #include <yara/sizedstr.h>
+#ifdef YR_PROFILING_ENABLED
 #include <yara/stopwatch.h>
+#endif
 #include <yara/strutils.h>
 #include <yara/utils.h>
 
@@ -1016,12 +1018,14 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
         r1.i = r1.o->value.i;
         break;
 
+#ifndef MINLIBYARA
       case OBJECT_TYPE_FLOAT:
         if (isnan(r1.o->value.d))
           r1.i = YR_UNDEFINED;
         else
           r1.d = r1.o->value.d;
         break;
+#endif
 
       case OBJECT_TYPE_STRING:
         if (r1.o->value.ss == NULL)

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -1135,7 +1135,8 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
       function = object_as_function(r2.o);
       result = ERROR_INTERNAL_FATAL_ERROR;
 
-      for (int i = 0; i < YR_MAX_OVERLOADED_FUNCTIONS; i++)
+      // re-use of i is intentional for assert below
+      for (i = 0; i < YR_MAX_OVERLOADED_FUNCTIONS; i++)
       {
         if (function->prototypes[i].arguments_fmt == NULL)
           break;

--- a/libyara/exefiles.c
+++ b/libyara/exefiles.c
@@ -27,7 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <limits.h>
+#include <yara/stdinc.h>
+
 #include <yara/elf.h>
 #include <yara/endian.h>
 #include <yara/exec.h>

--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -27,15 +27,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <fcntl.h>
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
-#else
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
+#include <yara/stdinc.h>
 
 #include <yara/error.h>
 #include <yara/filemap.h>

--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -74,13 +74,7 @@
 /* First part of user prologue.  */
 #line 32 "grammar.y"
 
-  
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <stddef.h>
+#include <yara/stdinc.h>
 
 #include <yara/arena.h>
 #include <yara/integers.h>

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -31,12 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %{
   
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <stddef.h>
+#include <yara/stdinc.h>
 
 #include <yara/arena.h>
 #include <yara/integers.h>

--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -27,8 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/error.h>
 #include <yara/hash.h>
 #include <yara/integers.h>

--- a/libyara/hex_grammar.c
+++ b/libyara/hex_grammar.c
@@ -70,9 +70,8 @@
 /* Copy the first part of user declarations.  */
 #line 30 "hex_grammar.y" /* yacc.c:339  */
 
+#include <yara/stdinc.h>
 
-#include <limits.h>
-#include <string.h>
 #include <yara/error.h>
 #include <yara/hex_lexer.h>
 #include <yara/integers.h>

--- a/libyara/hex_grammar.y
+++ b/libyara/hex_grammar.y
@@ -29,8 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %{
 
-#include <string.h>
-#include <limits.h>
+#include <yara/stdinc.h>
 
 #include <yara/integers.h>
 #include <yara/utils.h>

--- a/libyara/hex_lexer.l
+++ b/libyara/hex_lexer.l
@@ -44,7 +44,7 @@ with noyywrap then we can remove this pragma.
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
-#include <setjmp.h>
+#include <stdinc.h>
 
 #include <yara/globals.h>
 #include <yara/limits.h>

--- a/libyara/include/yara.h
+++ b/libyara/include/yara.h
@@ -30,9 +30,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_YARA_H
 #define YR_YARA_H
 
+#ifndef MINLIBYARA
 #include "yara/compiler.h"
+#endif
 #include "yara/error.h"
+#ifndef MINLIBYARA
 #include "yara/filemap.h"
+#endif
 #include "yara/hash.h"
 #include "yara/libyara.h"
 #include "yara/mem.h"

--- a/libyara/include/yara/arena.h
+++ b/libyara/include/yara/arena.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_ARENA_H
 #define YR_ARENA_H
 
-#include <stddef.h>
+#include <yara/stdinc.h>
+
 #include <yara/integers.h>
 #include <yara/limits.h>
 #include <yara/stream.h>

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -70,9 +70,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // of items in the list above.
 #define YR_NUM_SECTIONS 12
 
-// Number of variables used by loops. This doesn't include user defined
-// variables.
-#define YR_INTERNAL_LOOP_VARS 3
 
 typedef struct _YR_EXPRESSION
 {

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -30,8 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_COMPILER_H
 #define YR_COMPILER_H
 
-#include <setjmp.h>
-#include <stdio.h>
+#include <yara/stdinc.h>
+
 #include <yara/ahocorasick.h>
 #include <yara/arena.h>
 #include <yara/filemap.h>

--- a/libyara/include/yara/dex.h
+++ b/libyara/include/yara/dex.h
@@ -1,7 +1,8 @@
 #ifndef _DEX_H
 #define _DEX_H
 
-#include <stdlib.h>
+#include <yara/stdinc.h>
+
 #include <yara/integers.h>
 #include <yara/types.h>
 

--- a/libyara/include/yara/error.h
+++ b/libyara/include/yara/error.h
@@ -115,9 +115,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define FAIL_ON_ERROR(x)         \
   {                              \
-    int result = (x);            \
-    if (result != ERROR_SUCCESS) \
-      return result;             \
+    int foe_result = (x);            \
+    if (foe_result != ERROR_SUCCESS) \
+      return foe_result;             \
   }
 
 #define GOTO_EXIT_ON_ERROR_WITH_CLEANUP(x, cleanup) \
@@ -132,11 +132,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define FAIL_ON_ERROR_WITH_CLEANUP(x, cleanup) \
   {                                            \
-    int result = (x);                          \
-    if (result != ERROR_SUCCESS)               \
+    int foe_result = (x);                          \
+    if (foe_result != ERROR_SUCCESS)               \
     {                                          \
       cleanup;                                 \
-      return result;                           \
+      return foe_result;                           \
     }                                          \
   }
 

--- a/libyara/include/yara/error.h
+++ b/libyara/include/yara/error.h
@@ -30,11 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_ERROR_H
 #define YR_ERROR_H
 
-#include <string.h>
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
-#endif
+#include <yara/stdinc.h>
 
 #ifndef ERROR_SUCCESS
 #define ERROR_SUCCESS 0

--- a/libyara/include/yara/filemap.h
+++ b/libyara/include/yara/filemap.h
@@ -30,16 +30,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_FILEMAP_H
 #define YR_FILEMAP_H
 
-#include <sys/types.h>
+#include <yara/stdinc.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
 #define YR_FILE_DESCRIPTOR HANDLE
 #else
 #define YR_FILE_DESCRIPTOR int
 #endif
 
-#include <stdlib.h>
 #include <yara/integers.h>
 #include <yara/utils.h>
 

--- a/libyara/include/yara/hash.h
+++ b/libyara/include/yara/hash.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_HASH_H
 #define YR_HASH_H
 
-#include <stddef.h>
+#include <yara/stdinc.h>
+
 #include <yara/integers.h>
 #include <yara/utils.h>
 

--- a/libyara/include/yara/integers.h
+++ b/libyara/include/yara/integers.h
@@ -61,7 +61,7 @@ extern "C"
 #define INT8_MIN (-127i8 - 1)
 #endif
 
-#ifndef INT8_MIN
+#ifndef INT16_MIN
 #define INT16_MIN (-32767i16 - 1)
 #endif
 

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -101,6 +101,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_MAX_LOOP_VARS 2
 #endif
 
+// Number of variables used by loops. This doesn't include user defined
+// variables.
+#define YR_INTERNAL_LOOP_VARS 3
+
+
 // Maximum number of nested included files.
 #ifndef YR_MAX_INCLUDE_DEPTH
 #define YR_MAX_INCLUDE_DEPTH 16

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -30,9 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_LIMITS_H
 #define YR_LIMITS_H
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <windows.h>
-#endif
+#include <yara/stdinc.h>
 
 #include "utils.h"
 

--- a/libyara/include/yara/mem.h
+++ b/libyara/include/yara/mem.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_MEM_H
 #define YR_MEM_H
 
-#include <stdio.h>
+#include <yara/stdinc.h>
+
 #include <yara/utils.h>
 
 #ifdef DMALLOC

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -30,10 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_MODULES_H
 #define YR_MODULES_H
 
-#include <assert.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/error.h>
 #include <yara/exec.h>
 #include <yara/libyara.h>

--- a/libyara/include/yara/notebook.h
+++ b/libyara/include/yara/notebook.h
@@ -5,7 +5,7 @@
 #ifndef YR_NOTEBOOK_H
 #define YR_NOTEBOOK_H
 
-#include <stdlib.h>
+#include <yara/stdinc.h>
 
 typedef struct YR_NOTEBOOK YR_NOTEBOOK;
 

--- a/libyara/include/yara/object.h
+++ b/libyara/include/yara/object.h
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_OBJECT_H
 #define YR_OBJECT_H
 
+#ifndef MINLIBYARA
 #ifdef _MSC_VER
 #include <float.h>
 #ifndef isnan
@@ -42,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef NAN
 #define NAN (INFINITY - INFINITY)
+#endif
 #endif
 #endif
 
@@ -57,7 +59,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OBJECT_TYPE_ARRAY      4
 #define OBJECT_TYPE_FUNCTION   5
 #define OBJECT_TYPE_DICTIONARY 6
+#ifndef MINLIBYARA
 #define OBJECT_TYPE_FLOAT      7
+#endif
 
 int yr_object_create(
     int8_t type,
@@ -94,8 +98,10 @@ YR_OBJECT* yr_object_lookup(
 bool yr_object_has_undefined_value(YR_OBJECT* object, const char* field, ...)
     YR_PRINTF_LIKE(2, 3);
 
+#ifndef MINLIBYARA
 double yr_object_get_float(YR_OBJECT* object, const char* field, ...)
     YR_PRINTF_LIKE(2, 3);
+#endif
 
 int64_t yr_object_get_integer(YR_OBJECT* object, const char* field, ...)
     YR_PRINTF_LIKE(2, 3);
@@ -109,8 +115,10 @@ int yr_object_set_integer(
     const char* field,
     ...) YR_PRINTF_LIKE(3, 4);
 
+#ifndef MINLIBYARA
 int yr_object_set_float(double value, YR_OBJECT* object, const char* field, ...)
     YR_PRINTF_LIKE(3, 4);
+#endif
 
 int yr_object_set_string(
     const char* value,

--- a/libyara/include/yara/re.h
+++ b/libyara/include/yara/re.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_RE_H
 #define YR_RE_H
 
-#include <ctype.h>
+#include <yara/stdinc.h>
+
 #include <yara/arena.h>
 #include <yara/sizedstr.h>
 #include <yara/types.h>

--- a/libyara/include/yara/rules.h
+++ b/libyara/include/yara/rules.h
@@ -94,6 +94,7 @@ YR_API int yr_rules_scan_mem(
     void* user_data,
     int timeout);
 
+#ifndef MINLIBYARA
 YR_API int yr_rules_scan_file(
     YR_RULES* rules,
     const char* filename,
@@ -119,10 +120,13 @@ YR_API int yr_rules_scan_proc(
     int timeout);
 
 YR_API int yr_rules_save(YR_RULES* rules, const char* filename);
+#endif
 
 YR_API int yr_rules_save_stream(YR_RULES* rules, YR_STREAM* stream);
 
+#ifndef MINLIBYARA
 YR_API int yr_rules_load(const char* filename, YR_RULES** rules);
+#endif
 
 YR_API int yr_rules_load_stream(YR_STREAM* stream, YR_RULES** rules);
 
@@ -138,10 +142,12 @@ YR_API int yr_rules_define_boolean_variable(
     const char* identifier,
     int value);
 
+#ifndef MINLIBYARA
 YR_API int yr_rules_define_float_variable(
     YR_RULES* rules,
     const char* identifier,
     double value);
+#endif
 
 YR_API int yr_rules_define_string_variable(
     YR_RULES* rules,

--- a/libyara/include/yara/scanner.h
+++ b/libyara/include/yara/scanner.h
@@ -59,10 +59,12 @@ YR_API int yr_scanner_define_boolean_variable(
     const char* identifier,
     int value);
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_define_float_variable(
     YR_SCANNER* scanner,
     const char* identifier,
     double value);
+#endif
 
 YR_API int yr_scanner_define_string_variable(
     YR_SCANNER* scanner,
@@ -78,11 +80,13 @@ YR_API int yr_scanner_scan_mem(
     const uint8_t* buffer,
     size_t buffer_size);
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_scan_file(YR_SCANNER* scanner, const char* filename);
 
 YR_API int yr_scanner_scan_fd(YR_SCANNER* scanner, YR_FILE_DESCRIPTOR fd);
 
 YR_API int yr_scanner_scan_proc(YR_SCANNER* scanner, int pid);
+#endif
 
 YR_API YR_RULE* yr_scanner_last_error_rule(YR_SCANNER* scanner);
 
@@ -93,6 +97,8 @@ YR_API YR_RULE_PROFILING_INFO* yr_scanner_get_profiling_info(
 
 YR_API void yr_scanner_reset_profiling_info(YR_SCANNER* scanner);
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_print_profiling_info(YR_SCANNER* scanner);
+#endif
 
 #endif

--- a/libyara/include/yara/stdinc.h
+++ b/libyara/include/yara/stdinc.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <assert.h>
+#include <ctype.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif 
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <share.h>
+#endif 
+
+#include <float.h>
+#include <math.h>
+
+#include <setjmp.h>

--- a/libyara/include/yara/stopwatch.h
+++ b/libyara/include/yara/stopwatch.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_STOPWATCH_H
 #define YR_STOPWATCH_H
 
-#include <time.h>
+#include <yara/stdinc.h>
+
 #include <yara/integers.h>
 
 #if defined(_WIN32)

--- a/libyara/include/yara/stream.h
+++ b/libyara/include/yara/stream.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_STREAM_H
 #define YR_STREAM_H
 
-#include <stddef.h>
+#include <yara/stdinc.h>
 
 typedef size_t (*YR_STREAM_READ_FUNC)(
     void* ptr,

--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -30,9 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_STRUTILS_H
 #define YR_STRUTILS_H
 
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/integers.h>
 
 #if defined(_WIN32)

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef YR_UTILS_H
 #define YR_UTILS_H
 
-#include <limits.h>
+#include <yara/stdinc.h>
+
 #include <yara/strutils.h>
 
 #ifndef NULL

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -44,12 +44,7 @@ with noyywrap then we can remove this pragma.
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
-#include <math.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <setjmp.h>
+#include <stdinc.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -31,9 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <jemalloc/jemalloc.h>
 #endif
 
-#include <ctype.h>
-#include <stdio.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/error.h>
 #include <yara/globals.h>
 #include <yara/mem.h>

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -93,6 +93,7 @@ const char yr_debug_spaces[] = "                " /* 16 spaces * 1 */
 
 size_t yr_debug_spaces_len = sizeof(yr_debug_spaces);
 
+#ifndef MINLIBYARA
 double yr_debug_get_elapsed_seconds(void)
 {
   if (yr_debug_stopwatch_unstarted)
@@ -107,6 +108,7 @@ double yr_debug_get_elapsed_seconds(void)
 
   return seconds;
 }
+#endif
 
 char *yr_debug_callback_message_as_string(int message)
 {

--- a/libyara/mem.c
+++ b/libyara/mem.c
@@ -73,34 +73,6 @@ void* yr_realloc(void* ptr, size_t size)
   return (void*) HeapReAlloc(hHeap, HEAP_ZERO_MEMORY, ptr, size);
 }
 
-char* yr_strdup(const char* str)
-{
-  size_t len = strlen(str);
-  char* dup = (char*) yr_malloc(len + 1);
-
-  if (dup == NULL)
-    return NULL;
-
-  memcpy(dup, str, len);
-  dup[len] = '\0';
-
-  return (char*) dup;
-}
-
-char* yr_strndup(const char* str, size_t n)
-{
-  size_t len = strnlen(str, n);
-  char* dup = (char*) yr_malloc(len + 1);
-
-  if (dup == NULL)
-    return NULL;
-
-  memcpy(dup, str, len);
-  dup[len] = '\0';
-
-  return (char*) dup;
-}
-
 YR_API void yr_free(void* ptr)
 {
   HeapFree(hHeap, 0, ptr);

--- a/libyara/modules/module_list
+++ b/libyara/modules/module_list
@@ -1,7 +1,9 @@
 MODULE(tests)
 MODULE(pe)
 MODULE(elf)
+#ifndef MINLIBYARA
 MODULE(math)
+#endif
 MODULE(time)
 
 #ifdef DOTNET_MODULE

--- a/libyara/modules/tests/tests.c
+++ b/libyara/modules/tests/tests.c
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define MODULE_NAME tests
 
+#ifndef MINLIBYARA
 define_function(fsum_2)
 {
   double a = float_argument(1);
@@ -47,6 +48,7 @@ define_function(fsum_3)
 
   return_float(a + b + c);
 }
+#endif
 
 define_function(isum_2)
 {
@@ -110,7 +112,9 @@ begin_declarations
 
   begin_struct("undefined")
     declare_integer("i");
+#ifndef MINLIBYARA
     declare_float("f");
+#endif
   end_struct("undefined")
 
   declare_string("module_data");
@@ -146,8 +150,10 @@ begin_declarations
   declare_function("match", "rs", "i", match);
   declare_function("isum", "ii", "i", isum_2);
   declare_function("isum", "iii", "i", isum_3);
+#ifndef MINLIBYARA
   declare_function("fsum", "ff", "f", fsum_2);
   declare_function("fsum", "fff", "f", fsum_3);
+#endif
   declare_function("length", "s", "i", length);
   declare_function("empty", "", "s", empty);
   declare_function("foobar", "i", "s", foobar);

--- a/libyara/notebook.c
+++ b/libyara/notebook.c
@@ -27,8 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <stdint.h>
+#include <yara/stdinc.h>
+
 #include <yara/error.h>
 #include <yara/mem.h>
 #include <yara/notebook.h>

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -27,13 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <ctype.h>
-#include <math.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/error.h>
 #include <yara/exec.h>
 #include <yara/globals.h>

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -62,9 +62,11 @@ int yr_object_create(
   case OBJECT_TYPE_INTEGER:
     object_size = sizeof(YR_OBJECT);
     break;
+#ifndef MINLIBYARA
   case OBJECT_TYPE_FLOAT:
     object_size = sizeof(YR_OBJECT);
     break;
+#endif
   case OBJECT_TYPE_STRING:
     object_size = sizeof(YR_OBJECT);
     break;
@@ -90,9 +92,11 @@ int yr_object_create(
   case OBJECT_TYPE_INTEGER:
     obj->value.i = YR_UNDEFINED;
     break;
+#ifndef MINLIBYARA
   case OBJECT_TYPE_FLOAT:
     obj->value.d = NAN;
     break;
+#endif
   case OBJECT_TYPE_STRING:
     obj->value.ss = NULL;
     break;
@@ -194,9 +198,11 @@ int yr_object_function_create(
   case 's':
     return_type = OBJECT_TYPE_STRING;
     break;
+#ifndef MINLIBYARA
   case 'f':
     return_type = OBJECT_TYPE_FLOAT;
     break;
+#endif
   default:
     return ERROR_INVALID_FORMAT;
   }
@@ -253,9 +259,11 @@ int yr_object_from_external_variable(
     obj_type = OBJECT_TYPE_INTEGER;
     break;
 
+#ifndef MINLIBYARA
   case EXTERNAL_VARIABLE_TYPE_FLOAT:
     obj_type = OBJECT_TYPE_FLOAT;
     break;
+#endif
 
   case EXTERNAL_VARIABLE_TYPE_STRING:
   case EXTERNAL_VARIABLE_TYPE_MALLOC_STRING:
@@ -277,9 +285,11 @@ int yr_object_from_external_variable(
       result = yr_object_set_integer(external->value.i, obj, NULL);
       break;
 
+#ifndef MINLIBYARA
     case EXTERNAL_VARIABLE_TYPE_FLOAT:
       result = yr_object_set_float(external->value.f, obj, NULL);
       break;
+#endif
 
     case EXTERNAL_VARIABLE_TYPE_STRING:
     case EXTERNAL_VARIABLE_TYPE_MALLOC_STRING:
@@ -541,9 +551,11 @@ int yr_object_copy(YR_OBJECT* object, YR_OBJECT** object_copy)
     copy->value.i = object->value.i;
     break;
 
+#ifndef MINLIBYARA
   case OBJECT_TYPE_FLOAT:
     copy->value.d = object->value.d;
     break;
+#endif
 
   case OBJECT_TYPE_STRING:
 
@@ -847,8 +859,10 @@ bool yr_object_has_undefined_value(YR_OBJECT* object, const char* field, ...)
 
   switch (field_obj->type)
   {
+#ifndef MINLIBYARA
   case OBJECT_TYPE_FLOAT:
     return isnan(field_obj->value.d);
+#endif
   case OBJECT_TYPE_STRING:
     return field_obj->value.ss == NULL;
   case OBJECT_TYPE_INTEGER:
@@ -883,6 +897,7 @@ int64_t yr_object_get_integer(YR_OBJECT* object, const char* field, ...)
   return integer_obj->value.i;
 }
 
+#ifndef MINLIBYARA
 double yr_object_get_float(YR_OBJECT* object, const char* field, ...)
 {
   YR_OBJECT* double_obj;
@@ -907,6 +922,7 @@ double yr_object_get_float(YR_OBJECT* object, const char* field, ...)
 
   return double_obj->value.d;
 }
+#endif
 
 SIZED_STRING* yr_object_get_string(YR_OBJECT* object, const char* field, ...)
 {
@@ -966,6 +982,7 @@ int yr_object_set_integer(
   return ERROR_SUCCESS;
 }
 
+#ifndef MINLIBYARA
 int yr_object_set_float(double value, YR_OBJECT* object, const char* field, ...)
 {
   YR_OBJECT* double_obj;
@@ -994,6 +1011,7 @@ int yr_object_set_float(double value, YR_OBJECT* object, const char* field, ...)
 
   return ERROR_SUCCESS;
 }
+#endif
 
 int yr_object_set_string(
     const char* value,
@@ -1079,6 +1097,7 @@ YR_API void yr_object_print_data(
 
   switch (object->type)
   {
+#ifndef MINLIBYARA
   case OBJECT_TYPE_FLOAT:
     if (object->value.i != YR_UNDEFINED)
       printf(" = %f", object->value.d);
@@ -1086,6 +1105,7 @@ YR_API void yr_object_print_data(
       printf(" = YR_UNDEFINED");
 
     break;
+#endif
 
   case OBJECT_TYPE_INTEGER:
 

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -27,9 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <limits.h>
-#include <stddef.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/ahocorasick.h>
 #include <yara/arena.h>
 #include <yara/base64.h>

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -37,8 +37,8 @@ order to avoid confusion with operating system threads.
 
 */
 
-#include <assert.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/compiler.h>
 #include <yara/error.h>
 #include <yara/globals.h>

--- a/libyara/re_lexer.l
+++ b/libyara/re_lexer.l
@@ -44,8 +44,7 @@ with noyywrap then we can remove this pragma.
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
-#include <assert.h>
-#include <setjmp.h>
+#include <stdlib.h>
 
 #include <yara/globals.h>
 #include <yara/utils.h>

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -237,6 +237,7 @@ _exit:
   return result;
 }
 
+#ifndef MINLIBYARA
 YR_API int yr_rules_scan_file(
     YR_RULES* rules,
     const char* filename,
@@ -321,6 +322,7 @@ YR_API int yr_rules_scan_proc(
 
   return result;
 }
+#endif
 
 int yr_rules_from_arena(YR_ARENA* arena, YR_RULES** rules)
 {

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -27,9 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <ctype.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/compiler.h>
 #include <yara/error.h>
 #include <yara/filemap.h>

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -37,7 +37,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/re.h>
 #include <yara/rules.h>
 #include <yara/scan.h>
+#ifdef YR_PROFILING_ENABLED
 #include <yara/stopwatch.h>
+#endif
 #include <yara/strutils.h>
 #include <yara/types.h>
 #include <yara/utils.h>

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -27,10 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <assert.h>
-#include <ctype.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <yara/stdinc.h>
+
 #include <yara/bitmask.h>
 #include <yara/error.h>
 #include <yara/globals.h>

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -27,7 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdlib.h>
+#include <yara/stdinc.h>
+
 #include <yara/ahocorasick.h>
 #include <yara/error.h>
 #include <yara/exec.h>

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -380,6 +380,7 @@ YR_API int yr_scanner_define_boolean_variable(
   return yr_scanner_define_integer_variable(scanner, identifier, value);
 }
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_define_float_variable(
     YR_SCANNER* scanner,
     const char* identifier,
@@ -396,6 +397,7 @@ YR_API int yr_scanner_define_float_variable(
 
   return yr_object_set_float(value, obj, NULL);
 }
+#endif
 
 YR_API int yr_scanner_define_string_variable(
     YR_SCANNER* scanner,
@@ -670,6 +672,7 @@ YR_API int yr_scanner_scan_mem(
   return result;
 }
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_scan_file(YR_SCANNER* scanner, const char* filename)
 {
   YR_MAPPED_FILE mfile;
@@ -717,6 +720,7 @@ YR_API int yr_scanner_scan_proc(YR_SCANNER* scanner, int pid)
 
   return result;
 }
+#endif
 
 YR_API YR_STRING* yr_scanner_last_error_string(YR_SCANNER* scanner)
 {
@@ -799,6 +803,7 @@ YR_API void yr_scanner_reset_profiling_info(YR_SCANNER* scanner)
 #endif
 }
 
+#ifndef MINLIBYARA
 YR_API int yr_scanner_print_profiling_info(YR_SCANNER* scanner)
 {
   printf("\n===== PROFILING INFORMATION =====\n\n");
@@ -827,3 +832,4 @@ YR_API int yr_scanner_print_profiling_info(YR_SCANNER* scanner)
 
   return ERROR_SUCCESS;
 }
+#endif

--- a/libyara/sizedstr.c
+++ b/libyara/sizedstr.c
@@ -27,8 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <ctype.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/globals.h>
 #include <yara/mem.h>
 #include <yara/sizedstr.h>

--- a/libyara/stream.c
+++ b/libyara/stream.c
@@ -27,7 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stddef.h>
+#include <yara/stdinc.h>
+
 #include <yara/stream.h>
 
 

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -247,3 +247,31 @@ int yr_isalnum(const uint8_t* s)
          (*s >= 0x41 && *s <= 0x5a) ||
          (*s >= 0x61 && *s <= 0x7a);
 }
+
+char* yr_strdup(const char* str)
+{
+  size_t len = strlen(str);
+  char* dup = (char*) yr_malloc(len + 1);
+
+  if (dup == NULL)
+    return NULL;
+
+  memcpy(dup, str, len);
+  dup[len] = '\0';
+
+  return (char*) dup;
+}
+
+char* yr_strndup(const char* str, size_t n)
+{
+  size_t len = strnlen(str, n);
+  char* dup = (char*) yr_malloc(len + 1);
+
+  if (dup == NULL)
+    return NULL;
+
+  memcpy(dup, str, len);
+  dup[len] = '\0';
+
+  return (char*) dup;
+}

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -27,8 +27,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <yara/stdinc.h>
+
 #include <yara/strutils.h>
 
 uint64_t xtoi(const char* hexstr)

--- a/windows/vs2015/test-alignment/test-alignment.vcxproj
+++ b/windows/vs2015/test-alignment/test-alignment.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{76A5B2B8-8844-4278-A33E-CE95261AF6A1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>testalignment</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/windows/vs2017/libyara/libyara.vcxproj
+++ b/windows/vs2017/libyara/libyara.vcxproj
@@ -267,6 +267,7 @@
     <ClCompile Include="..\..\..\libyara\threading.c" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\minyara\minyara.vcxproj" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/windows/vs2017/libyara/libyara.vcxproj
+++ b/windows/vs2017/libyara/libyara.vcxproj
@@ -24,27 +24,27 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E236CE39-D8F3-4DB6-985C-F2794FF17746}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'" Label="Configuration">

--- a/windows/vs2017/minlibyara/minlibyara.vcxproj
+++ b/windows/vs2017/minlibyara/minlibyara.vcxproj
@@ -250,9 +250,6 @@
     <ClCompile Include="..\..\..\libyara\stream.c" />
     <ClCompile Include="..\..\..\libyara\strutils.c" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/windows/vs2017/minlibyara/minlibyara.vcxproj
+++ b/windows/vs2017/minlibyara/minlibyara.vcxproj
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="StaticRelease|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{380c2d56-7764-4282-bfcf-07fe55d91edb}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>$(ProjectName)32</TargetName>
+    <OutDir>$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>$(ProjectName)64</TargetName>
+    <OutDir>$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>$(ProjectName)32</TargetName>
+    <OutDir>$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>$(ProjectName)64</TargetName>
+    <OutDir>$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DOTNET_MODULE;MINLIBYARA;YR_DEBUG_VERBOSITY=0;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
+      <CompileAs>CompileAsC</CompileAs>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)</ObjectFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PrecompiledHeaderFile />
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>jansson.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>..\packages\YARA.OpenSSL.x86.1.1.1\lib;..\packages\YARA.Jansson.x86.1.1.0\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/IGNORE:4221</AdditionalOptions>
+    </Lib>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <Link>
+      <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DOTNET_MODULE;MINLIBYARA;YR_DEBUG_VERBOSITY=0;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
+      <CompileAs>CompileAsC</CompileAs>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)</ObjectFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <OmitFramePointers>false</OmitFramePointers>
+      <PrecompiledHeaderFile />
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;advapi32.lib;jansson.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+      <AdditionalLibraryDirectories>..\packages\YARA.OpenSSL.x64.1.1.1\lib;..\packages\YARA.Jansson.x64.1.1.0\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/IGNORE:4221</AdditionalOptions>
+    </Lib>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <Link>
+      <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DOTNET_MODULE;MINLIBYARA;YR_DEBUG_VERBOSITY=0;YR_BUILDING_STATIC_LIB</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
+      <CompileAs>CompileAsC</CompileAs>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)</ObjectFileName>
+      <PrecompiledHeaderFile />
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>jansson.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>..\packages\YARA.OpenSSL.x86.1.1.1\lib;..\packages\YARA.Jansson.x86.1.1.0\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/IGNORE:4221</AdditionalOptions>
+    </Lib>
+    <Link>
+      <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DOTNET_MODULE;MINLIBYARA;YR_DEBUG_VERBOSITY=0;YR_BUILDING_STATIC_LIB</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
+      <CompileAs>CompileAsC</CompileAs>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)</ObjectFileName>
+      <OmitFramePointers>false</OmitFramePointers>
+      <PrecompiledHeaderFile />
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>jansson.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
+      <AdditionalLibraryDirectories>..\packages\YARA.OpenSSL.x64.1.1.1\lib;..\packages\YARA.Jansson.x64.1.1.0\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/IGNORE:4221</AdditionalOptions>
+    </Lib>
+    <Link>
+      <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;NDEBUG=1</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
+      <CompileAs>CompileAsC</CompileAs>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)</ObjectFileName>
+      <OmitFramePointers>false</OmitFramePointers>
+      <PrecompiledHeaderFile />
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>jansson.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
+      <AdditionalLibraryDirectories>..\packages\YARA.OpenSSL.x64.1.1.1\lib;..\packages\YARA.Jansson.x64.1.1.0\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/IGNORE:4221</AdditionalOptions>
+    </Lib>
+    <Link>
+      <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\libyara\arena.c" />
+    <ClCompile Include="..\..\..\libyara\base64.c" />
+    <ClCompile Include="..\..\..\libyara\bitmask.c" />
+    <ClCompile Include="..\..\..\libyara\exec.c" />
+    <ClCompile Include="..\..\..\libyara\exefiles.c" />
+    <ClCompile Include="..\..\..\libyara\hash.c" />
+    <ClCompile Include="..\..\..\libyara\hex_grammar.c" />
+    <ClCompile Include="..\..\..\libyara\hex_lexer.c" />
+    <ClCompile Include="..\..\..\libyara\libyara.c" />
+    <ClCompile Include="..\..\..\libyara\modules.c" />
+    <ClCompile Include="..\..\..\libyara\modules\dex\dex.c" />
+    <ClCompile Include="..\..\..\libyara\modules\dotnet\dotnet.c" />
+    <ClCompile Include="..\..\..\libyara\modules\elf\elf.c" />
+    <ClCompile Include="..\..\..\libyara\modules\macho\macho.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\pe.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\pe_utils.c" />
+    <ClCompile Include="..\..\..\libyara\modules\tests\tests.c" />
+    <ClCompile Include="..\..\..\libyara\modules\time\time.c" />
+    <ClCompile Include="..\..\..\libyara\notebook.c" />
+    <ClCompile Include="..\..\..\libyara\object.c" />
+    <ClCompile Include="..\..\..\libyara\re.c" />
+    <ClCompile Include="..\..\..\libyara\re_grammar.c" />
+    <ClCompile Include="..\..\..\libyara\re_lexer.c" />
+    <ClCompile Include="..\..\..\libyara\rules.c" />
+    <ClCompile Include="..\..\..\libyara\scan.c" />
+    <ClCompile Include="..\..\..\libyara\scanner.c" />
+    <ClCompile Include="..\..\..\libyara\sizedstr.c" />
+    <ClCompile Include="..\..\..\libyara\stream.c" />
+    <ClCompile Include="..\..\..\libyara\strutils.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/windows/vs2017/minyara/minyara.vcxproj
+++ b/windows/vs2017/minyara/minyara.vcxproj
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{a8592865-dbf3-4ff5-99fc-dc3e37dc3c65}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>yara</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)32</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>$(ProjectName)64</TargetName>
+    <OutDir>$(SolutionDir)\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)32</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)64</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>MINLIBYARA;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;..\..\..\cli;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>ws2_32.lib;crypt32.lib;minlibyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\minlibyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>MINLIBYARA;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;..\..\..\cli;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>ws2_32.lib;crypt32.lib;minlibyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\minlibyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>MINLIBYARA;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;..\..\..\cli;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>ws2_32.lib;crypt32.lib;minlibyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\minlibyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+    </Link>
+    <ProjectReference>
+      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>MINLIBYARA;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\libyara\include;..\..\..\cli;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>ws2_32.lib;crypt32.lib;minlibyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\minlibyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\cli\args.c" />
+    <ClCompile Include="..\..\..\cli\common.c" />
+    <ClCompile Include="..\..\..\cli\minyara.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/windows/vs2017/minyara/minyara.vcxproj
+++ b/windows/vs2017/minyara/minyara.vcxproj
@@ -176,6 +176,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\cli\args.c" />
     <ClCompile Include="..\..\..\cli\common.c" />
+    <ClCompile Include="..\..\..\cli\minruntime.c" />
     <ClCompile Include="..\..\..\cli\minyara.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/windows/vs2017/yara.sln
+++ b/windows/vs2017/yara.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31829.152
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libyara", "libyara\libyara.vcxproj", "{E236CE39-D8F3-4DB6-985C-F2794FF17746}"
 EndProject
@@ -16,6 +16,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "yarac", "yarac\yarac.vcxpro
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-alignment", "..\vs2015\test-alignment\test-alignment.vcxproj", "{76A5B2B8-8844-4278-A33E-CE95261AF6A1}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "minlibyara", "minlibyara\minlibyara.vcxproj", "{380C2D56-7764-4282-BFCF-07FE55D91EDB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,8 +59,19 @@ Global
 		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x64.Build.0 = Release|x64
 		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x86.ActiveCfg = Release|Win32
 		{76A5B2B8-8844-4278-A33E-CE95261AF6A1}.Release|x86.Build.0 = Release|Win32
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Debug|x64.ActiveCfg = Debug|x64
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Debug|x64.Build.0 = Debug|x64
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Debug|x86.ActiveCfg = Debug|Win32
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Debug|x86.Build.0 = Debug|Win32
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x64.ActiveCfg = Release|x64
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x64.Build.0 = Release|x64
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x86.ActiveCfg = Release|Win32
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C4E699FB-A1FD-4141-9672-D3B6D4029DF9}
 	EndGlobalSection
 EndGlobal

--- a/windows/vs2017/yara.sln
+++ b/windows/vs2017/yara.sln
@@ -19,6 +19,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test-alignment", "..\vs2015
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "minlibyara", "minlibyara\minlibyara.vcxproj", "{380C2D56-7764-4282-BFCF-07FE55D91EDB}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "minyara", "minyara\minyara.vcxproj", "{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}"
+	ProjectSection(ProjectDependencies) = postProject
+		{380C2D56-7764-4282-BFCF-07FE55D91EDB} = {380C2D56-7764-4282-BFCF-07FE55D91EDB}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -67,6 +72,14 @@ Global
 		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x64.Build.0 = Release|x64
 		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x86.ActiveCfg = Release|Win32
 		{380C2D56-7764-4282-BFCF-07FE55D91EDB}.Release|x86.Build.0 = Release|Win32
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Debug|x64.ActiveCfg = Debug|x64
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Debug|x64.Build.0 = Debug|x64
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Debug|x86.ActiveCfg = Debug|Win32
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Debug|x86.Build.0 = Debug|Win32
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Release|x64.ActiveCfg = Release|x64
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Release|x64.Build.0 = Release|x64
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Release|x86.ActiveCfg = Release|Win32
+		{A8592865-DBF3-4FF5-99FC-DC3E37DC3C65}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/vs2017/yara/yara.vcxproj
+++ b/windows/vs2017/yara/yara.vcxproj
@@ -22,35 +22,35 @@
     <ProjectGuid>{DF8232C7-D8C1-4D05-9921-F8F504134410}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>yara</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/windows/vs2017/yarac/yarac.vcxproj
+++ b/windows/vs2017/yarac/yarac.vcxproj
@@ -22,34 +22,34 @@
     <ProjectGuid>{7C72350B-AA5B-41AD-8957-CE3924A7F11B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>yarac</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
fix UINT16_MIN macro fence
avoid redefinition of 'result' in a macro
fix assert since apparently 'i' was intended to be re-used in exec.c