### PR TITLE
Add MD5 of decrypted rich data to PE module

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -924,6 +924,10 @@ Reference
 
         Data after being decrypted by XORing it with the key.
 
+    .. c:member:: hash
+
+        MD5 hash of the clear rich header data.
+
     .. c:function:: version(version, [toolid])
 
         .. versionadded:: 3.5.0

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -924,7 +924,7 @@ Reference
 
         Data after being decrypted by XORing it with the key.
 
-    .. c:member:: hash
+    .. c:member:: md5
 
         MD5 hash of the clear rich header data.
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -265,7 +265,7 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
   /* Calculate the MD5 of the decrypted Rich data */
   unsigned char rich_hash[YR_MD5_LEN];
 
-  MD5_CTX ctx;
+  yr_md5_ctx ctx;
   yr_md5_init(&ctx);
   yr_md5_update(&ctx, clear_data, rich_len);
   yr_md5_final(rich_hash, &ctx);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -262,6 +262,20 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
     *rich_ptr ^= rich_signature->key1;
   }
 
+  /* Calculate the MD5 of the decrypted Rich data */
+  unsigned char rich_hash[YR_MD5_LEN];
+
+  MD5_CTX ctx;
+  yr_md5_init(&ctx);
+  yr_md5_update(&ctx, clear_data, rich_len);
+  yr_md5_final(rich_hash, &ctx);
+
+  char rich_hash_ascii[YR_MD5_LEN * 2 + 1];
+  for (int i = 0; i < YR_MD5_LEN; ++i)
+    sprintf(rich_hash_ascii + (i * 2), "%02x", rich_hash[i]);
+
+  set_string(rich_hash_ascii, pe->object, "rich_signature.hash");
+
   set_sized_string(
       (char*) raw_data, rich_len, pe->object, "rich_signature.raw_data");
 
@@ -3471,6 +3485,7 @@ begin_declarations
     declare_integer("key");
     declare_string("raw_data");
     declare_string("clear_data");
+    declare_string("hash");
     declare_function("version", "i", "i", rich_version);
     declare_function("version", "ii", "i", rich_version_toolid);
     declare_function("toolid", "i", "i", rich_toolid);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -274,7 +274,7 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
   for (int i = 0; i < YR_MD5_LEN; ++i)
     sprintf(rich_hash_ascii + (i * 2), "%02x", rich_hash[i]);
 
-  set_string(rich_hash_ascii, pe->object, "rich_signature.hash");
+  set_string(rich_hash_ascii, pe->object, "rich_signature.md5");
 
   set_sized_string(
       (char*) raw_data, rich_len, pe->object, "rich_signature.raw_data");
@@ -3485,7 +3485,7 @@ begin_declarations
     declare_integer("key");
     declare_string("raw_data");
     declare_string("clear_data");
-    declare_string("hash");
+    declare_string("md5");
     declare_function("version", "i", "i", rich_version);
     declare_function("version", "ii", "i", rich_version_toolid);
     declare_function("toolid", "i", "i", rich_toolid);

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -508,7 +508,7 @@ int main(int argc, char** argv)
           pe.rich_signature.toolid(1, 0) > 40 and pe.rich_signature.toolid(1, 0) < 45 and \
           pe.rich_signature.version(30319) and \
           pe.rich_signature.version(40219, 170) == 11 and \
-          pe.rich_signature.hash == \"acc92f51ede1b8553e81789764e1a55c\" \
+          pe.rich_signature.md5 == \"acc92f51ede1b8553e81789764e1a55c\" \
       }",
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
@@ -523,7 +523,7 @@ int main(int argc, char** argv)
           pe.rich_signature.offset == 0x200 and \
           pe.rich_signature.length == 64 and \
           pe.rich_signature.key == 0x9f1d8511 and \
-          pe.rich_signature.hash == \"c776c17a2e491b6fbb8a81eb0fe1bdd2\" and \
+          pe.rich_signature.md5 == \"c776c17a2e491b6fbb8a81eb0fe1bdd2\" and \
           pe.rich_signature.clear_data == \"DanS\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x11\\x00\\x00\\x00\\xc3\\x0f]\\x00\\x03\\x00\\x00\\x00\\x09x\\x95\\x00\\x01\\x00\\x00\\x00\\x09x\\x83\\x00\\x05\\x00\\x00\\x00\\x09x\\x94\\x00\\x01\\x00\\x00\\x00\\x09x\\x91\\x00\\x01\\x00\\x00\\x00\" \
       }",
       "tests/data/weird_rich");

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -507,7 +507,8 @@ int main(int argc, char** argv)
           pe.rich_signature.toolid(157, 40219) == 1 and \
           pe.rich_signature.toolid(1, 0) > 40 and pe.rich_signature.toolid(1, 0) < 45 and \
           pe.rich_signature.version(30319) and \
-          pe.rich_signature.version(40219, 170) == 11 \
+          pe.rich_signature.version(40219, 170) == 11 and \
+          pe.rich_signature.hash == \"acc92f51ede1b8553e81789764e1a55c\" \
       }",
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
@@ -522,6 +523,7 @@ int main(int argc, char** argv)
           pe.rich_signature.offset == 0x200 and \
           pe.rich_signature.length == 64 and \
           pe.rich_signature.key == 0x9f1d8511 and \
+          pe.rich_signature.hash == \"c776c17a2e491b6fbb8a81eb0fe1bdd2\" and \
           pe.rich_signature.clear_data == \"DanS\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x11\\x00\\x00\\x00\\xc3\\x0f]\\x00\\x03\\x00\\x00\\x00\\x09x\\x95\\x00\\x01\\x00\\x00\\x00\\x09x\\x83\\x00\\x05\\x00\\x00\\x00\\x09x\\x94\\x00\\x01\\x00\\x00\\x00\\x09x\\x91\\x00\\x01\\x00\\x00\\x00\" \
       }",
       "tests/data/weird_rich");


### PR DESCRIPTION
A simple addition to the PE module. An MD5 hash of the clear (XOR decrypted) rich header data.