### PR TITLE
Fix yr_re_fast_exec on larger than 2GiB files

### DIFF
--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -158,7 +158,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RE_MAX_STACK 1024
 #endif
 
-// Maximum input size scanned by yr_re_exec
+// Maximum input size scanned by yr_re_exec and yr_re_fast_exec
 #ifndef YR_RE_SCAN_LIMIT
 #define YR_RE_SCAN_LIMIT 4096
 #endif

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -2085,10 +2085,13 @@ int yr_re_fast_exec(
   RE_FAST_EXEC_POSITION* last;
 
   int input_incr = flags & RE_FLAGS_BACKWARDS ? -1 : 1;
-  int max_bytes_matched = flags & RE_FLAGS_BACKWARDS
-                              ? (int) yr_min(input_backwards_size, INT_MAX)
-                              : (int) yr_min(input_forwards_size, INT_MAX);
   int bytes_matched;
+  int max_bytes_matched;
+
+  if (flags & RE_FLAGS_BACKWARDS)
+    max_bytes_matched = (int) yr_min(input_backwards_size, YR_RE_SCAN_LIMIT);
+  else
+    max_bytes_matched = (int) yr_min(input_forwards_size, YR_RE_SCAN_LIMIT);
 
   const uint8_t* ip = code;
 

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -1699,12 +1699,14 @@ int yr_re_exec(
 
   if (flags & RE_FLAGS_BACKWARDS)
   {
+    // Signedness conversion is sound as long as YR_RE_SCAN_LIMIT <= INT_MAX
     max_bytes_matched = (int) yr_min(input_backwards_size, YR_RE_SCAN_LIMIT);
     input -= character_size;
     input_incr = -input_incr;
   }
   else
   {
+    // Signedness conversion is sound as long as YR_RE_SCAN_LIMIT <= INT_MAX
     max_bytes_matched = (int) yr_min(input_forwards_size, YR_RE_SCAN_LIMIT);
   }
 
@@ -2084,8 +2086,8 @@ int yr_re_fast_exec(
 
   int input_incr = flags & RE_FLAGS_BACKWARDS ? -1 : 1;
   int max_bytes_matched = flags & RE_FLAGS_BACKWARDS
-                              ? (int) input_backwards_size
-                              : (int) input_forwards_size;
+                              ? (int) yr_min(input_backwards_size, INT_MAX)
+                              : (int) yr_min(input_forwards_size, INT_MAX);
   int bytes_matched;
 
   const uint8_t* ip = code;


### PR DESCRIPTION
There was a silent integer overflow on the `max_bytes_matched`
calculation as `input_forwards_size` can be way more than what can fit
in a signed int. `yr_re_exec` doesn't suffer from the same issue as
a match there is bounded to `YR_RE_SCAN_LIMIT` which already fits into
an int just fine.