### PR TITLE
Fix issue #1616

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1389,10 +1389,13 @@ int _tmain(int argc, const char_t** argv)
     exit_with_code(EXIT_FAILURE);
   }
 
-  yr_set_configuration(YR_CONFIG_STACK_SIZE, &stack_size);
-  yr_set_configuration(YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
-  yr_set_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
+  yr_set_configuration_uint32(YR_CONFIG_STACK_SIZE, stack_size);
+
+  yr_set_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, max_strings_per_rule);
+
+  yr_set_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, max_process_memory_chunk);
 
   // Try to load the rules file as a binary file containing
   // compiled rules first

--- a/cli/yarac.c
+++ b/cli/yarac.c
@@ -228,7 +228,9 @@ int _tmain(int argc, const char_t** argv)
   cr.errors = 0;
   cr.warnings = 0;
 
-  yr_set_configuration(YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
+  yr_set_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, max_strings_per_rule);
+
   yr_compiler_set_callback(compiler, report_error, &cr);
 
   if (!compile_files(compiler, argc, argv))

--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -303,7 +303,7 @@ normal python warning system for you and scanning will continue.
 You may also find that the default sizes for the stack for the matching engine in
 yara or the default size for the maximum number of strings per rule is too low. In
 the C libyara API, you can modify these using the ``YR_CONFIG_STACK_SIZE`` and
-``YR_CONFIG_MAX_STRINGS_PER_RULE`` variables via the ``yr_set_configuration``
+``YR_CONFIG_MAX_STRINGS_PER_RULE`` variables via the ``yr_set_configuration_uint32``
 function in libyara. The command-line tool exposes these as the ``--stack-size``
 (``-k``) and ``--max-strings-per-rule`` command-line arguments. In order to set
 these values via the Python API, you can use ``yara.set_config`` with either or
@@ -313,7 +313,7 @@ strings per rule was ``10000``.
 
 Also, ``yara.set_config`` accepts the `max_match_data` argument for controlling
 the maximum number of bytes that will be returned for each matching string. This
-is equivalent to using ``YR_CONFIG_MAX_MATCH_DATA`` with the ``yr_set_configuration``
+is equivalent to using ``YR_CONFIG_MAX_MATCH_DATA`` with the ``yr_set_configuration_uint32``
 in the C API. By the default this is set to 512.
 
 Here are a few example calls:

--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -1000,7 +1000,8 @@ YR_API char* yr_compiler_get_error_message(
     snprintf(buffer, buffer_size, "regular expression is too complex");
     break;
   case ERROR_TOO_MANY_STRINGS:
-    yr_get_configuration(YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
+    yr_get_configuration_uint32(
+        YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
     snprintf(
         buffer,
         buffer_size,

--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -369,7 +369,7 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
 
   uint8_t opcode;
 
-  yr_get_configuration(YR_CONFIG_STACK_SIZE, (void*) &stack.capacity);
+  yr_get_configuration_uint32(YR_CONFIG_STACK_SIZE, &stack.capacity);
 
   stack.sp = 0;
   stack.items = (YR_VALUE*) yr_malloc(stack.capacity * sizeof(YR_VALUE));

--- a/libyara/include/yara/libyara.h
+++ b/libyara/include/yara/libyara.h
@@ -88,7 +88,11 @@ YR_API int yr_initialize(void);
 YR_API int yr_finalize(void);
 
 YR_API int yr_set_configuration(YR_CONFIG_NAME, void*);
+YR_API int yr_set_configuration_uint32(YR_CONFIG_NAME, uint32_t);
+YR_API int yr_set_configuration_uint64(YR_CONFIG_NAME, uint64_t);
 
 YR_API int yr_get_configuration(YR_CONFIG_NAME, void*);
+YR_API int yr_get_configuration_uint32(YR_CONFIG_NAME, uint32_t*);
+YR_API int yr_get_configuration_uint64(YR_CONFIG_NAME, uint64_t*);
 
 #endif

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -822,8 +822,8 @@ union YR_VALUE
 
 struct YR_VALUE_STACK
 {
-  int32_t sp;
-  int32_t capacity;
+  uint32_t sp;
+  uint32_t capacity;
   YR_VALUE* items;
 };
 

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -358,11 +358,15 @@ YR_API int yr_finalize(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Sets a configuration option.
+// Set a configuration option.
 //
 // This function receives a configuration name, as defined by the YR_CONFIG_NAME
 // enum, and a pointer to the value being set. The type of the value depends on
 // the configuration name.
+//
+// The caller must ensure that the pointer passed to the function is the correct
+// type. Using yr_set_configuration_uintXX is preferred, as those functions will
+// perform the necessary type checking.
 //
 // Args:
 //   name: Any of the values defined by the YR_CONFIG_NAME enum. Possible values
@@ -370,13 +374,13 @@ YR_API int yr_finalize(void)
 //              YR_CONFIG_STACK_SIZE                data type: uint32_t
 //              YR_CONFIG_MAX_STRINGS_PER_RULE      data type: uint32_t
 //              YR_CONFIG_MAX_MATCH_DATA            data type: uint32_t
-//              YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK   data type: uint64_t
+//              YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK  data type: uint64_t
 //
 //   src: Pointer to the value being set for the option.
 //
 // Returns:
 //   ERROR_SUCCESS
-//   ERROR_INTERNAL_FATAL_ERROR
+//   ERROR_INVALID_ARGUMENT
 //
 YR_API int yr_set_configuration(YR_CONFIG_NAME name, void *src)
 {
@@ -402,10 +406,76 @@ YR_API int yr_set_configuration(YR_CONFIG_NAME name, void *src)
   return ERROR_SUCCESS;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Set a configuration option.
+//
+// This function receives a configuration name, as defined by the YR_CONFIG_NAME
+// and a value for the configuration being set. Only configuration names with
+// type uint32_t will be accepted, if not ERROR_INVALID_ARGUMENT will be
+// returned.
+//
+// Returns:
+//   ERROR_SUCCESS
+//   ERROR_INVALID_ARGUMENT
+//
+YR_API int yr_set_configuration_uint32(YR_CONFIG_NAME name, uint32_t value)
+{
+  switch (name)
+  {
+  // Accept only the configuration options that are of type uint32_t.
+  case YR_CONFIG_STACK_SIZE:
+  case YR_CONFIG_MAX_STRINGS_PER_RULE:
+  case YR_CONFIG_MAX_MATCH_DATA:
+    return yr_set_configuration(name, &value);
+  default:
+    return ERROR_INVALID_ARGUMENT;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Set a configuration option.
+//
+// See yr_set_configuration_uint32 for more details.
+//
+YR_API int yr_set_configuration_uint64(YR_CONFIG_NAME name, uint64_t value)
+{
+  switch (name)
+  {
+  case YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK:
+    return yr_set_configuration(name, &value);
+  default:
+    return ERROR_INVALID_ARGUMENT;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Get a configuration option.
+//
+// This function receives a configuration name, as defined by the YR_CONFIG_NAME
+// enum, and a pointer to the variable that will receive the value for that
+// option. The type of the value depends on the configuration name.
+//
+// The caller must ensure that the pointer passed to the function is the correct
+// type. Using yr_get_configuration_uintXX is preferred.
+//
+// Args:
+//   name: Any of the values defined by the YR_CONFIG_NAME enum. Possible values
+//         are:
+//              YR_CONFIG_STACK_SIZE                data type: uint32_t
+//              YR_CONFIG_MAX_STRINGS_PER_RULE      data type: uint32_t
+//              YR_CONFIG_MAX_MATCH_DATA            data type: uint32_t
+//              YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK  data type: uint64_t
+//
+//   dest: Pointer to a variable that will receive the value for the option.
+//
+// Returns:
+//   ERROR_SUCCESS
+//   ERROR_INVALID_ARGUMENT
+//
 YR_API int yr_get_configuration(YR_CONFIG_NAME name, void *dest)
 {
   if (dest == NULL)
-    return ERROR_INTERNAL_FATAL_ERROR;
+    return ERROR_INVALID_ARGUMENT;
 
   switch (name)
   {  // lump all the cases using same types together in one cascade
@@ -420,8 +490,50 @@ YR_API int yr_get_configuration(YR_CONFIG_NAME name, void *dest)
     break;
 
   default:
-    return ERROR_INTERNAL_FATAL_ERROR;
+    return ERROR_INVALID_ARGUMENT;
   }
 
   return ERROR_SUCCESS;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Get a configuration option.
+//
+// This function receives a configuration name, as defined by the YR_CONFIG_NAME
+// and a value for the configuration being set. Only configuration names with
+// type uint32_t will be accepted, if not ERROR_INVALID_ARGUMENT will be
+// returned.
+//
+// Returns:
+//   ERROR_SUCCESS
+//   ERROR_INVALID_ARGUMENT
+//
+YR_API int yr_get_configuration_uint32(YR_CONFIG_NAME name, uint32_t *dest)
+{
+  switch (name)
+  {
+  // Accept only the configuration options that are of type uint32_t.
+  case YR_CONFIG_STACK_SIZE:
+  case YR_CONFIG_MAX_STRINGS_PER_RULE:
+  case YR_CONFIG_MAX_MATCH_DATA:
+    return yr_get_configuration(name, (void *) dest);
+  default:
+    return ERROR_INVALID_ARGUMENT;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Get a configuration option.
+//
+// See yr_get_configuration_uint64 for more details.
+//
+YR_API int yr_get_configuration_uint64(YR_CONFIG_NAME name, uint64_t *value)
+{
+  switch (name)
+  {
+  case YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK:
+    return yr_get_configuration(name, (void *) value);
+  default:
+    return ERROR_INVALID_ARGUMENT;
+  }
 }

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -44,8 +44,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/strutils.h>
 #include <yara/utils.h>
 
-#define todigit(x) \
-  ((x) >= 'A' && (x) <= 'F') ? ((uint8_t)(x - 'A' + 10)) : ((uint8_t)(x - '0'))
+#define todigit(x)                                        \
+  ((x) >= 'A' && (x) <= 'F') ? ((uint8_t) (x - 'A' + 10)) \
+                             : ((uint8_t) (x - '0'))
 
 int yr_parser_emit(
     yyscan_t yyscanner,
@@ -948,8 +949,8 @@ int yr_parser_reduce_rule_declaration_phase_2(
   YR_STRING* string;
   YR_COMPILER* compiler = yyget_extra(yyscanner);
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, (void*) &max_strings_per_rule);
+  yr_get_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, &max_strings_per_rule);
 
   YR_RULE* rule = (YR_RULE*) yr_arena_ref_to_ptr(compiler->arena, rule_ref);
 

--- a/libyara/proc/freebsd.c
+++ b/libyara/proc/freebsd.c
@@ -145,8 +145,8 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 
   uint64_t max_process_memory_chunk;
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, (void*) &max_process_memory_chunk);
+  yr_get_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
 
   if (proc_info->vm_entry.pve_end <= current_begin)
   {

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -318,8 +318,8 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 
   uint64_t max_process_memory_chunk;
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, (void*) &max_process_memory_chunk);
+  yr_get_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
 
   if (proc_info->next_block_end <= current_begin)
   {

--- a/libyara/proc/mach.c
+++ b/libyara/proc/mach.c
@@ -127,8 +127,8 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
   vm_address_t address = current_begin;
   uint64_t max_process_memory_chunk;
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, (void*) &max_process_memory_chunk);
+  yr_get_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
 
   iterator->last_error = ERROR_SUCCESS;
 

--- a/libyara/proc/openbsd.c
+++ b/libyara/proc/openbsd.c
@@ -157,8 +157,8 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 
   uint64_t max_process_memory_chunk;
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, (void*) &max_process_memory_chunk);
+  yr_get_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
 
   if (proc_info->old_end <= current_begin)
   {

--- a/libyara/proc/windows.c
+++ b/libyara/proc/windows.c
@@ -139,8 +139,8 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
       (void*) (context->current_block.base + context->current_block.size);
   uint64_t max_process_memory_chunk;
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, (void*) &max_process_memory_chunk);
+  yr_get_configuration_uint64(
+      YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, &max_process_memory_chunk);
 
   iterator->last_error = ERROR_SUCCESS;
 

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -490,7 +490,7 @@ static int _yr_scan_verify_chained_string_match(
     uint32_t max_match_data;
 
     FAIL_ON_ERROR(
-        yr_get_configuration(YR_CONFIG_MAX_MATCH_DATA, &max_match_data))
+        yr_get_configuration_uint32(YR_CONFIG_MAX_MATCH_DATA, &max_match_data))
 
     if (STRING_IS_CHAIN_TAIL(matching_string))
     {
@@ -545,8 +545,8 @@ static int _yr_scan_verify_chained_string_match(
           _yr_scan_remove_match_from_list(
               match, &context->unconfirmed_matches[string->idx]);
 
-          match->match_length = (int32_t)(
-              match_offset - match->offset + match_length);
+          match->match_length =
+              (int32_t) (match_offset - match->offset + match_length);
 
           match->data_length = yr_min(
               match->match_length, (int32_t) max_match_data);
@@ -694,7 +694,7 @@ static int _yr_scan_match_callback(
     uint32_t max_match_data;
 
     FAIL_ON_ERROR(
-        yr_get_configuration(YR_CONFIG_MAX_MATCH_DATA, &max_match_data));
+        yr_get_configuration_uint32(YR_CONFIG_MAX_MATCH_DATA, &max_match_data));
 
     new_match = yr_notebook_alloc(
         callback_args->context->matches_notebook, sizeof(YR_MATCH));

--- a/libyara/scanner.c
+++ b/libyara/scanner.c
@@ -450,7 +450,7 @@ YR_API int yr_scanner_scan_mem_blocks(
     uint32_t max_match_data;
 
     FAIL_ON_ERROR(
-        yr_get_configuration(YR_CONFIG_MAX_MATCH_DATA, &max_match_data));
+        yr_get_configuration_uint32(YR_CONFIG_MAX_MATCH_DATA, &max_match_data));
 
     result = yr_notebook_create(
         1024 * (sizeof(YR_MATCH) + max_match_data), &scanner->matches_notebook);

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -196,11 +196,11 @@ void test_max_string_per_rules()
 
   yr_initialize();
 
-  yr_get_configuration(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, (void*) &old_max_strings_per_rule);
+  yr_get_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, &old_max_strings_per_rule);
 
-  yr_set_configuration(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, (void*) &new_max_strings_per_rule);
+  yr_set_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, new_max_strings_per_rule);
 
   assert_error(
       "rule test { \
@@ -213,8 +213,8 @@ void test_max_string_per_rules()
 
   new_max_strings_per_rule = 2;
 
-  yr_set_configuration(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, (void*) &new_max_strings_per_rule);
+  yr_set_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, new_max_strings_per_rule);
 
   assert_error(
       "rule test { \
@@ -225,8 +225,8 @@ void test_max_string_per_rules()
            all of them }",
       ERROR_SUCCESS);
 
-  yr_set_configuration(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, (void*) &old_max_strings_per_rule);
+  yr_set_configuration_uint32(
+      YR_CONFIG_MAX_STRINGS_PER_RULE, old_max_strings_per_rule);
 
   yr_finalize();
 }
@@ -268,9 +268,8 @@ void test_max_match_data()
 
   yr_initialize();
 
-  yr_get_configuration(YR_CONFIG_MAX_MATCH_DATA, (void*) &old_max_match_data);
-
-  yr_set_configuration(YR_CONFIG_MAX_MATCH_DATA, (void*) &new_max_match_data);
+  yr_get_configuration_uint32(YR_CONFIG_MAX_MATCH_DATA, &old_max_match_data);
+  yr_set_configuration_uint32(YR_CONFIG_MAX_MATCH_DATA, new_max_match_data);
 
   if (compile_rule(rules_str, &rules) != ERROR_SUCCESS)
   {


### PR DESCRIPTION
This is a more comprehensive fix than #1617, it adds new functions to the API for getting/setting uint32 and uint64 settings.  Using these functions is preferable over calling `yr_(get|set)_configuration` directly.