### PR TITLE
Update docs to show folders that modules are in

### DIFF
--- a/docs/writingmodules.rst
+++ b/docs/writingmodules.rst
@@ -204,24 +204,24 @@ The second step is modifying the *Makefile.am* to tell the *make* program that
 the source code for your module must be compiled and linked into YARA. At the
 very beginning of *libyara/Makefile.am* you'll find this::
 
-    MODULES =  modules/tests.c
-    MODULES += modules/pe.c
+    MODULES =  modules/tests/tests.c
+    MODULES += modules/pe/pe.c
 
     if CUCKOO_MODULE
-    MODULES += modules/cuckoo.c
+    MODULES += modules/cuckoo/cuckoo.c
     endif
 
 
 Just add a new line for your module::
 
-    MODULES =  modules/tests.c
-    MODULES += modules/pe.c
+    MODULES =  modules/tests/tests.c
+    MODULES += modules/pe/pe.c
 
     if CUCKOO_MODULE
-    MODULES += modules/cuckoo.c
+    MODULES += modules/cuckoo/cuckoo.c
     endif
 
-    MODULES += modules/demo.c
+    MODULES += modules/demo/demo.c
 
 And that's all! Now you're ready to build YARA with your brand-new module
 included. Just go to the source tree root directory and type as always::


### PR DESCRIPTION
Old documentation referenced ".c" files that were all in the same folder. However, later versions of YARA have them each in their own folder. Updating the docs to reflect this will mean there is no confusion when trying to create new modules.

Currently adding in `MODULES += modules/demo.c` won't work either, so this will make it easier for people to test the demo module.