### PR TITLE
Remove LibreSSL compatibility define that prevents compilation of pe module

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <openssl/safestack.h>
 #include <openssl/x509.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define X509_get_signature_nid(o) OBJ_obj2nid((o)->sig_alg->algorithm)
 #endif
 


### PR DESCRIPTION
Changes to LibreSSL mean that this compatibility shim in `pe` has not been necessary for some time and now breaks compilation. Reference: [patch in OpenBSD Ports](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/security/yara/main/patches/patch-libyara_modules_pe_c)

Tested successfully on OpenBSD 7.0-CURRENT (amd64)