### PR TITLE
Fix issue with dotnet build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,16 @@ AC_ARG_ENABLE([pb-tests],
 AC_ARG_ENABLE([dotnet],
   [AS_HELP_STRING([--disable-dotnet], [disable dotnet module])],
   [if test x$enableval = xyes; then
+        AC_MSG_WARN([
+*****************************************************************
+  The dotnet module is enabled by default now. No need to specify
+  --enable-dotnet. To disable this module please use
+  --disable-dotnet.
+*****************************************************************
+])
+    build_dotnet_module=true
+    CFLAGS="$CFLAGS -DDOTNET_MODULE"
+  else
     build_dotnet_module=false
   fi],
   [


### PR DESCRIPTION
If a user specifies --enable-dotnet the build system will (currently) disable
the dotnet module, which is most certainly not what they want. This is likely to
cause unexpected issues for build systems (like brew, other third party
ports/package systems, and internal builds at $job) which have specified
--enable-dotnet automatically for a while now.

This diff fixes it by making --enable-dotnet print a warning message that this
option is no longer required, but it will still build the module.

The default behavior of building the module if neither --enable-dotnet or
--disable-dotnet is set is still maintained, along with honoring
--disable-dotnet.

Building with --enable-dotnet prints a warning and still builds the module:

```
wxs@wxs-mbp yara % ./configure --enable-dotnet > /dev/null
configure: WARNING:
*****************************************************************
  The dotnet module is enabled by default now. No need to specify
  --enable-dotnet. To disable this module please use
  --disable-dotnet.
*****************************************************************

wxs@wxs-mbp yara % make clean >/dev/null
wxs@wxs-mbp yara % make | grep dotnet
  CC       modules/dotnet/dotnet.lo
wxs@wxs-mbp yara %
```

Building with --disable-dotnet does not build the module:

```
wxs@wxs-mbp yara % ./configure --disable-dotnet > /dev/null
wxs@wxs-mbp yara % make clean >/dev/null
wxs@wxs-mbp yara % make | grep dotnet
wxs@wxs-mbp yara %
```

And finally, building with neither option specified builds it by default:

```
wxs@wxs-mbp yara % ./configure > /dev/null
wxs@wxs-mbp yara % make clean >/dev/null
wxs@wxs-mbp yara % make | grep dotnet
  CC       modules/dotnet/dotnet.lo
wxs@wxs-mbp yara %
```