### PR TITLE
Attempt to improve atom selection.

### DIFF
--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -826,9 +826,9 @@ void test_rules_stats()
   assert_true_expr(stats.num_strings == 6);
   assert_true_expr(stats.ac_matches == 6);
   assert_true_expr(stats.ac_root_match_list_length == 0);
-  assert_true_expr(stats.top_ac_match_list_lengths[0] == 3);
-  assert_true_expr(stats.ac_match_list_length_pctls[1] == 3);
-  assert_true_expr(stats.ac_match_list_length_pctls[100] == 3);
+  assert_true_expr(stats.top_ac_match_list_lengths[0] == 1);
+  assert_true_expr(stats.ac_match_list_length_pctls[1] == 1);
+  assert_true_expr(stats.ac_match_list_length_pctls[100] == 1);
 
   stats_for_rules(
       "\
@@ -849,9 +849,9 @@ void test_rules_stats()
   assert_true_expr(stats.num_strings == 8);
   assert_true_expr(stats.ac_matches == 8);
   assert_true_expr(stats.ac_root_match_list_length == 0);
-  assert_true_expr(stats.top_ac_match_list_lengths[0] == 3);
+  assert_true_expr(stats.top_ac_match_list_lengths[0] == 1);
   assert_true_expr(stats.ac_match_list_length_pctls[1] == 1);
-  assert_true_expr(stats.ac_match_list_length_pctls[100] == 3);
+  assert_true_expr(stats.ac_match_list_length_pctls[100] == 1);
 
   stats_for_rules(
       "\

--- a/tests/test-atoms.c
+++ b/tests/test-atoms.c
@@ -226,6 +226,14 @@ void test_heuristic_quality()
   assert_true_expr(qFFFFFFFF < q01010101);
 
   assert_true_expr(q01020304 == YR_MAX_ATOM_QUALITY);
+
+  // https://github.com/VirusTotal/yara/issues/1646
+  assert_re_atoms(
+      "foobar\\.{128}",
+      1,
+      (struct atom[]){
+          {4, {0x72, 0x2e, 0x2e, 0x2e}},
+      });
 }
 
 void test_atom_choose()


### PR DESCRIPTION
If you have an atom that is all the same bytes we should penalize it a little
bit to try to discourage the selection of that atom. We should prefer atoms with
unique values as much as possible.