### PR TITLE
Improve atom extraction logic

### DIFF
--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -1369,19 +1369,6 @@ int yr_atoms_extract_from_re(
     (*atoms)->next = NULL;
   }
 
-  for (YR_ATOM_LIST_ITEM* atom_li = *atoms; atom_li != NULL;
-       atom_li = atom_li->next)
-  {
-    printf("atom: ");
-    for (int i = 0; i < atom_li->atom.length; i++)
-      printf("%02x", atom_li->atom.bytes[i]);
-
-    printf(
-        "q: %d\n",
-        yr_atoms_heuristic_quality(config, &atom_li->atom) -
-            YR_MAX_ATOM_QUALITY + 22 * YR_MAX_ATOM_LENGTH);
-  }
-
   return ERROR_SUCCESS;
 }
 

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -914,7 +914,7 @@ static int _yr_atoms_extract_from_re(
 
   // This first item pushed in the stack is the last one to be poped out, the
   // sole purpose of this item is forcing that any pending leaf is appended to
-  // current_appending_node during the last iteration of the loop.
+  // appending_node during the last iteration of the loop.
   si.re_node = NULL;
   si.new_appending_node = appending_node;
 
@@ -968,6 +968,7 @@ static int _yr_atoms_extract_from_re(
       }
 
       current_appending_node = si.new_appending_node;
+      best_quality = -1;
     }
 
     if (si.re_node != NULL)

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -109,13 +109,35 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
 
   int quality = 0;
   int unique_bytes = 0;
-  int i;
 
   assert(atom->length <= YR_MAX_ATOM_LENGTH);
 
   yr_bitmask_clear_all(seen_bytes);
 
-  for (i = 0; i < atom->length; i++)
+  // Each byte in the atom contributes a certain amount of points to the
+  // quality. Bytes [a-zA-Z] contribute 18 points each, common bytes like
+  // 0x00, 0x20 and 0xFF contribute only 10 points, and the rest of the
+  // bytes contribute 20 points. The ?? mask substracts 6 points, and masks
+  // X? and ?X contribute 2 points. An additional boost consisting in 2x the
+  // number of unique bytes in the atom is added to the quality. This are
+  // some examples of the quality of atoms:
+  //
+  //   01 02 03 04   quality = 20 + 20 + 20 + 20 + 8 = 88
+  //   01 ?? 03 04   quality = 20 -  6 + 20 + 20 + 6 = 60
+  //   01 0? 03      quality = 20 +  2 + 20      + 4 = 46
+  //   01 02         quality = 20 + 20           + 4 = 44
+  //   01 ?? ?3 04   quality = 20 -  6 +  2 + 20 + 4 = 40
+  //   61 62         quality = 18 + 18           + 4 = 40
+  //   61 61         quality = 18 + 18           + 2 = 38  <- warning threshold
+  //   00 01         quality = 10 + 20           + 4 = 34
+  //   01 ?? 02      quality = 20 -  6 + 20      + 4 = 38
+  //   01            quality = 20                + 1 = 21
+  //
+
+  //    0x72, 0x2e, 0x2e, 0x2e      79+4 = 83
+  //    0x2e, 0x2e, 0x2e, 0x2e      80+2 = 82
+
+  for (int i = 0; i < atom->length; i++)
   {
     switch (atom->mask[i])
     {
@@ -123,10 +145,10 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
       quality -= 6;
       break;
     case 0x0F:
-      quality += 1;
+      quality += 2;
       break;
     case 0xF0:
-      quality += 1;
+      quality += 2;
       break;
     case 0xFF:
       switch (atom->bytes[i])
@@ -136,7 +158,7 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
       case 0xCC:
       case 0xFF:
         // Common bytes contribute less to the quality than the rest.
-        quality += 15;
+        quality += 10;
         break;
       default:
         // Bytes in the a-z and A-Z ranges have a slightly lower quality
@@ -145,10 +167,11 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
         // calls to _yr_atoms_case_combinations.
         if (yr_lowercase[atom->bytes[i]] >= 'a' &&
             yr_lowercase[atom->bytes[i]] <= 'z')
-          quality += 19;
+          quality += 18;
         else
           quality += 20;
-      };
+      }
+
       if (!yr_bitmask_is_set(seen_bytes, atom->bytes[i]))
       {
         yr_bitmask_set(seen_bytes, atom->bytes[i]);
@@ -167,8 +190,19 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
   {
     quality -= 10 * atom->length;
   }
+  // In general atoms with more unique bytes have a better quality, so let's
+  // boost the quality in the amount of unique bytes.
+  else
+  {
+    quality += 2 * unique_bytes;
+  }
 
-  return YR_MAX_ATOM_QUALITY - 20 * YR_MAX_ATOM_LENGTH + quality;
+  // The final quality is not zero-based, we start at YR_MAX_ATOM_QUALITY
+  // for the best possible atom and substract from there. The best possible
+  // quality is 21 * YR_MAX_ATOM_LENGTH (20 points per byte + 2 additional
+  // points per unique byte, with a maximum of 2*YR_MAX_ATOM_LENGTH unique
+  // bytes).
+  return YR_MAX_ATOM_QUALITY - 22 * YR_MAX_ATOM_LENGTH + quality;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -411,7 +445,6 @@ static YR_ATOM_LIST_ITEM* _yr_atoms_list_concat(
   item->next = list2;
   return list1;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // If the atom starts or ends with an unknown byte (mask == 0x00), trim
@@ -721,7 +754,6 @@ static int _yr_atoms_case_insensitive(
   return ERROR_SUCCESS;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // For a given list of atoms returns another list after a single byte xor
 // has been applied to it.
@@ -767,7 +799,6 @@ static int _yr_atoms_xor(
   }
   return ERROR_SUCCESS;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // For a given list of atoms returns another list with the corresponding
@@ -821,24 +852,21 @@ static int _yr_atoms_wide(
   return ERROR_SUCCESS;
 }
 
-
 struct STACK_ITEM
 {
   RE_NODE* re_node;
   YR_ATOM_TREE_NODE* new_appending_node;
 };
 
-
-#define make_atom_from_re_nodes(atom, nodes_length, nodes)  \
-  {                                                         \
-    atom.length = nodes_length;                             \
-    for (i = 0; i < atom.length; i++)                       \
-    {                                                       \
-      atom.bytes[i] = (uint8_t)(recent_re_nodes)[i]->value; \
-      atom.mask[i] = (uint8_t)(recent_re_nodes)[i]->mask;   \
-    }                                                       \
+#define make_atom_from_re_nodes(atom, nodes_length, nodes)   \
+  {                                                          \
+    atom.length = nodes_length;                              \
+    for (i = 0; i < atom.length; i++)                        \
+    {                                                        \
+      atom.bytes[i] = (uint8_t) (recent_re_nodes)[i]->value; \
+      atom.mask[i] = (uint8_t) (recent_re_nodes)[i]->mask;   \
+    }                                                        \
   }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Extract atoms from a regular expression. This is a helper function used by
@@ -1137,7 +1165,6 @@ static int _yr_atoms_extract_from_re(
   return ERROR_SUCCESS;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Makes an exact copy of an YR_ATOM_LIST_ITEM.
 //
@@ -1153,7 +1180,6 @@ static YR_ATOM_LIST_ITEM* _yr_atoms_clone_list_item(YR_ATOM_LIST_ITEM* item)
 
   return clone;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Given list of atoms that may contain wildcards, replace those wildcarded
@@ -1241,7 +1267,6 @@ static int _yr_atoms_expand_wildcards(YR_ATOM_LIST_ITEM* atoms)
 
   return ERROR_SUCCESS;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Extract atoms from a regular expression. This function receives the abstract

--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -1370,19 +1370,6 @@ int yr_atoms_extract_from_re(
     (*atoms)->next = NULL;
   }
 
-  for (YR_ATOM_LIST_ITEM* atom_li = *atoms; atom_li != NULL;
-       atom_li = atom_li->next)
-  {
-    printf("atom: ");
-    for (int i = 0; i < atom_li->atom.length; i++)
-      printf("%02x (%02x) ", atom_li->atom.bytes[i], atom_li->atom.mask[i]);
-
-    printf(
-        "q: %d\n",
-        yr_atoms_heuristic_quality(config, &atom_li->atom) -
-            YR_MAX_ATOM_QUALITY + 22 * YR_MAX_ATOM_LENGTH);
-  }
-
   return ERROR_SUCCESS;
 }
 

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -87,7 +87,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // If a rule generates more than this number of atoms a warning is shown.
 #ifndef YR_ATOMS_PER_RULE_WARNING_THRESHOLD
-#define YR_ATOMS_PER_RULE_WARNING_THRESHOLD 10000
+#define YR_ATOMS_PER_RULE_WARNING_THRESHOLD 12000
 #endif
 
 // Maximum number of nested "for" loops in rule. Rules ith nested loops

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -82,7 +82,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // must specify the threshold when calling yr_compiler_set_atom_quality_table.
 #ifndef YR_ATOM_QUALITY_WARNING_THRESHOLD
 #define YR_ATOM_QUALITY_WARNING_THRESHOLD \
-  YR_MAX_ATOM_QUALITY - 20 * YR_MAX_ATOM_LENGTH + 38
+  YR_MAX_ATOM_QUALITY - 22 * YR_MAX_ATOM_LENGTH + 38
 #endif
 
 // If a rule generates more than this number of atoms a warning is shown.

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -826,9 +826,9 @@ void test_rules_stats()
   assert_true_expr(stats.num_strings == 6);
   assert_true_expr(stats.ac_matches == 6);
   assert_true_expr(stats.ac_root_match_list_length == 0);
-  assert_true_expr(stats.top_ac_match_list_lengths[0] == 3);
-  assert_true_expr(stats.ac_match_list_length_pctls[1] == 3);
-  assert_true_expr(stats.ac_match_list_length_pctls[100] == 3);
+  assert_true_expr(stats.top_ac_match_list_lengths[0] == 1);
+  assert_true_expr(stats.ac_match_list_length_pctls[1] == 1);
+  assert_true_expr(stats.ac_match_list_length_pctls[100] == 1);
 
   stats_for_rules(
       "\
@@ -849,9 +849,9 @@ void test_rules_stats()
   assert_true_expr(stats.num_strings == 8);
   assert_true_expr(stats.ac_matches == 8);
   assert_true_expr(stats.ac_root_match_list_length == 0);
-  assert_true_expr(stats.top_ac_match_list_lengths[0] == 3);
+  assert_true_expr(stats.top_ac_match_list_lengths[0] == 1);
   assert_true_expr(stats.ac_match_list_length_pctls[1] == 1);
-  assert_true_expr(stats.ac_match_list_length_pctls[100] == 3);
+  assert_true_expr(stats.ac_match_list_length_pctls[100] == 1);
 
   stats_for_rules(
       "\

--- a/tests/test-atoms.c
+++ b/tests/test-atoms.c
@@ -507,7 +507,7 @@ void test_atom_choose()
           {3, {0x61, 0x62, 0x63}},
       });
 
-  assert_hex_atoms("{61 6? 63 [1-5] 65 66 }", 16, atoms_61_6X_63);
+  assert_hex_atoms("{61 6? 63 [1-5] 65 66}", 16, atoms_61_6X_63);
 
   assert_hex_atoms(
       "{(61 62 63 | 65 66 67 68)}",
@@ -520,15 +520,22 @@ void test_atom_choose()
   assert_hex_atoms("{61 62 0? 64}", 16, atoms_61_62_0X_64);
 
   assert_hex_atoms(
-      "{11 ?? 11 ?? 22 33 44 55 66 }",
+      "{11 ?? 11 ?? 22 33 44 55 66}",
       1,
       (struct atom[]){
           {4, {0x22, 0x33, 0x44, 0x55}},
       });
 
+  assert_hex_atoms(
+      "{68 ?? ?? 00 00 58}",
+      1,
+      (struct atom[]){
+          {3, {0x00, 0x00, 0x58}},
+      });
+
   // Test case for issue #1025
   assert_hex_atoms(
-      "{?? 11 22 33 ?? 55 66 }",
+      "{?? 11 22 33 ?? 55 66}",
       1,
       (struct atom[]){
           {3, {0x11, 0x22, 0x33}},

--- a/tests/test-atoms.c
+++ b/tests/test-atoms.c
@@ -533,7 +533,7 @@ void test_atom_choose()
           {3, {0x00, 0x00, 0x58}},
       });
 
-  // Test case for issue #1025
+  // Test case for https://github.com/VirusTotal/yara/issues/1025
   assert_hex_atoms(
       "{?? 11 22 33 ?? 55 66}",
       1,
@@ -541,12 +541,21 @@ void test_atom_choose()
           {3, {0x11, 0x22, 0x33}},
       });
 
-  // https://github.com/VirusTotal/yara/issues/1646
+  // Test case for https://github.com/VirusTotal/yara/issues/1646
   assert_re_atoms(
       "foobar\\.{128}",
       1,
       (struct atom[]){
           {4, {0x62, 0x61, 0x72, 0x2e}},
+      });
+
+  // Test case for https://github.com/VirusTotal/yara/issues/1654
+  assert_hex_atoms(
+      "{(61 61 62 63 64 ?? | 65 ?? ?? 00 00 66)}",
+      2,
+      (struct atom[]){
+          {3, {0x00, 0x00, 0x66}},
+          {4, {0x61, 0x62, 0x63, 0x64}},
       });
 }
 

--- a/tests/test-atoms.c
+++ b/tests/test-atoms.c
@@ -533,6 +533,13 @@ void test_atom_choose()
           {3, {0x00, 0x00, 0x58}},
       });
 
+  assert_hex_atoms(
+      "{69 ?? a0 0d 00}",
+      1,
+      (struct atom[]){
+          {3, {0xa0, 0x0d, 0x00}},
+      });
+
   // Test case for https://github.com/VirusTotal/yara/issues/1025
   assert_hex_atoms(
       "{?? 11 22 33 ?? 55 66}",

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3160,6 +3160,10 @@ void test_performance_warnings()
         strings: $a = { 68 ?? 00 ?? 00 68 ?? 00 ?? 00} \
         condition: $a }");
 
+  assert_no_warnings("rule test { \
+        strings: $a = { (61 62 63 64 ?? | 65 ?? ?? 00 00 66)} \
+        condition: $a }");
+
   assert_warning("rule test { \
         strings: $a = { 1? 2? 3? } \
         condition: $a }");

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3156,7 +3156,7 @@ void test_performance_warnings()
         strings: $a = { 01 ?? 02 1? } \
         condition: $a }");
 
-  assert_no_warnings("rule test { \
+  assert_warning("rule test { \
         strings: $a = { 68 ?? 00 ?? 00 68 ?? 00 ?? 00} \
         condition: $a }");
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3240,6 +3240,10 @@ void test_performance_warnings()
         strings: $a = \"MZ\" \
         condition: $a }");
 
+  assert_no_warnings("rule test { \
+        strings: $a = \"ZZ\" \
+        condition: $a }");
+
   assert_warning("rule test { \
         strings: $a = \"                    \" xor(0x20) \
         condition: $a }");

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3156,6 +3156,10 @@ void test_performance_warnings()
         strings: $a = { 01 ?? 02 1? } \
         condition: $a }");
 
+  assert_no_warnings("rule test { \
+        strings: $a = { 68 ?? 00 ?? 00 68 ?? 00 ?? 00} \
+        condition: $a }");
+
   assert_warning("rule test { \
         strings: $a = { 1? 2? 3? } \
         condition: $a }");

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3148,11 +3148,11 @@ void test_performance_warnings()
         strings: $a = { 01 ?? ?? 02 } \
         condition: $a }");
 
-  assert_warning("rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 01 ?? ?2 03 } \
         condition: $a }");
 
-  assert_warning("rule test { \
+  assert_no_warnings("rule test { \
         strings: $a = { 01 ?? 02 1? } \
         condition: $a }");
 


### PR DESCRIPTION
Fix issue #1646 by generalizing the solution provided in #1647. Atoms with a higher number of unique bytes are prioritized over atoms that have repeated characters. 

Also fixes issue #1654, which was discovered in a debug session, but has been there for a long time.