### PR TITLE
Fix docs for console callback with python.

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -307,6 +307,7 @@ yara-python, but you can handle them in your own callback using the
 Here is an example:
 
 .. code-block:: python
+
   import yara
 
   r = """


### PR DESCRIPTION
I think this will fix an issue where the example doesn't show up in readthedocs?

<img width="732" alt="Screen Shot 2022-03-04 at 9 33 42 PM" src="https://user-images.githubusercontent.com/1394879/156864515-83809731-745d-4a69-8168-c2efc75ad8d8.png">