### PR TITLE
Fix #1660.

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -1414,6 +1414,7 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
       YR_DEBUG_FPRINTF(
           2, stderr, "- case OP_OF_FOUND_IN: // %s()\n", __FUNCTION__);
 
+      found = 0;
       count = 0;
       pop(r2);
       pop(r1);
@@ -1434,7 +1435,7 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
           if (match->base + match->offset >= r1.i &&
               match->base + match->offset <= r2.i)
           {
-            count++;
+            found++;
             break;
           }
 
@@ -1444,11 +1445,15 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
           match = match->next;
         }
 
+        count++;
         pop(r3);
       }
 
       pop(r1);
-      r1.i = count >= r1.i ? 1 : 0;
+      if (is_undef(r1))
+        r1.i = found >= count ? 1 : 0;
+      else
+        r1.i = found >= r1.i ? 1 : 0;
 
       push(r1);
       break;

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -631,6 +631,18 @@ static void test_strings()
        }",
       "foobarbaz" TEXT_1024_BYTES);
 
+  // https://github.com/VirusTotal/yara/issues/1660
+  assert_false_rule(
+      "rule test {\n\
+         strings:\n\
+             $a = \"foo\"\n\
+             $b = \"bar\"\n\
+             $c = \"baz\"\n\
+         condition:\n\
+             all of them in (0..1)\n\
+       }",
+      TEXT_1024_BYTES);
+
   assert_true_rule(
       "rule test {\n\
          strings:\n\


### PR DESCRIPTION
There is an issue where the OP_OF_FOUND_IN opcode is broken when using "all of".
This is because the UNDEF that is pushed on the stack to indicate "all" is
compared to the number of matched strings as signed integers. If there are no
matched strings the condition still evaluates to true because 0 > (signed)
UNDEF.

Fix it by checking if we are using an UNDEF and compare it to the number of
strings checked if that is the case.