### PR TITLE
Fix logic error in Linux memory scanning

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -157,8 +157,9 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
 
   int fd = -2;  // Assume mapping not connected with a file.
 
-  if (strlen(proc_info->map_path) > 0 && proc_info->map_dmaj != 0 &&
-      proc_info->map_ino != 0)
+  // Only try mapping the file if it has a path and belongs to a device
+  if (strlen(proc_info->map_path) > 0 &&
+      !(proc_info->map_dmaj == 0 && proc_info->map_dmin == 0))
   {
     struct stat st;
     fd = open(proc_info->map_path, O_RDONLY);


### PR DESCRIPTION
Memory-mapped files from tmpfs (major number = 0) are no longer ignored.

I first noticed this due to failing tests on Debian's autobuilders that I was able to rreproduce by running `test-rules` from within a directory residing on a tmpfs filesystem.