### PR TITLE
Implement the --skip-larger command-line option in Windows.

### DIFF
--- a/cli/args.c
+++ b/cli/args.c
@@ -96,7 +96,21 @@ args_error_type_t args_parse_option(
     *(bool*) opt->value = !(*(bool*) opt->value);
     break;
 
-  case ARGS_OPT_INTEGER:
+  case ARGS_OPT_LONG:
+    if (opt_arg == NULL)
+      return ARGS_ERROR_REQUIRED_INTEGER_ARG;
+
+    *(long*) opt->value = _tcstol(opt_arg, &endptr, 0);
+
+    if (*endptr != '\0')
+      return ARGS_ERROR_REQUIRED_INTEGER_ARG;
+
+    if (opt_arg_was_used != NULL)
+      *opt_arg_was_used = 1;
+
+    break;
+
+  case ARGS_OPT_LONG_LONG:
     if (opt_arg == NULL)
       return ARGS_ERROR_REQUIRED_INTEGER_ARG;
 
@@ -268,7 +282,8 @@ void args_print_usage(args_option_t* options, int help_alignment)
     if (options->long_name != NULL)
       len += _stprintf(buffer + len, _T("--%s"), options->long_name);
 
-    if (options->type == ARGS_OPT_STRING || options->type == ARGS_OPT_INTEGER)
+    if (options->type == ARGS_OPT_STRING || options->type == ARGS_OPT_LONG ||
+        options->type == ARGS_OPT_LONG_LONG)
     {
       len += _stprintf(
           buffer + len,

--- a/cli/args.c
+++ b/cli/args.c
@@ -100,7 +100,7 @@ args_error_type_t args_parse_option(
     if (opt_arg == NULL)
       return ARGS_ERROR_REQUIRED_INTEGER_ARG;
 
-    *(long*) opt->value = _tcstol(opt_arg, &endptr, 0);
+    *(long long*) opt->value = _tcstoll(opt_arg, &endptr, 0);
 
     if (*endptr != '\0')
       return ARGS_ERROR_REQUIRED_INTEGER_ARG;

--- a/cli/args.h
+++ b/cli/args.h
@@ -33,57 +33,59 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include "unicode.h"
 
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-typedef enum _args_error_type
-{
+  typedef enum _args_error_type
+  {
     ARGS_ERROR_OK,
     ARGS_ERROR_UNKNOWN_OPT,
     ARGS_ERROR_TOO_MANY,
     ARGS_ERROR_REQUIRED_INTEGER_ARG,
     ARGS_ERROR_REQUIRED_STRING_ARG,
     ARGS_ERROR_UNEXPECTED_ARG,
-} args_error_type_t;
+  } args_error_type_t;
 
+  typedef enum _args_option_type
+  {
+    // special
+    ARGS_OPT_END,
+    ARGS_OPT_GROUP,
+    // options with no arguments
+    ARGS_OPT_BOOLEAN,
+    // options with arguments (optional or required)
+    ARGS_OPT_LONG,
+    ARGS_OPT_LONG_LONG,
+    ARGS_OPT_STRING,
+  } args_option_type_t;
 
-typedef enum _args_option_type
-{
-  // special
-  ARGS_OPT_END,
-  ARGS_OPT_GROUP,
-  // options with no arguments
-  ARGS_OPT_BOOLEAN,
-  // options with arguments (optional or required)
-  ARGS_OPT_INTEGER,
-  ARGS_OPT_STRING,
-} args_option_type_t;
-
-
-typedef struct _args_option
-{
-  args_option_type_t type;
-  const char_t short_name;
-  const char_t *long_name;
-  void *value;
-  int max_count;
-  const char_t *help;
-  const char_t *type_help;
-  int count;
-} args_option_t;
-
+  typedef struct _args_option
+  {
+    args_option_type_t type;
+    const char_t short_name;
+    const char_t *long_name;
+    void *value;
+    int max_count;
+    const char_t *help;
+    const char_t *type_help;
+    int count;
+  } args_option_t;
 
 #define OPT_BOOLEAN(short_name, long_name, value, ...)             \
   {                                                                \
     ARGS_OPT_BOOLEAN, short_name, long_name, value, 1, __VA_ARGS__ \
   }
 
-#define OPT_INTEGER(short_name, long_name, value, ...)             \
-  {                                                                \
-    ARGS_OPT_INTEGER, short_name, long_name, value, 1, __VA_ARGS__ \
+#define OPT_LONG(short_name, long_name, value, ...)             \
+  {                                                             \
+    ARGS_OPT_LONG, short_name, long_name, value, 1, __VA_ARGS__ \
+  }
+
+#define OPT_LONG_LONG(short_name, long_name, value, ...)             \
+  {                                                                  \
+    ARGS_OPT_LONG_LONG, short_name, long_name, value, 1, __VA_ARGS__ \
   }
 
 #define OPT_STRING_MULTI(short_name, long_name, value, max_count, ...)    \
@@ -99,17 +101,11 @@ typedef struct _args_option
     ARGS_OPT_END, 0 \
   }
 
-int args_parse(
-    args_option_t *options,
-    int argc,
-    const char_t **argv);
+  int args_parse(args_option_t *options, int argc, const char_t **argv);
 
-void args_print_usage(
-    args_option_t *options,
-    int alignment);
+  void args_print_usage(args_option_t *options, int alignment);
 
-void args_free(
-	args_option_t *options);
+  void args_free(args_option_t *options);
 
 #ifdef __cplusplus
 }

--- a/cli/unicode.h
+++ b/cli/unicode.h
@@ -33,14 +33,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef _MSC_VER
 #include <tchar.h>
 #define char_t TCHAR
-#define PF_S "hs"
-#define PF_C "hc"
+#define PF_S   "hs"
+#define PF_C   "hc"
 
 #else
 #define char_t char
-#define _T(x) x
-#define PF_S "s"
-#define PF_C "c"
+#define _T(x)  x
+#define PF_S   "s"
+#define PF_C   "c"
 
 #ifdef __CYGWIN__
 #define _tcstok_s strtok_r
@@ -48,20 +48,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _tcstok_s strtok_s
 #endif
 
-#define _tcscmp strcmp
-#define _tcsdup strdup
-#define _tcschr strchr
-#define _tcslen strlen
-#define _tcsstr strstr
-#define _tcstol strtol
-#define _tstoi atoi
-#define _tstof atof
-#define _tisdigit isdigit
-#define _tfopen fopen
-#define _ftprintf fprintf
-#define _stprintf sprintf
-#define _tprintf printf
-#define _tmain main
+#define _tcscmp    strcmp
+#define _tcsdup    strdup
+#define _tcschr    strchr
+#define _tcslen    strlen
+#define _tcsstr    strstr
+#define _tcstol    strtol
+#define _tcstoll   strtoll
+#define _tstoi     atoi
+#define _tstof     atof
+#define _tisdigit  isdigit
+#define _tfopen    fopen
+#define _ftprintf  fprintf
+#define _stprintf  sprintf
+#define _tprintf   printf
+#define _tmain     main
 #define _sntprintf snprintf
 #endif
 

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -157,14 +157,14 @@ static bool negate = false;
 static bool print_count_only = false;
 static bool fail_on_warnings = false;
 static bool rules_are_compiled = false;
-static long long total_count = 0;
-static long long limit = 0;
-static long long timeout = 1000000;
-static long long stack_size = DEFAULT_STACK_SIZE;
+static long total_count = 0;
+static long limit = 0;
+static long timeout = 1000000;
+static long stack_size = DEFAULT_STACK_SIZE;
+static long threads = YR_MAX_THREADS;
+static long max_strings_per_rule = DEFAULT_MAX_STRINGS_PER_RULE;
+static long max_process_memory_chunk = DEFAULT_MAX_PROCESS_MEMORY_CHUNK;
 static long long skip_larger = 0;
-static long long threads = YR_MAX_THREADS;
-static long long max_strings_per_rule = DEFAULT_MAX_STRINGS_PER_RULE;
-static long long max_process_memory_chunk = DEFAULT_MAX_PROCESS_MEMORY_CHUNK;
 
 #define USAGE_STRING \
   "Usage: yara [OPTION]... [NAMESPACE:]RULES_FILE... FILE | DIR | PID"
@@ -215,7 +215,7 @@ args_option_t options[] = {
         _T("print only rules named IDENTIFIER"),
         _T("IDENTIFIER")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         0,
         _T("max-process-memory-chunk"),
         &max_process_memory_chunk,
@@ -223,14 +223,14 @@ args_option_t options[] = {
         _T(" (default=1073741824)"),
         _T("NUMBER")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         'l',
         _T("max-rules"),
         &limit,
         _T("abort scanning after matching a NUMBER of rules"),
         _T("NUMBER")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         0,
         _T("max-strings-per-rule"),
         &max_strings_per_rule,
@@ -310,14 +310,14 @@ args_option_t options[] = {
         &scan_list_search,
         _T("scan files listed in FILE, one per line")),
 
-    OPT_INTEGER(
+    OPT_LONG_LONG(
         'z',
         _T("skip-larger"),
         &skip_larger,
         _T("skip files larger than the given size when scanning a directory"),
         _T("NUMBER")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         'k',
         _T("stack-size"),
         &stack_size,
@@ -332,14 +332,14 @@ args_option_t options[] = {
         _T("print only rules tagged as TAG"),
         _T("TAG")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         'p',
         _T("threads"),
         &threads,
         _T("use the specified NUMBER of threads to scan a directory"),
         _T("NUMBER")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         'a',
         _T("timeout"),
         &timeout,
@@ -478,7 +478,7 @@ static int scan_dir(const char_t* dir, SCAN_OPTIONS* scan_opts)
 
       if (!(FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
       {
-        ULARGE_INTEGER file_size;
+        LARGE_INTEGER file_size;
 
         file_size.HighPart = FindFileData.nFileSizeHigh;
         file_size.LowPart = FindFileData.nFileSizeLow;
@@ -1411,10 +1411,10 @@ int _tmain(int argc, const char_t** argv)
     exit_with_code(EXIT_FAILURE);
   }
 
-  yr_set_configuration_uint32(YR_CONFIG_STACK_SIZE, stack_size);
+  yr_set_configuration_uint32(YR_CONFIG_STACK_SIZE, (uint32_t) stack_size);
 
   yr_set_configuration_uint32(
-      YR_CONFIG_MAX_STRINGS_PER_RULE, max_strings_per_rule);
+      YR_CONFIG_MAX_STRINGS_PER_RULE, (uint32_t) max_strings_per_rule);
 
   yr_set_configuration_uint64(
       YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK, max_process_memory_chunk);

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -494,7 +494,7 @@ static int scan_dir(const char_t* dir, SCAN_OPTIONS* scan_opts)
               _T("skipping %s (%" PRIu64
                  " bytes) because it's larger than %ld bytes.\n"),
               path,
-              file_size,
+              file_size.QuadPart,
               skip_larger);
         }
       }

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -492,7 +492,7 @@ static int scan_dir(const char_t* dir, SCAN_OPTIONS* scan_opts)
           _ftprintf(
               stderr,
               _T("skipping %s (%" PRIu64
-                 " bytes) because it's larger than %ld bytes.\n"),
+                 " bytes) because it's larger than %lld bytes.\n"),
               path,
               file_size.QuadPart,
               skip_larger);

--- a/cli/yarac.c
+++ b/cli/yarac.c
@@ -103,7 +103,7 @@ args_option_t options[] = {
 
     OPT_BOOLEAN('h', _T("help"), &show_help, _T("show this help and exit")),
 
-    OPT_INTEGER(
+    OPT_LONG(
         0,
         _T("max-strings-per-rule"),
         &max_strings_per_rule,


### PR DESCRIPTION
Also allow a 64 bits integer as the argument to `--skip-larger` both in Linux and Windows.