### PR TITLE
finish all processes spawned in the test suite

### DIFF
--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3061,7 +3061,7 @@ void test_process_scan()
     exit(EXIT_FAILURE);
   }
 
-  spawn("/bin/sh", "-c", "VAR='Hello, world!'; sleep 600; true");
+  spawn("/bin/sh", "-c", "VAR='Hello, world!'; sleep 600& PID=\$!; trap \"kill \$PID\" EXIT; wait; true");
 
   counters.rules_matching = 0;
   counters.rules_not_matching = 0;


### PR DESCRIPTION
This PR fixes a test case to ensure all spawned processes are finished. In `tests/test-rules.c` a shell process is created which itself spawns the `sleep`-executable. The latter isn't killed after the test run which confuses some automated test suites an leads to timeout issues (see https://bugs.gentoo.org/836790).