### PR TITLE
Add function to parse rules from raw buffer

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -629,6 +629,31 @@ YR_API int yr_compiler_add_fd(
   return result;
 }
 
+YR_API int yr_compiler_add_bytes(
+    YR_COMPILER* compiler,
+    const void* rules_data,
+    size_t rules_size,
+    const char* namespace_)
+{
+  // Don't allow calls to yr_compiler_add_bytes() after
+  // yr_compiler_get_rules() has been called.
+  assert(compiler->rules == NULL);
+
+  // Don't allow calls to yr_compiler_add_bytes() if a previous call to
+  // yr_compiler_add_XXXX failed.
+  assert(compiler->errors == 0);
+
+  if (namespace_ != NULL)
+    compiler->last_error = _yr_compiler_set_namespace(compiler, namespace_);
+  else
+    compiler->last_error = _yr_compiler_set_namespace(compiler, "default");
+
+  if (compiler->last_error != ERROR_SUCCESS)
+    return ++compiler->errors;
+
+  return yr_lex_parse_rules_bytes(rules_data, rules_size, compiler);
+}
+
 YR_API int yr_compiler_add_string(
     YR_COMPILER* compiler,
     const char* rules_string,

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -367,6 +367,12 @@ YR_API int yr_compiler_add_fd(
     const char* namespace_,
     const char* file_name);
 
+YR_API int yr_compiler_add_bytes(
+    YR_COMPILER* compiler,
+    const void* rules_data,
+    size_t rules_size,
+    const char* namespace_);
+
 YR_API int yr_compiler_add_string(
     YR_COMPILER* compiler,
     const char* rules_string,

--- a/libyara/include/yara/lexer.h
+++ b/libyara/include/yara/lexer.h
@@ -96,6 +96,8 @@ void yyfatal(yyscan_t yyscanner, const char* error_message);
 
 YY_EXTRA_TYPE yyget_extra(yyscan_t yyscanner);
 
+int yr_lex_parse_rules_bytes(const void* rules_data, size_t rules_size, YR_COMPILER* compiler);
+
 int yr_lex_parse_rules_string(const char* rules_string, YR_COMPILER* compiler);
 
 int yr_lex_parse_rules_file(FILE* rules_file, YR_COMPILER* compiler);

--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -3580,6 +3580,39 @@ void yyerror(
 }
 
 
+int yr_lex_parse_rules_bytes(
+    const void* rules_data,
+    size_t rules_size,
+    YR_COMPILER* compiler)
+{
+  yyscan_t yyscanner;
+
+  compiler->errors = 0;
+
+  if (yylex_init(&yyscanner) != 0)
+  {
+    compiler->errors = 1;
+    compiler->last_error = ERROR_INSUFFICIENT_MEMORY;
+    return compiler->errors;
+  }
+
+  if (setjmp(compiler->error_recovery) != 0)
+    return compiler->errors;
+
+  #if YYDEBUG
+  yydebug = 1;
+  #endif
+
+  yyset_extra(compiler, yyscanner);
+  yy_scan_bytes(rules_data, rules_size, yyscanner);
+  yyset_lineno(1, yyscanner);
+  yyparse(yyscanner, compiler);
+  yylex_destroy(yyscanner);
+
+  return compiler->errors;
+}
+
+
 int yr_lex_parse_rules_string(
     const char* rules_string,
     YR_COMPILER* compiler)

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -888,6 +888,39 @@ void yyerror(
 }
 
 
+int yr_lex_parse_rules_bytes(
+    const void* rules_data,
+    size_t rules_size,
+    YR_COMPILER* compiler)
+{
+  yyscan_t yyscanner;
+
+  compiler->errors = 0;
+
+  if (yylex_init(&yyscanner) != 0)
+  {
+    compiler->errors = 1;
+    compiler->last_error = ERROR_INSUFFICIENT_MEMORY;
+    return compiler->errors;
+  }
+
+  if (setjmp(compiler->error_recovery) != 0)
+    return compiler->errors;
+
+  #if YYDEBUG
+  yydebug = 1;
+  #endif
+
+  yyset_extra(compiler, yyscanner);
+  yy_scan_bytes(rules_data, rules_size, yyscanner);
+  yyset_lineno(1, yyscanner);
+  yyparse(yyscanner, compiler);
+  yylex_destroy(yyscanner);
+
+  return compiler->errors;
+}
+
+
 int yr_lex_parse_rules_string(
     const char* rules_string,
     YR_COMPILER* compiler)


### PR DESCRIPTION
There are some cases where we need to load rules not only from files, but directly from memory. One of these is updating over the network and (re)parsing without dropping to disk.
`yr_compiler_add_string()` is not suitable because buffers in-memory are not null-terminated, and `strlen()` is time consuming.

Here we add the ability to work with the most portable form of raw data: pointer + size.