### PR TITLE
Fixed lexer pattern for bad character set

### DIFF
--- a/libyara/re_lexer.l
+++ b/libyara/re_lexer.l
@@ -308,7 +308,7 @@ hex_digit     [0-9a-fA-F]
 
 
 
-<char_class>(\\x{hex_digit}{2}|\\.|[^\\])\-[^]] {
+<char_class>(\\x{hex_digit}{2}|\\.|[^\\\]])\-[^]] {
 
   // A range inside a character class.
   //  [abc0-9]


### PR DESCRIPTION
Fixes an issue with the lexer pattern for character ranges to now no-longer allow an unescaped closing square bracket inside a character set.


I'm using the following test rule, and test data.
```
$ cat ~/testrule.yara 
rule test {
        strings:
                $ = /[0-9]-2/
        condition:
                all of them
}
```
```
$ cat ~/yara_test_file.txt 
1-2-3-4-5
```

Using a version of Yara without a fix, Yara improperly gives an error for the pattern in the rule above.
```
$ /usr/bin/yara --version
3.9.0

/usr/bin/yara -s ~/testrule.yara ~/yara_test_file.txt 
~/testrule.yara(3): error: invalid regular expression "$": bad character range
```


With my changes, Yara appears to be working as expected
```
./yara -s ~/testrule.yara ~/yara_test_file.txt
test /home/cyberdraco/yara_test_file.txt
0x0:$: 1-2
```

Closes #1690