### PR TITLE
Fix an issue with none and 0 in expressions.

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -1390,8 +1390,13 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
 
         if (is_undef(r2))
           r1.i = found >= count ? 1 : 0;
-        else
-          r1.i = found >= r2.i ? 1 : 0;
+        else {
+          // https://github.com/VirusTotal/yara/issues/1695
+          if (r2.i == 0)
+            r1.i = found == r2.i ? 1 : 0;
+          else
+            r1.i = found >= r2.i ? 1 : 0;
+        }
       }
       else  // OP_OF_PERCENT
       {
@@ -1452,8 +1457,13 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
       pop(r1);
       if (is_undef(r1))
         r1.i = found >= count ? 1 : 0;
-      else
-        r1.i = found >= r1.i ? 1 : 0;
+      else {
+        // https://github.com/VirusTotal/yara/issues/1695
+        if (r2.i == 0)
+          r1.i = found == r2.i ? 1 : 0;
+        else
+          r1.i = found >= r2.i ? 1 : 0;
+      }
 
       push(r1);
       break;

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -631,6 +631,17 @@ static void test_strings()
        }",
       "foobarbaz" TEXT_1024_BYTES);
 
+  // https://github.com/VirusTotal/yara/issues/1695
+  assert_false_rule(
+      "rule test {\n\
+         strings:\n\
+             $a = \"AXS\"\n\
+             $b = \"ERS\"\n\
+         condition:\n\
+             none of them in (0..10)\n\
+       }",
+      "AXSERS" TEXT_1024_BYTES);
+
   // https://github.com/VirusTotal/yara/issues/1660
   assert_false_rule(
       "rule test {\n\
@@ -1629,6 +1640,10 @@ static void test_rule_of()
   assert_match_count(
       "rule a { condition: true } rule b { condition: 1 of (a) }", NULL, 2);
 
+  // https://github.com/VirusTotal/yara/issues/1695
+  assert_match_count(
+      "rule a { condition: false } rule b { condition: none of (a) }", NULL, 1);
+
   assert_match_count(
       "rule a1 { condition: true } "
       "rule a2 { condition: true } "
@@ -1680,6 +1695,12 @@ static void test_of()
       "condition: none of them }",
       TEXT_1024_BYTES "AXSERS");
 
+  // https://github.com/VirusTotal/yara/issues/1695
+  assert_false_rule(
+      "rule test { strings: $a = \"dummy1\" $b = \"dummy2\" $c = \"ssi\" "
+      "condition: none of them }",
+      TEXT_1024_BYTES "mississippi");
+
   assert_true_rule(
       "rule test { strings: $a = \"ssi\" $b = \"mis\" private $c = \"oops\" "
       "condition: 1 of them }",
@@ -1691,14 +1712,21 @@ static void test_of()
       TEXT_1024_BYTES "mississippi");
 
   assert_true_rule(
-      "rule test { strings: $a1 = \"dummy1\" $b1 = \"dummy1\" $b2 = \"ssi\""
+      "rule test { strings: $a1 = \"dummy1\" $b1 = \"dummy1\" $b2 = \"ssi\" "
       "condition: any of ($a*, $b*) }",
       TEXT_1024_BYTES "mississippi");
 
   assert_true_rule(
-      "rule test { strings: $a1 = \"dummy1\" $b1 = \"dummy1\" $b2 = \"ssi\""
+      "rule test { strings: $a1 = \"dummy1\" $b1 = \"dummy1\" $b2 = \"ssi\" "
       "condition: none of ($a*, $b*) }",
       TEXT_1024_BYTES "AXSERS");
+
+  // https://github.com/VirusTotal/yara/issues/1695
+  assert_false_rule(
+      "rule test { strings: $a1 = \"dummy1\" $b1 = \"dummy2\" $b2 = \"ssi\" "
+      "condition: none of ($a*, $b*) }",
+      TEXT_1024_BYTES "mississippi");
+
 
   assert_true_rule_blob(
       "rule test { \


### PR DESCRIPTION
As discussed in https://github.com/VirusTotal/yara/issues/1695, there is an
issue with some expressions involving "0" (and by extension "none"). If you
said "0 of them" and one of them matched we would evaluate that expression to
true because we never checked for the special 0 case.

Turns out this bug has existed for a while now but was likely never triggered
because not many people would say "0 of them" before the "none" keyword came
around. However, the author of the issue is correct that this should have been
exposed with better tests when I implemented the none keyword.

Fixes #1695.