### PR TITLE
incrementing the minor version of yara to reflect current ver #

### DIFF
--- a/libyara/include/yara/libyara.h
+++ b/libyara/include/yara/libyara.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define YR_MAJOR_VERSION 4
 #define YR_MINOR_VERSION 2
-#define YR_MICRO_VERSION 0
+#define YR_MICRO_VERSION 1
 
 #define version_str(s)  _version_str(s)
 #define _version_str(s) #s


### PR DESCRIPTION
YR_MINOR_VERSION is still 0 which doesnt reflect current versioning.

Linked to and/or the sames as: https://github.com/VirusTotal/yara/issues/1706
