### PR TITLE
Fixed typos in pe.delayed_import_details structure

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -3548,14 +3548,14 @@ begin_declarations
     end_struct_array("functions");
   end_struct_array("import_details");
 
-  begin_struct_array("delay_import_details")
+  begin_struct_array("delayed_import_details")
     declare_string("library_name");
-    declare_integer("number_of_function");
+    declare_integer("number_of_functions");
     begin_struct_array("functions")
       declare_string("name");
       declare_integer("ordinal");
     end_struct_array("functions");
-  end_struct_array("delay_import_details");
+  end_struct_array("delayed_import_details");
 
   declare_integer("resource_timestamp");
 

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -599,6 +599,22 @@ int main(int argc, char** argv)
   assert_true_rule_file(
       "import \"pe\" \
       \
+      rule import_delayed_import_details \
+      {\
+          condition:\
+            for any import_detail in pe.delayed_import_details : (\
+                import_detail.number_of_functions == 2 and\
+                import_detail.library_name == \"USER32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"MessageBoxA\"\
+                )\
+            )\
+      }",
+      "tests/data/pe_imports");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
       rule zero_length_version_info_value \
       {\
           condition:\


### PR DESCRIPTION
There were several typos across the `pe.delayed_import_details` which resulted in certain delayed import information not being available at all.