### PR TITLE
Magic tests fix

### DIFF
--- a/tests/test-magic.c
+++ b/tests/test-magic.c
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
 
   assert_true_rule_blob(
       "import \"magic\" rule test { condition: \
-      magic.type() contains \"PE32\" and \
+      magic.type() contains \"MS-DOS executable\" and \
       magic.mime_type() == \"application/x-dosexec\" }",
       PE32_FILE);
 

--- a/tests/test-magic.c
+++ b/tests/test-magic.c
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
   assert_true_rule_blob(
       "import \"magic\" rule test { condition: \
       magic.type() contains \"Mach-O\" and \
-      magic.mime_type() == \"application/x-mach-binary\" and \
+      (magic.mime_type() == \"application/x-mach-binary\" or magic.mime_type() == \"application/octet-stream\") and \
       magic.type() contains \"Mach-O\"}",
       MACHO_X86_FILE);
 


### PR DESCRIPTION
Update test conditions for magic module. This change is necessary because different versions of libmagic return different identifications.

For example docker image `centos:7` fails to pass `make check` tests. I extracted the `PE32_FILE` and `MACHO_X86_FILE` using python into a file and using `file` identified expected output.

Additionally to the original issue there is also problem with the macho binary, this time not with `magic.type()` but `magic.mime_type()` which returns:
```bash
[root@f6c81b5ba76a /]# file -i full.macho
full.macho: application/octet-stream; charset=binary
```
vs. current arch linux:
```bash
λ file -i full.macho
full.macho: application/x-mach-binary; charset=binary
```

1. pe32 test condition is changed to `MS-DOS executable` which is common identification for both libmagic versions
2. macho test condition is extended with alternative `magic.mime_type()`

Fixes https://github.com/VirusTotal/yara/issues/1713