### PR TITLE
Update atom logic to properly score [A-Z]

### DIFF
--- a/libyara/atoms.c
+++ b/libyara/atoms.c
@@ -161,8 +161,8 @@ int yr_atoms_heuristic_quality(YR_ATOMS_CONFIG* config, YR_ATOM* atom)
         // than the rest. We want to favor atoms that contain bytes outside
         // those ranges because they generate less additional atoms during
         // calls to _yr_atoms_case_combinations.
-        if (yr_lowercase[atom->bytes[i]] >= 'a' &&
-            yr_lowercase[atom->bytes[i]] <= 'z')
+        if ((yr_lowercase[atom->bytes[i]] >= 'a' && yr_lowercase[atom->bytes[i]] <= 'z') ||
+        (yr_lowercase[atom->bytes[i]] >= 'A' && yr_lowercase[atom->bytes[i]] <= 'Z'))
           quality += 18;
         else
           quality += 20;

--- a/tests/test-atoms.c
+++ b/tests/test-atoms.c
@@ -167,6 +167,12 @@ void test_heuristic_quality()
       .bytes = {0x61, 0x62, 0x63, 0x64},
       .mask = {0xFF, 0xFF, 0xFF, 0xFF}};
 
+  // ABCD
+  YR_ATOM a41424344 = {
+      .length = 4,
+      .bytes = {0x41, 0x42, 0x43, 0x44},
+      .mask = {0xFF, 0xFF, 0xFF, 0xFF}};
+
   // abc.
   YR_ATOM a6162632E = {
       .length = 4,
@@ -195,6 +201,7 @@ void test_heuristic_quality()
   int qCCCCCCCC = yr_atoms_heuristic_quality(&c, &aCCCCCCCC);
   int qFFFFFFFF = yr_atoms_heuristic_quality(&c, &aFFFFFFFF);
   int q61626364 = yr_atoms_heuristic_quality(&c, &a61626364);
+  int q41424344 = yr_atoms_heuristic_quality(&c, &a41424344);
   int q6162632E = yr_atoms_heuristic_quality(&c, &a6162632E);
 
   a010203.mask[1] = 0x00;
@@ -239,6 +246,7 @@ void test_heuristic_quality()
   assert_true_expr(q01020102 > q010203);
   assert_true_expr(q01020304 > q61626364);
   assert_true_expr(q010203 < q61626364);
+  assert_true_expr(q61626364 == q41424344);
   assert_true_expr(q6162632E > q61626364);
 
   // Byte sequences like 90 90 90 90 and CC CC CC CC are using as function


### PR DESCRIPTION
The [documentation says](https://github.com/VirusTotal/yara/blob/ee6b2363f7d3bcb6b6bbe655ad8a71a451cc3af8/libyara/atoms.c#L118) `Bytes [a-zA-Z] contribute 18 points each`, but it looks like [in the code](https://github.com/VirusTotal/yara/blob/ee6b2363f7d3bcb6b6bbe655ad8a71a451cc3af8/libyara/atoms.c#L164) that only `[a-z]` is given 18 points, whereas `[A-Z]` is given 20 points. This commit will make sure these ranges have the proper atom scoring applied.