### PR TITLE
Fix autoreconf error due to m4 CRLF issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# https://pete.akeo.ie/2010/12/that-darn-libtoolize-acconfigmacrodirm4.html
+*.sh text eol=lf
+*.ac text eol=lf
+*.am text eol=lf


### PR DESCRIPTION
Trying to run `autoreconf -fiv` on a Windows system using wsl causes the following error:
```
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
.ibtoolize:   error: AC_CONFIG_MACRO_DIRS([m4]) conflicts with ACLOCAL_AMFLAGS=-I m4
autoreconf: libtoolize failed with exit status: 1
```
This is likely due to a CRLF error in the makefile. This commit applies the following fix:
https://pete.akeo.ie/2010/12/that-darn-libtoolize-acconfigmacrodirm4.html