### PR TITLE
Fix incorrect error message in range check.

### DIFF
--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -4192,7 +4192,7 @@ yyreduce:
           if ((yyvsp[-3].expression).value.integer > (yyvsp[-1].expression).value.integer)
           {
             yr_compiler_set_error_extra_info(
-                compiler, "range lower bound must be greater than upper bound");
+                compiler, "range lower bound must be less than upper bound");
             result = ERROR_INVALID_VALUE;
           } else if ((yyvsp[-3].expression).value.integer < 0)
           {

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -2136,7 +2136,7 @@ range
           if ($2.value.integer > $4.value.integer)
           {
             yr_compiler_set_error_extra_info(
-                compiler, "range lower bound must be greater than upper bound");
+                compiler, "range lower bound must be less than upper bound");
             result = ERROR_INVALID_VALUE;
           } else if ($2.value.integer < 0)
           {


### PR DESCRIPTION
This error message is incorrect. It should explain that the lower bound must be less than the upper bound.