### PR TITLE
Fix null derefrences while loading compiled rules

### DIFF
--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -597,7 +597,8 @@ int yr_arena_load_stream(YR_STREAM* stream, YR_ARENA** arena)
     YR_ARENA_BUFFER* b = &new_arena->buffers[reloc_ref.buffer_id];
 
     if (reloc_ref.buffer_id >= new_arena->num_buffers ||
-        reloc_ref.offset > b->used - sizeof(void*))
+        reloc_ref.offset > b->used - sizeof(void*) ||
+        b->data == NULL)
     {
       yr_arena_release(new_arena);
       return ERROR_CORRUPT_FILE;

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -56,7 +56,7 @@ int yr_object_create(
   YR_OBJECT* obj;
   size_t object_size = 0;
 
-  assert(parent != NULL || object != NULL);
+  assert(identifier != NULL || parent != NULL || object != NULL);
 
   switch (type)
   {

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -56,7 +56,8 @@ int yr_object_create(
   YR_OBJECT* obj;
   size_t object_size = 0;
 
-  assert(identifier != NULL || parent != NULL || object != NULL);
+  assert(parent != NULL || object != NULL);
+  assert(identifier != NULL);
 
   switch (type)
   {

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -333,6 +333,9 @@ int yr_rules_from_arena(YR_ARENA* arena, YR_RULES** rules)
   YR_SUMMARY* summary = (YR_SUMMARY*) yr_arena_get_ptr(
       arena, YR_SUMMARY_SECTION, 0);
 
+  if (summary == NULL)
+    return ERROR_CORRUPT_FILE;
+
   // Now YR_RULES relies on this arena, let's increment the arena's
   // reference count so that if the original owner of the arena calls
   // yr_arena_destroy the arena is not destroyed.


### PR DESCRIPTION
While reading compiled rules file - there are a couple of places where a NULL dereference could happen. 
1. `yr_arena_get_ptr` could return `NULL` which is not checked in  https://github.com/VirusTotal/yara/blob/929af6ef214e595d9f1a06cfaf048bf439e6b933/libyara/rules.c#L333-L343
2. `b->data` could be `NULL` in `yr_arena_load_stream` in https://github.com/VirusTotal/yara/blob/929af6ef214e595d9f1a06cfaf048bf439e6b933/libyara/arena.c#L597-L610

I can attach some sample testcases that could trigger these code paths.