### PR TITLE
Fix negative indexing in dex module.

### DIFF
--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -418,7 +418,7 @@ static int64_t dex_get_integer(
     const char* pattern,
     int64_t index)
 {
-  if (index == YR_UNDEFINED || index < 0)
+  if (index < 0)
     return YR_UNDEFINED;
 
   // Impose a reasonably large limit to table indexes.
@@ -434,7 +434,7 @@ static SIZED_STRING* dex_get_string(
     const char* pattern,
     int64_t index)
 {
-  if (index == YR_UNDEFINED || index < 0)
+  if (index < 0)
     return NULL;
 
   // Impose a reasonably large limit to table indexes.

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -418,7 +418,7 @@ static int64_t dex_get_integer(
     const char* pattern,
     int64_t index)
 {
-  if (index < 0)
+  if (index == YR_UNDEFINED || index < 0)
     return YR_UNDEFINED;
 
   // Impose a reasonably large limit to table indexes.
@@ -434,7 +434,7 @@ static SIZED_STRING* dex_get_string(
     const char* pattern,
     int64_t index)
 {
-  if (index < 0)
+  if (index == YR_UNDEFINED || index < 0)
     return NULL;
 
   // Impose a reasonably large limit to table indexes.

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -418,7 +418,7 @@ static int64_t dex_get_integer(
     const char* pattern,
     int64_t index)
 {
-  if (index == YR_UNDEFINED)
+  if (index == YR_UNDEFINED || index < 0)
     return YR_UNDEFINED;
 
   // Impose a reasonably large limit to table indexes.
@@ -434,7 +434,7 @@ static SIZED_STRING* dex_get_string(
     const char* pattern,
     int64_t index)
 {
-  if (index == YR_UNDEFINED)
+  if (index == YR_UNDEFINED || index < 0)
     return NULL;
 
   // Impose a reasonably large limit to table indexes.


### PR DESCRIPTION
When attempting to call dex_get_integer() or dex_get_string() with a negative
index we would eventually land in the assert() at
https://github.com/VirusTotal/yara/blob/master/libyara/object.c#L497 failing.
Instead of doing that let's check for negative values before going any further,
which will at least allow the module to continue processing.

Fixes #951.