### PR TITLE
XOR Values.

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -147,6 +147,7 @@ static bool show_tags = false;
 static bool show_stats = false;
 static bool show_strings = false;
 static bool show_string_length = false;
+static bool show_xor_key = false;
 static bool show_meta = false;
 static bool show_namespace = false;
 static bool show_version = false;
@@ -295,6 +296,12 @@ args_option_t options[] = {
         _T("print-string-length"),
         &show_string_length,
         _T("print length of matched strings")),
+
+    OPT_BOOLEAN(
+        'X',
+        _T("print-xor-key"),
+        &show_xor_key,
+        _T("print xor key of matched strings")),
 
     OPT_BOOLEAN('g', _T("print-tags"), &show_tags, _T("print tags")),
 
@@ -1081,7 +1088,7 @@ static int handle_message(
 
     // Show matched strings.
 
-    if (show_strings || show_string_length)
+    if (show_strings || show_string_length || show_xor_key)
     {
       YR_STRING* string;
 
@@ -1102,6 +1109,9 @@ static int handle_message(
                 _T("0x%" PRIx64 ":%" PF_S),
                 match->base + match->offset,
                 string->identifier);
+
+          if (show_xor_key && STRING_IS_XOR(string))
+            _tprintf(_T(":0x%02x"), match->xor_key);
 
           if (show_strings)
           {

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1110,8 +1110,8 @@ static int handle_message(
                 match->base + match->offset,
                 string->identifier);
 
-          if (show_xor_key && STRING_IS_XOR(string))
-            _tprintf(_T(":0x%02x"), match->xor_key);
+          if (show_xor_key)
+            _tprintf(_T(":xor(0x%02x)"), match->xor_key);
 
           if (show_strings)
           {

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -496,6 +496,9 @@ struct YR_MATCH
 
   // True if this is match for a private string.
   bool is_private;
+
+  // Set to the xor key if this is an xor string.
+  uint8_t xor_key;
 };
 
 struct YR_AC_STATE


### PR DESCRIPTION
When the xor modifier is used we have not displayed (or even kept) the xor key.
This diff adds a -X option to the CLI that will display the xor key. To do this
I am recording the xor key in _yr_scan_xor_compare() and _yr_scan_xor_wcompare()
and then populating that in the YR_MATCH structure. This way it is available to
the consumers of libyara to handle how they see fit.

The yara command is getting a `-X` argument which displays the key (as a hex value, I find that easier to see in my brain) which will add an extra field to the output when an xor string is found, but nothing when a non-xor string is found. See this rule and output for an example:

```
wxs@mbp yara % cat rules/xor.yara
rule a {
  strings:
    $a = "This program cannot"
    $b = "This program cannot" xor(0-5)
  condition:
    any of them
}
wxs@mbp yara % ./yara -sLX rules/xor.yara tests/data/xor.out
a tests/data/xor.out
0x4:19:$a: This program cannot
0x4:19:$b:0x00: This program cannot
0x1c:19:$b:0x01: Uihr!qsnfs`l!b`oonu
0x34:19:$b:0x02: Vjkq"rpmepco"acllmv
0x4c:19:$b:0x03: Wkjp#sqldqbn#`bmmlw
0x64:19:$b:0x04: Plmw$tvkcvei$gejjkp
0x7c:19:$b:0x05: Qmlv%uwjbwdh%fdkkjq
wxs@mbp yara %
```

As you can see, `$a` is not using the xor modifier so the fourth field is the string contents, but the other lines have 5 fields because they are xor strings and as such get the xor key in the 4th field. I'm a bit torn on if this is the right way to do it or not. The other option I considered was always including an xor value even if the string is not an xor string. That would look like this:

```
wxs@mbp yara % ./yara -sLX rules/xor.yara tests/data/xor.out
a tests/data/xor.out
0x4:19:$a:0x00: This program cannot
0x4:19:$b:0x00: This program cannot
0x1c:19:$b:0x01: Uihr!qsnfs`l!b`oonu
0x34:19:$b:0x02: Vjkq"rpmepco"acllmv
0x4c:19:$b:0x03: Wkjp#sqldqbn#`bmmlw
0x64:19:$b:0x04: Plmw$tvkcvei$gejjkp
0x7c:19:$b:0x05: Qmlv%uwjbwdh%fdkkjq
wxs@mbp yara %
```

Notice that the `$a` string has a 4th field that is the xor key, even though it is not using the xor modifier. This makes the output consistent but at the cost of being confusing to users. It doesn't make sense, to me, for there to be a field which is the xor value if the string is not an xor string.

I'll be adding support for exposing the xor key in yara-python if this PR is accepted.