### PR TITLE
fix: reset index of import_details functions in pe module

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -991,10 +991,10 @@ void pe_set_imports(
     const char* fun_ordinal)
 {
   int dll_cnt = 0;
-  int fun_cnt = 0;
 
   for (; dll != NULL; dll = dll->next, dll_cnt++)
   {
+    int fun_cnt = 0;
     for (IMPORT_FUNCTION* func = dll->functions; func != NULL;
          func = func->next, fun_cnt++)
     {

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -704,6 +704,22 @@ int main(int argc, char** argv)
   assert_true_rule_file(
       "import \"pe\" \
       \
+      rule import_details \
+      {\
+          condition:\
+            pe.number_of_imports == 2 and\
+            pe.import_details[0].library_name == \"KERNEL32.dll\" and\
+            pe.import_details[0].number_of_functions == 21 and\
+            pe.import_details[0].functions[20].name == \"VirtualQuery\" and\
+            pe.import_details[1].library_name == \"msvcrt.dll\" and\
+            pe.import_details[1].number_of_functions == 27 and\
+            pe.import_details[1].functions[26].name == \"vfprintf\"\
+      }",
+      "tests/data/tiny");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
       rule zero_length_version_info_value \
       {\
           condition:\


### PR DESCRIPTION
The function index was not reset between subsequent DLL imports, leading
to the number_of_functions value and the functions indexes being wrong
for all imports after the first one.

This is fixed by simply pushing the counter inside the DLL loop.

Closes #1746 