### PR TITLE
Improve docs for -d.

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -57,9 +57,9 @@ Available options are:
 
   Print only number of matches.
 
-.. option:: -d <identifier>=<value>
+.. option:: -d <identifier>=<value> --define=identifier=value
 
-  Define external variable.
+  Define external variable. This option can be used multiple times.
 
 .. option:: --fail-on-warnings
 


### PR DESCRIPTION
As mentioned in #1749, this commit brings the docs up to date with the man page
and usage statement.

Fixes #1749.