### PR TITLE
Fix ELF module warning about potential uninitialized free

### DIFF
--- a/libyara/modules/elf/elf.c
+++ b/libyara/modules/elf/elf.c
@@ -77,9 +77,10 @@ define_function(telfhash)
       "malloc_trim"};
 
   SIMPLE_STR* sstr = NULL;
+  Tlsh* tlsh = NULL;
 
   int symbol_count = 0;
-  char** clean_names = yr_malloc(list->count * sizeof(*clean_names));
+  char** clean_names = yr_calloc(list->count, sizeof(*clean_names));
 
   if (!clean_names)
     return_string(YR_UNDEFINED);
@@ -153,8 +154,7 @@ define_function(telfhash)
       goto cleanup;
   }
 
-  Tlsh* tlsh = tlsh_new();
-
+  tlsh = tlsh_new();
   if (!tlsh)
     goto cleanup;
 


### PR DESCRIPTION
With a new compiler version, I've noticed a warning when compiling YARA about a mistake I've made.

```
modules/elf/elf.c: In function ‘telfhash’:
modules/elf/elf.c:179:3: warning: ‘tlsh’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  179 |   tlsh_free(tlsh);
      |   ^~~~~~~~~~~~~~~
 ```
 The problem can happen due to the potential `goto` jump to a `tlsh_free(tlsh)` before the `tlsh` variable is created.
 
 Fix:
 I've initialized the `tlsh` to NULL before any cleanup jumps.