### PR TITLE
propagate undefined value in OP_FOUND_AT

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -1336,12 +1336,7 @@ int yr_execute_code(YR_SCAN_CONTEXT* context)
       pop(r2);
       pop(r1);
 
-      if (is_undef(r1))
-      {
-        r1.i = 0;
-        push(r1);
-        break;
-      }
+      ensure_defined(r1);
 
 #if YR_PARANOID_EXEC
       ensure_within_rules_arena(r2.p);

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3636,6 +3636,19 @@ void test_defined()
           defined \"foo\" contains \"f\" \
       }",
       NULL);
+
+  // Test FOUND_IN and FOUND_AT propagates undefined values
+  assert_true_rule(
+      "import \"pe\" \
+      rule t { \
+        strings: \
+            $a = \"abc\" \
+        condition: \
+          not defined ($a in (0..pe.number_of_resources)) and \
+          not defined ($a in (pe.number_of_resources..5)) and \
+          not defined ($a at pe.number_of_resources) \
+      }",
+      NULL);
 }
 
 static void test_pass(int pass)


### PR DESCRIPTION
Before, this fix, this rule was true:

```
import "tests"

rule a {
    strings:
        $foo = "foo"
    condition:
        not defined ($foo in (0..tests.integer_array[40])) and
        defined ($foo at tests.integer_array[40])
}
```

where `tests.integer_array[40]` is just a way to get an undefined value.

This is surprising, OP_FOUND_AT is the only operation of this kind that
is not propagating the undefined value. This commit fixes this behavior.