### PR TITLE
yr_hash_table_iterate() no longer causes undefined behavior when namespace is NULL pointer

### DIFF
--- a/libyara/hash.c
+++ b/libyara/hash.c
@@ -255,7 +255,8 @@ YR_API int yr_hash_table_iterate(
     entry = table->buckets[i];
     while (entry != NULL)
     {
-      if (!strcmp(entry->ns, ns))
+      if ((entry->ns == NULL && ns == NULL)
+          || (entry->ns != NULL && ns != NULL && !strcmp(entry->ns, ns)))
       {
         result = iterate_func(
             entry->key, entry->key_length, entry->value, data);


### PR DESCRIPTION
Recently I had YARA compiled with ASAN and wanted to run `yr_hash_table_iterate()` on a hash table with `NULL` namespaces. What happened is that my program crashed on ASAN check. `strcmp` with NULL pointers is implementation specific and can cause undefined behavior. This fixes the `yr_hash_table_iterate()` so that it no longer calls `strcmp` with `NULL` pointers.