### PR TITLE
Renamed generic module macros to include 'yr_' prefix

### DIFF
--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -210,9 +210,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define regexp_argument(n) ((RE*) (__args[n - 1].re))
 
-#define module()       yr_object_get_root((YR_OBJECT*) __function_obj)
-#define parent()       (__function_obj->parent)
-#define scan_context() (__context)
+#define yr_module()       yr_object_get_root((YR_OBJECT*) __function_obj)
+#define yr_parent()       (__function_obj->parent)
+#define yr_scan_context() (__context)
 
 #define foreach_memory_block(iterator, block)            \
   for (block = iterator->first(iterator); block != NULL; \
@@ -221,28 +221,28 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define first_memory_block(context) \
   (context)->iterator->first((context)->iterator)
 
-#define is_undefined(object, ...) \
+#define yr_is_undefined(object, ...) \
   yr_object_has_undefined_value(object, __VA_ARGS__)
 
-#define get_object(object, ...) yr_object_lookup(object, 0, __VA_ARGS__)
+#define yr_get_object(object, ...) yr_object_lookup(object, 0, __VA_ARGS__)
 
-#define get_integer(object, ...) yr_object_get_integer(object, __VA_ARGS__)
+#define yr_get_integer(object, ...) yr_object_get_integer(object, __VA_ARGS__)
 
-#define get_float(object, ...) yr_object_get_float(object, __VA_ARGS__)
+#define yr_get_float(object, ...) yr_object_get_float(object, __VA_ARGS__)
 
-#define get_string(object, ...) yr_object_get_string(object, __VA_ARGS__)
+#define yr_get_string(object, ...) yr_object_get_string(object, __VA_ARGS__)
 
-#define set_integer(value, object, ...) \
+#define yr_set_integer(value, object, ...) \
   yr_object_set_integer(value, object, __VA_ARGS__)
 
-#define set_float(value, object, ...) \
+#define yr_set_float(value, object, ...) \
   yr_object_set_float(value, object, __VA_ARGS__)
 
-#define set_sized_string(value, len, object, ...) \
+#define yr_set_sized_string(value, len, object, ...) \
   yr_object_set_string(value, len, object, __VA_ARGS__)
 
-#define set_string(value, object, ...) \
-  set_sized_string(                    \
+#define yr_set_string(value, object, ...) \
+  yr_set_sized_string(                    \
       value, (value == NULL) ? 0 : strlen(value), object, __VA_ARGS__)
 
 #define return_integer(integer)                                                \

--- a/libyara/modules/console/console.c
+++ b/libyara/modules/console/console.c
@@ -40,7 +40,7 @@ define_function(log_string)
   // We are intentionally using sized strings here as we may be needing to
   // output strings with a null character in the middle.
   SIZED_STRING* s = sized_string_argument(1);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   // Assume the entire string is non-printable, so allocate 4 times the
@@ -78,7 +78,7 @@ define_function(log_string_msg)
   // We are intentionally using sized strings here as we may be needing to
   // output strings with a null character in the middle.
   SIZED_STRING* s = sized_string_argument(2);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   // Assume the entire string is non-printable, so allocate 4 times the
@@ -117,7 +117,7 @@ define_function(log_integer)
 {
   char* msg = NULL;
   int64_t i = integer_argument(1);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "%lli", i);
@@ -138,7 +138,7 @@ define_function(log_integer_msg)
   char* msg = NULL;
   char* s = string_argument(1);
   int64_t i = integer_argument(2);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "%s%lli", s, i);
@@ -158,7 +158,7 @@ define_function(log_float)
 {
   char* msg = NULL;
   double f = float_argument(1);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "%f", f);
@@ -179,7 +179,7 @@ define_function(log_float_msg)
   char* msg = NULL;
   char* s = string_argument(1);
   double f = float_argument(2);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "%s%f", s, f);
@@ -199,7 +199,7 @@ define_function(hex_integer)
 {
   char* msg = NULL;
   int64_t i = integer_argument(1);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "0x%llx", i);
@@ -220,7 +220,7 @@ define_function(hex_integer_msg)
   char* msg = NULL;
   char* s = string_argument(1);
   int64_t i = integer_argument(2);
-  YR_SCAN_CONTEXT* ctx = scan_context();
+  YR_SCAN_CONTEXT* ctx = yr_scan_context();
   YR_CALLBACK_FUNC callback = ctx->callback;
 
   yr_asprintf(&msg, "%s0x%llx", s, i);

--- a/libyara/modules/cuckoo/cuckoo.c
+++ b/libyara/modules/cuckoo/cuckoo.c
@@ -43,8 +43,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define_function(network_dns_lookup)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* network_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* network_obj = yr_parent();
 
   json_t* network_json = (json_t*) network_obj->data;
   json_t* value;
@@ -144,21 +144,21 @@ uint64_t http_request(
 define_function(network_http_request)
 {
   return_integer(http_request(
-      scan_context(), parent(), regexp_argument(1), METHOD_GET | METHOD_POST));
+      yr_scan_context(), yr_parent(), regexp_argument(1), METHOD_GET | METHOD_POST));
 }
 
 
 define_function(network_http_get)
 {
   return_integer(
-      http_request(scan_context(), parent(), regexp_argument(1), METHOD_GET));
+      http_request(yr_scan_context(), yr_parent(), regexp_argument(1), METHOD_GET));
 }
 
 
 define_function(network_http_post)
 {
   return_integer(
-      http_request(scan_context(), parent(), regexp_argument(1), METHOD_POST));
+      http_request(yr_scan_context(), yr_parent(), regexp_argument(1), METHOD_POST));
 }
 
 
@@ -166,8 +166,8 @@ define_function(network_http_post)
 // loops through array and checks value for argument
 define_function(network_host)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* network_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* network_obj = yr_parent();
 
   json_t* network_json = (json_t*) network_obj->data;
   json_t* value;
@@ -193,8 +193,8 @@ define_function(network_host)
 // checks for dest IP regex and dest port integer match
 define_function(network_tcp)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* network_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* network_obj = yr_parent();
 
   json_t* network_json = (json_t*) network_obj->data;
   json_t* value;
@@ -230,8 +230,8 @@ define_function(network_tcp)
 // checks for dest IP regex and dest port integer match
 define_function(network_udp)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* network_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* network_obj = yr_parent();
 
   json_t* network_json = (json_t*) network_obj->data;
   json_t* value;
@@ -267,8 +267,8 @@ define_function(network_udp)
 // checks for regex match on user-agent
 define_function(network_http_user_agent)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* network_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* network_obj = yr_parent();
 
   json_t* network_json = (json_t*) network_obj->data;
   json_t* http_json = json_object_get(network_json, "http");
@@ -297,8 +297,8 @@ define_function(network_http_user_agent)
 
 define_function(registry_key_access)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* registry_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* registry_obj = yr_parent();
 
   json_t* keys_json = (json_t*) registry_obj->data;
   json_t* value;
@@ -321,8 +321,8 @@ define_function(registry_key_access)
 
 define_function(filesystem_file_access)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* filesystem_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* filesystem_obj = yr_parent();
 
   json_t* files_json = (json_t*) filesystem_obj->data;
   json_t* value;
@@ -345,8 +345,8 @@ define_function(filesystem_file_access)
 
 define_function(sync_mutex)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
-  YR_OBJECT* sync_obj = parent();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
+  YR_OBJECT* sync_obj = yr_parent();
 
   json_t* mutexes_json = (json_t*) sync_obj->data;
   json_t* value;
@@ -439,10 +439,10 @@ int module_load(
 
   module_object->data = (void*) json;
 
-  network_obj = get_object(module_object, "network");
-  registry_obj = get_object(module_object, "registry");
-  filesystem_obj = get_object(module_object, "filesystem");
-  sync_obj = get_object(module_object, "sync");
+  network_obj = yr_get_object(module_object, "network");
+  registry_obj = yr_get_object(module_object, "registry");
+  filesystem_obj = yr_get_object(module_object, "filesystem");
+  sync_obj = yr_get_object(module_object, "sync");
 
   network_obj->data = (void*) json_object_get(json, "network");
 

--- a/libyara/modules/demo/demo.c
+++ b/libyara/modules/demo/demo.c
@@ -54,7 +54,7 @@ int module_load(
     void* module_data,
     size_t module_data_size)
 {
-  set_string("Hello World!", module_object, "greeting");
+  yr_set_string("Hello World!", module_object, "greeting");
 
   return ERROR_SUCCESS;
 }

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -41,15 +41,15 @@ define_function(has_method_string)
 {
   SIZED_STRING* parsed_name;
   SIZED_STRING* method_name = sized_string_argument(1);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_name = get_string(module, "method[%i].name", i);
+    parsed_name = yr_get_string(module, "method[%i].name", i);
     if (parsed_name != NULL &&
         strcmp(parsed_name->c_string, method_name->c_string) == 0)
     {
@@ -66,22 +66,22 @@ define_function(has_method_and_class_string)
   SIZED_STRING* parsed_name;
   SIZED_STRING* class_name = sized_string_argument(1);
   SIZED_STRING* method_name = sized_string_argument(2);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_class = get_string(module, "method[%i].class_name", i);
+    parsed_class = yr_get_string(module, "method[%i].class_name", i);
     if (parsed_class != NULL &&
         strcmp(parsed_class->c_string, class_name->c_string) != 0)
     {
       continue;
     }
 
-    parsed_name = get_string(module, "method[%i].name", i);
+    parsed_name = yr_get_string(module, "method[%i].name", i);
     if (parsed_name != NULL &&
         strcmp(parsed_name->c_string, method_name->c_string) == 0)
     {
@@ -96,17 +96,17 @@ define_function(has_method_regexp)
 {
   SIZED_STRING* parsed_name;
   RE* regex = regexp_argument(1);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_name = get_string(module, "method[%i].name", i);
+    parsed_name = yr_get_string(module, "method[%i].name", i);
     if (parsed_name != NULL &&
-        yr_re_match(scan_context(), regex, parsed_name->c_string) != -1)
+        yr_re_match(yr_scan_context(), regex, parsed_name->c_string) != -1)
     {
       return_integer(1);
     }
@@ -120,24 +120,24 @@ define_function(has_method_and_class_regexp)
   SIZED_STRING* parsed_name;
   RE* class_regex = regexp_argument(1);
   RE* name_regex = regexp_argument(2);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_class = get_string(module, "method[%i].class_name", i);
+    parsed_class = yr_get_string(module, "method[%i].class_name", i);
     if (parsed_class != NULL &&
-        yr_re_match(scan_context(), class_regex, parsed_class->c_string) == -1)
+        yr_re_match(yr_scan_context(), class_regex, parsed_class->c_string) == -1)
     {
       continue;
     }
 
-    parsed_name = get_string(module, "method[%i].name", i);
+    parsed_name = yr_get_string(module, "method[%i].name", i);
     if (parsed_name != NULL &&
-        yr_re_match(scan_context(), name_regex, parsed_name->c_string) != -1)
+        yr_re_match(yr_scan_context(), name_regex, parsed_name->c_string) != -1)
     {
       return_integer(1);
     }
@@ -149,15 +149,15 @@ define_function(has_class_string)
 {
   SIZED_STRING* parsed_class;
   SIZED_STRING* class_name = sized_string_argument(1);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_class = get_string(module, "method[%i].class_name", i);
+    parsed_class = yr_get_string(module, "method[%i].class_name", i);
     if (parsed_class != NULL &&
         strcmp(parsed_class->c_string, class_name->c_string) == 0)
     {
@@ -172,17 +172,17 @@ define_function(has_class_regexp)
 {
   SIZED_STRING* parsed_class;
   RE* regex = regexp_argument(1);
-  YR_OBJECT* module = module();
-  int64_t number_of_methods = get_integer(module, "number_of_methods");
+  YR_OBJECT* module = yr_module();
+  int64_t number_of_methods = yr_get_integer(module, "number_of_methods");
 
   if (number_of_methods == YR_UNDEFINED)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < number_of_methods; i++)
   {
-    parsed_class = get_string(module, "method[%i].class_name", i);
+    parsed_class = yr_get_string(module, "method[%i].class_name", i);
     if (parsed_class != NULL &&
-        yr_re_match(scan_context(), regex, parsed_class->c_string) != -1)
+        yr_re_match(yr_scan_context(), regex, parsed_class->c_string) != -1)
     {
       return_integer(1);
     }
@@ -425,7 +425,7 @@ static int64_t dex_get_integer(
   if (index > 0x80000)
     return YR_UNDEFINED;
 
-  return get_integer(object, pattern, (int) index);
+  return yr_get_integer(object, pattern, (int) index);
 }
 
 
@@ -441,7 +441,7 @@ static SIZED_STRING* dex_get_string(
   if (index > 0x80000)
     return NULL;
 
-  return get_string(object, pattern, (int) index);
+  return yr_get_string(object, pattern, (int) index);
 }
 
 
@@ -470,84 +470,84 @@ dex_header_t* dex_get_header(const uint8_t* data, size_t data_size)
 
 void dex_parse_header(dex_header_t* dex_header, YR_OBJECT* module_object)
 {
-  set_sized_string(
+  yr_set_sized_string(
       (char*) dex_header->magic,
       strnlen((char*) dex_header->magic, 8 * sizeof(char)),
       module_object,
       "header.magic");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->checksum), module_object, "header.checksum");
 
-  set_sized_string(
+  yr_set_sized_string(
       (char*) dex_header->signature,
       strnlen((char*) dex_header->signature, 20 * sizeof(char)),
       module_object,
       "header.signature");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->file_size), module_object, "header.file_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->header_size), module_object, "header.header_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->endian_tag), module_object, "header.endian_tag");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->link_size), module_object, "header.link_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->link_offset), module_object, "header.link_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->map_offset), module_object, "header.map_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->string_ids_size),
       module_object,
       "header.string_ids_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->string_ids_offset),
       module_object,
       "header.string_ids_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->type_ids_size),
       module_object,
       "header.type_ids_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->type_ids_offset),
       module_object,
       "header.type_ids_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->proto_ids_size),
       module_object,
       "header.proto_ids_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->proto_ids_offset),
       module_object,
       "header.proto_ids_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->field_ids_size),
       module_object,
       "header.field_ids_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->field_ids_offset),
       module_object,
       "header.field_ids_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->method_ids_size),
       module_object,
       "header.method_ids_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->method_ids_offset),
       module_object,
       "header.method_ids_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->class_defs_size),
       module_object,
       "header.class_defs_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->class_defs_offset),
       module_object,
       "header.class_defs_offset");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->data_size), module_object, "header.data_size");
-  set_integer(
+  yr_set_integer(
       yr_le32toh(dex_header->data_offset), module_object, "header.data_offset");
 }
 
@@ -577,22 +577,22 @@ uint32_t load_encoded_field(
   encoded_field.access_flags = (uint32_t) read_uleb128(
       (dex->data + start_offset + current_size), &current_size);
 
-  set_integer(
+  yr_set_integer(
       encoded_field.field_idx_diff,
       dex->object,
       "field[%i].field_idx_diff",
       index_encoded_field);
 
-  set_integer(
+  yr_set_integer(
       encoded_field.access_flags,
       dex->object,
       "field[%i].access_flags",
       index_encoded_field);
 
-  set_integer(
+  yr_set_integer(
       static_field, dex->object, "field[%i].static", index_encoded_field);
 
-  set_integer(
+  yr_set_integer(
       instance_field, dex->object, "field[%i].instance", index_encoded_field);
 
   *previous_field_idx = encoded_field.field_idx_diff + *previous_field_idx;
@@ -622,7 +622,7 @@ uint32_t load_encoded_field(
         "[DEX]\tFIELD_NAME %s NAME_IDX 0x%llx\n", field_name->c_string, name_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         field_name->c_string,
         field_name->length,
         dex->object,
@@ -649,7 +649,7 @@ uint32_t load_encoded_field(
         descriptor_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         class_name->c_string,
         class_name->length,
         dex->object,
@@ -676,7 +676,7 @@ uint32_t load_encoded_field(
         shorty_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         proto_name->c_string,
         proto_name->length,
         dex->object,
@@ -715,28 +715,28 @@ uint32_t load_encoded_method(
   encoded_method.code_off = (uint32_t) read_uleb128(
       (dex->data + start_offset + current_size), &current_size);
 
-  set_integer(
+  yr_set_integer(
       encoded_method.method_idx_diff,
       dex->object,
       "method[%i].method_idx_diff",
       index_encoded_method);
 
-  set_integer(
+  yr_set_integer(
       encoded_method.access_flags,
       dex->object,
       "method[%i].access_flags",
       index_encoded_method);
 
-  set_integer(
+  yr_set_integer(
       encoded_method.code_off,
       dex->object,
       "method[%i].code_off",
       index_encoded_method);
 
-  set_integer(
+  yr_set_integer(
       direct_method, dex->object, "method[%i].direct", index_encoded_method);
 
-  set_integer(
+  yr_set_integer(
       virtual_method, dex->object, "method[%i].virtual", index_encoded_method);
 
   *previous_method_idx = encoded_method.method_idx_diff + *previous_method_idx;
@@ -773,7 +773,7 @@ uint32_t load_encoded_method(
         name_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         method_name->c_string,
         method_name->length,
         dex->object,
@@ -800,7 +800,7 @@ uint32_t load_encoded_method(
         descriptor_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         class_name->c_string,
         class_name->length,
         dex->object,
@@ -827,7 +827,7 @@ uint32_t load_encoded_method(
         descriptor_idx);
 #endif
 
-    set_sized_string(
+    yr_set_sized_string(
         proto_name->c_string,
         proto_name->length,
         dex->object,
@@ -847,32 +847,32 @@ uint32_t load_encoded_method(
       code_item_t* code_item =
           (code_item_t*) (dex->data + encoded_method.code_off);
 
-      set_integer(
+      yr_set_integer(
           code_item->registers_size,
           dex->object,
           "method[%i].code_item.registers_size",
           index_encoded_method);
-      set_integer(
+      yr_set_integer(
           code_item->ins_size,
           dex->object,
           "method[%i].code_item.ins_size",
           index_encoded_method);
-      set_integer(
+      yr_set_integer(
           code_item->outs_size,
           dex->object,
           "method[%i].code_item.outs_size",
           index_encoded_method);
-      set_integer(
+      yr_set_integer(
           code_item->tries_size,
           dex->object,
           "method[%i].code_item.tries_size",
           index_encoded_method);
-      set_integer(
+      yr_set_integer(
           code_item->debug_info_off,
           dex->object,
           "method[%i].code_item.debug_info_off",
           index_encoded_method);
-      set_integer(
+      yr_set_integer(
           code_item->insns_size,
           dex->object,
           "method[%i].code_item.insns_size",
@@ -883,7 +883,7 @@ uint32_t load_encoded_method(
               dex->data + encoded_method.code_off + sizeof(code_item_t),
               code_item->insns_size * 2))
       {
-        set_sized_string(
+        yr_set_sized_string(
             (const char*) (dex->data + encoded_method.code_off + sizeof(code_item_t)),
             code_item->insns_size * 2,
             dex->object,
@@ -958,15 +958,15 @@ void dex_parse(DEX* dex, uint64_t base_address)
             value))
       continue;
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(string_id_item->string_data_offset),
         dex->object,
         "string_ids[%i].offset",
         i);
 
-    set_integer(value, dex->object, "string_ids[%i].size", i);
+    yr_set_integer(value, dex->object, "string_ids[%i].size", i);
 
-    set_sized_string(
+    yr_set_sized_string(
         (const char*) (
             dex->data + yr_le32toh(string_id_item->string_data_offset) + 1),
         value,
@@ -991,7 +991,7 @@ void dex_parse(DEX* dex, uint64_t base_address)
     type_id_item_t* type_id_item =
         (type_id_item_t*) (dex->data + yr_le32toh(dex_header->type_ids_offset) + i * sizeof(type_id_item_t));
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(type_id_item->descriptor_idx),
         dex->object,
         "type_ids[%i].descriptor_idx",
@@ -1014,17 +1014,17 @@ void dex_parse(DEX* dex, uint64_t base_address)
     proto_id_item_t* proto_id_item =
         (proto_id_item_t*) (dex->data + yr_le32toh(dex_header->proto_ids_offset) + i * sizeof(proto_id_item_t));
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(proto_id_item->shorty_idx),
         dex->object,
         "proto_ids[%i].shorty_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(proto_id_item->return_type_idx),
         dex->object,
         "proto_ids[%i].return_type_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(proto_id_item->parameters_offset),
         dex->object,
         "proto_ids[%i].parameters_offset",
@@ -1047,17 +1047,17 @@ void dex_parse(DEX* dex, uint64_t base_address)
     field_id_item_t* field_id_item =
         (field_id_item_t*) (dex->data + yr_le32toh(dex_header->field_ids_offset) + i * sizeof(field_id_item_t));
 
-    set_integer(
+    yr_set_integer(
         yr_le16toh(field_id_item->class_idx),
         dex->object,
         "field_ids[%i].class_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le16toh(field_id_item->type_idx),
         dex->object,
         "field_ids[%i].type_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(field_id_item->name_idx),
         dex->object,
         "field_ids[%i].name_idx",
@@ -1080,17 +1080,17 @@ void dex_parse(DEX* dex, uint64_t base_address)
     method_id_item_t* method_id_item =
         (method_id_item_t*) (dex->data + yr_le32toh(dex_header->method_ids_offset) + i * sizeof(method_id_item_t));
 
-    set_integer(
+    yr_set_integer(
         yr_le16toh(method_id_item->class_idx),
         dex->object,
         "method_ids[%i].class_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le16toh(method_id_item->proto_idx),
         dex->object,
         "method_ids[%i].proto_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(method_id_item->name_idx),
         dex->object,
         "method_ids[%i].name_idx",
@@ -1111,7 +1111,7 @@ void dex_parse(DEX* dex, uint64_t base_address)
     uint32_t* map_list_size =
         (uint32_t*) (dex->data + yr_le32toh(dex_header->map_offset));
 
-    set_integer(yr_le32toh(*map_list_size), dex->object, "map_list.size");
+    yr_set_integer(yr_le32toh(*map_list_size), dex->object, "map_list.size");
 
     if (!fits_in_dex(
             dex,
@@ -1127,22 +1127,22 @@ void dex_parse(DEX* dex, uint64_t base_address)
       if (!struct_fits_in_dex(dex, map_item, map_item_t))
         return;
 
-      set_integer(
+      yr_set_integer(
           yr_le16toh(map_item->type),
           dex->object,
           "map_list.map_item[%i].type",
           i);
-      set_integer(
+      yr_set_integer(
           yr_le16toh(map_item->unused),
           dex->object,
           "map_list.map_item[%i].unused",
           i);
-      set_integer(
+      yr_set_integer(
           yr_le32toh(map_item->size),
           dex->object,
           "map_list.map_item[%i].size",
           i);
-      set_integer(
+      yr_set_integer(
           yr_le32toh(map_item->offset),
           dex->object,
           "map_list.map_item[%i].offset",
@@ -1182,42 +1182,42 @@ void dex_parse(DEX* dex, uint64_t base_address)
         yr_le32toh(class_id_item->static_values_offset));
 #endif
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->class_idx),
         dex->object,
         "class_defs[%i].class_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->access_flags),
         dex->object,
         "class_defs[%i].access_flags",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->super_class_idx),
         dex->object,
         "class_defs[%i].super_class_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->interfaces_offset),
         dex->object,
         "class_defs[%i].interfaces_offset",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->source_file_idx),
         dex->object,
         "class_defs[%i].source_file_idx",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->annotations_offset),
         dex->object,
         "class_defs[%i].annotations_offset",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->class_data_offset),
         dex->object,
         "class_defs[%i].class_data_offset",
         i);
-    set_integer(
+    yr_set_integer(
         yr_le32toh(class_id_item->static_values_offset),
         dex->object,
         "class_defs[%i].static_values_offset",
@@ -1254,25 +1254,25 @@ void dex_parse(DEX* dex, uint64_t base_address)
            uleb128_size),
           &uleb128_size);
 
-      set_integer(
+      yr_set_integer(
           class_data_item.static_fields_size,
           dex->object,
           "class_data_item[%i].static_fields_size",
           index_class_data_item);
 
-      set_integer(
+      yr_set_integer(
           class_data_item.instance_fields_size,
           dex->object,
           "class_data_item[%i].instance_fields_size",
           index_class_data_item);
 
-      set_integer(
+      yr_set_integer(
           class_data_item.direct_methods_size,
           dex->object,
           "class_data_item[%i].direct_methods_size",
           index_class_data_item);
 
-      set_integer(
+      yr_set_integer(
           class_data_item.virtual_methods_size,
           dex->object,
           "class_data_item[%i].virtual_methods_size",
@@ -1381,8 +1381,8 @@ void dex_parse(DEX* dex, uint64_t base_address)
     }
   }
 
-  set_integer(index_encoded_method, dex->object, "number_of_methods");
-  set_integer(index_encoded_field, dex->object, "number_of_fields");
+  yr_set_integer(index_encoded_method, dex->object, "number_of_methods");
+  yr_set_integer(index_encoded_field, dex->object, "number_of_fields");
 }
 
 
@@ -1409,56 +1409,56 @@ int module_load(
 
   dex_header_t* dex_header;
 
-  set_string(DEX_FILE_MAGIC_035, module_object, "DEX_FILE_MAGIC_035");
-  set_string(DEX_FILE_MAGIC_036, module_object, "DEX_FILE_MAGIC_036");
-  set_string(DEX_FILE_MAGIC_037, module_object, "DEX_FILE_MAGIC_037");
-  set_string(DEX_FILE_MAGIC_038, module_object, "DEX_FILE_MAGIC_038");
-  set_string(DEX_FILE_MAGIC_039, module_object, "DEX_FILE_MAGIC_039");
+  yr_set_string(DEX_FILE_MAGIC_035, module_object, "DEX_FILE_MAGIC_035");
+  yr_set_string(DEX_FILE_MAGIC_036, module_object, "DEX_FILE_MAGIC_036");
+  yr_set_string(DEX_FILE_MAGIC_037, module_object, "DEX_FILE_MAGIC_037");
+  yr_set_string(DEX_FILE_MAGIC_038, module_object, "DEX_FILE_MAGIC_038");
+  yr_set_string(DEX_FILE_MAGIC_039, module_object, "DEX_FILE_MAGIC_039");
 
-  set_integer(0x12345678, module_object, "ENDIAN_CONSTANT");
-  set_integer(0x78563412, module_object, "REVERSE_ENDIAN_CONSTANT");
+  yr_set_integer(0x12345678, module_object, "ENDIAN_CONSTANT");
+  yr_set_integer(0x78563412, module_object, "REVERSE_ENDIAN_CONSTANT");
 
-  set_integer(0xffffffff, module_object, "NO_INDEX");
-  set_integer(0x1, module_object, "ACC_PUBLIC");
-  set_integer(0x2, module_object, "ACC_PRIVATE");
-  set_integer(0x4, module_object, "ACC_PROTECTED");
-  set_integer(0x8, module_object, "ACC_STATIC");
-  set_integer(0x10, module_object, "ACC_FINAL");
-  set_integer(0x20, module_object, "ACC_SYNCHRONIZED");
-  set_integer(0x40, module_object, "ACC_VOLATILE");
-  set_integer(0x40, module_object, "ACC_BRIDGE");
-  set_integer(0x80, module_object, "ACC_TRANSIENT");
-  set_integer(0x80, module_object, "ACC_VARARGS");
-  set_integer(0x100, module_object, "ACC_NATIVE");
-  set_integer(0x200, module_object, "ACC_INTERFACE");
-  set_integer(0x400, module_object, "ACC_ABSTRACT");
-  set_integer(0x800, module_object, "ACC_STRICT");
-  set_integer(0x1000, module_object, "ACC_SYNTHETIC");
-  set_integer(0x2000, module_object, "ACC_ANNOTATION");
-  set_integer(0x4000, module_object, "ACC_ENUM");
-  set_integer(0x10000, module_object, "ACC_CONSTRUCTOR");
-  set_integer(0x20000, module_object, "ACC_DECLARED_SYNCHRONIZED");
+  yr_set_integer(0xffffffff, module_object, "NO_INDEX");
+  yr_set_integer(0x1, module_object, "ACC_PUBLIC");
+  yr_set_integer(0x2, module_object, "ACC_PRIVATE");
+  yr_set_integer(0x4, module_object, "ACC_PROTECTED");
+  yr_set_integer(0x8, module_object, "ACC_STATIC");
+  yr_set_integer(0x10, module_object, "ACC_FINAL");
+  yr_set_integer(0x20, module_object, "ACC_SYNCHRONIZED");
+  yr_set_integer(0x40, module_object, "ACC_VOLATILE");
+  yr_set_integer(0x40, module_object, "ACC_BRIDGE");
+  yr_set_integer(0x80, module_object, "ACC_TRANSIENT");
+  yr_set_integer(0x80, module_object, "ACC_VARARGS");
+  yr_set_integer(0x100, module_object, "ACC_NATIVE");
+  yr_set_integer(0x200, module_object, "ACC_INTERFACE");
+  yr_set_integer(0x400, module_object, "ACC_ABSTRACT");
+  yr_set_integer(0x800, module_object, "ACC_STRICT");
+  yr_set_integer(0x1000, module_object, "ACC_SYNTHETIC");
+  yr_set_integer(0x2000, module_object, "ACC_ANNOTATION");
+  yr_set_integer(0x4000, module_object, "ACC_ENUM");
+  yr_set_integer(0x10000, module_object, "ACC_CONSTRUCTOR");
+  yr_set_integer(0x20000, module_object, "ACC_DECLARED_SYNCHRONIZED");
 
-  set_integer(0x0000, module_object, "TYPE_HEADER_ITEM");
-  set_integer(0x0001, module_object, "TYPE_STRING_ID_ITEM");
-  set_integer(0x0002, module_object, "TYPE_TYPE_ID_ITEM");
-  set_integer(0x0003, module_object, "TYPE_PROTO_ID_ITEM");
-  set_integer(0x0004, module_object, "TYPE_FIELD_ID_ITEM");
-  set_integer(0x0005, module_object, "TYPE_METHOD_ID_ITEM");
-  set_integer(0x0006, module_object, "TYPE_CLASS_DEF_ITEM");
-  set_integer(0x0007, module_object, "TYPE_CALL_SITE_ID_ITEM");
-  set_integer(0x0008, module_object, "TYPE_METHOD_HANDLE_ITEM");
-  set_integer(0x1000, module_object, "TYPE_MAP_LIST");
-  set_integer(0x1001, module_object, "TYPE_TYPE_LIST");
-  set_integer(0x1002, module_object, "TYPE_ANNOTATION_SET_REF_LIST");
-  set_integer(0x1003, module_object, "TYPE_ANNOTATION_SET_ITEM");
-  set_integer(0x2000, module_object, "TYPE_CLASS_DATA_ITEM");
-  set_integer(0x2001, module_object, "TYPE_CODE_ITEM");
-  set_integer(0x2002, module_object, "TYPE_STRING_DATA_ITEM");
-  set_integer(0x2003, module_object, "TYPE_DEBUG_INFO_ITEM");
-  set_integer(0x2004, module_object, "TYPE_ANNOTATION_ITEM");
-  set_integer(0x2005, module_object, "TYPE_ENCODED_ARRAY_ITEM");
-  set_integer(0x2006, module_object, "TYPE_ANNOTATIONS_DIRECTORY_ITEM");
+  yr_set_integer(0x0000, module_object, "TYPE_HEADER_ITEM");
+  yr_set_integer(0x0001, module_object, "TYPE_STRING_ID_ITEM");
+  yr_set_integer(0x0002, module_object, "TYPE_TYPE_ID_ITEM");
+  yr_set_integer(0x0003, module_object, "TYPE_PROTO_ID_ITEM");
+  yr_set_integer(0x0004, module_object, "TYPE_FIELD_ID_ITEM");
+  yr_set_integer(0x0005, module_object, "TYPE_METHOD_ID_ITEM");
+  yr_set_integer(0x0006, module_object, "TYPE_CLASS_DEF_ITEM");
+  yr_set_integer(0x0007, module_object, "TYPE_CALL_SITE_ID_ITEM");
+  yr_set_integer(0x0008, module_object, "TYPE_METHOD_HANDLE_ITEM");
+  yr_set_integer(0x1000, module_object, "TYPE_MAP_LIST");
+  yr_set_integer(0x1001, module_object, "TYPE_TYPE_LIST");
+  yr_set_integer(0x1002, module_object, "TYPE_ANNOTATION_SET_REF_LIST");
+  yr_set_integer(0x1003, module_object, "TYPE_ANNOTATION_SET_ITEM");
+  yr_set_integer(0x2000, module_object, "TYPE_CLASS_DATA_ITEM");
+  yr_set_integer(0x2001, module_object, "TYPE_CODE_ITEM");
+  yr_set_integer(0x2002, module_object, "TYPE_STRING_DATA_ITEM");
+  yr_set_integer(0x2003, module_object, "TYPE_DEBUG_INFO_ITEM");
+  yr_set_integer(0x2004, module_object, "TYPE_ANNOTATION_ITEM");
+  yr_set_integer(0x2005, module_object, "TYPE_ENCODED_ARRAY_ITEM");
+  yr_set_integer(0x2006, module_object, "TYPE_ANNOTATIONS_DIRECTORY_ITEM");
 
   foreach_memory_block(iterator, block)
   {

--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -1095,7 +1095,7 @@ static void parse_type_parents(
   uint32_t base_type_idx = 0;
   if (parent)
   {
-    set_string(
+    yr_set_string(
         parent,
         ctx->pe->object,
         "classes[%i].base_types[%i]",
@@ -1124,7 +1124,7 @@ static void parse_type_parents(
           ctx, row.Interface, class_gen_params, NULL);
       if (inteface)
       {
-        set_string(
+        yr_set_string(
             inteface,
             ctx->pe->object,
             "classes[%i].base_types[%i]",
@@ -1135,7 +1135,7 @@ static void parse_type_parents(
       }
     }
   }
-  set_integer(
+  yr_set_integer(
       base_type_idx,
       ctx->pe->object,
       "classes[%i].number_of_base_types",
@@ -1227,7 +1227,7 @@ static bool parse_method_params(
 
   // If we got all of them correctly, write to output and cleanup
   YR_OBJECT* out_obj = ctx->pe->object;
-  set_integer(
+  yr_set_integer(
       param_count,
       out_obj,
       "classes[%i].methods[%i].number_of_parameters",
@@ -1236,14 +1236,14 @@ static bool parse_method_params(
 
   for (uint32_t i = 0; i < param_count; ++i)
   {
-    set_string(
+    yr_set_string(
         params[i].name,
         out_obj,
         "classes[%i].methods[%i].parameters[%i].name",
         class_idx,
         method_idx,
         i);
-    set_string(
+    yr_set_string(
         params[i].type,
         out_obj,
         "classes[%i].methods[%i].parameters[%i].type",
@@ -1403,31 +1403,31 @@ static void parse_methods(
     uint32_t abstract = (row.Flags & METHOD_ATTR_ABSTRACT) != 0;
 
     YR_OBJECT* out_obj = ctx->pe->object;
-    set_string(
+    yr_set_string(
         name, out_obj, "classes[%i].methods[%i].name", class_idx, out_idx);
-    set_string(
+    yr_set_string(
         visibility,
         out_obj,
         "classes[%i].methods[%i].visibility",
         class_idx,
         out_idx);
-    set_integer(
+    yr_set_integer(
         stat, out_obj, "classes[%i].methods[%i].static", class_idx, out_idx);
-    set_integer(
+    yr_set_integer(
         virtual,
         out_obj,
         "classes[%i].methods[%i].virtual",
         class_idx,
         out_idx);
-    set_integer(
+    yr_set_integer(
         final, out_obj, "classes[%i].methods[%i].final", class_idx, out_idx);
-    set_integer(
+    yr_set_integer(
         abstract,
         out_obj,
         "classes[%i].methods[%i].abstract",
         class_idx,
         out_idx);
-    set_integer(
+    yr_set_integer(
         method_gen_params.len,
         out_obj,
         "classes[%i].methods[%i].number_of_generic_parameters",
@@ -1436,7 +1436,7 @@ static void parse_methods(
 
     for (uint32_t i = 0; i < method_gen_params.len; ++i)
     {
-      set_string(
+      yr_set_string(
           method_gen_params.names[i],
           ctx->pe->object,
           "classes[%i].methods[%i].generic_parameters[%i]",
@@ -1448,7 +1448,7 @@ static void parse_methods(
     // Unset return type for constructors for FileInfo compatibility
     if (strcmp(name, ".ctor") != 0 && strcmp(name, ".cctor") != 0)
     {
-      set_string(
+      yr_set_string(
           return_type,
           out_obj,
           "classes[%i].methods[%i].return_type",
@@ -1462,7 +1462,7 @@ static void parse_methods(
     yr_free(method_gen_params.names);
   }
 
-  set_integer(
+  yr_set_integer(
       out_idx, ctx->pe->object, "classes[%i].number_of_methods", class_idx);
 }
 
@@ -1568,9 +1568,9 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
       continue;
 
     if (end)
-      set_sized_string(name, end - name, out_obj, "classes[%i].name", out_idx);
+      yr_set_sized_string(name, end - name, out_obj, "classes[%i].name", out_idx);
     else
-      set_string(name, out_obj, "classes[%i].name", out_idx);
+      yr_set_string(name, out_obj, "classes[%i].name", out_idx);
 
     char* fullname = NULL;
     char* namespace = pe_get_dotnet_string(
@@ -1581,14 +1581,14 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
     {
       char* nested_namespace = parse_enclosing_types(ctx, idx + 1, 1);
       namespace = create_full_name(namespace, nested_namespace);
-      set_string(namespace, out_obj, "classes[%i].namespace", out_idx);
+      yr_set_string(namespace, out_obj, "classes[%i].namespace", out_idx);
       fullname = create_full_name(name, namespace);
       yr_free(nested_namespace);
       yr_free(namespace);
     }
     else
     {
-      set_string(namespace, out_obj, "classes[%i].namespace", out_idx);
+      yr_set_string(namespace, out_obj, "classes[%i].namespace", out_idx);
       fullname = create_full_name(name, namespace);
     }
 
@@ -1596,11 +1596,11 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
     uint32_t abstract = (row.Flags & TYPE_ATTR_ABSTRACT) != 0;
     uint32_t sealed = (row.Flags & TYPE_ATTR_SEALED) != 0;
 
-    set_string(fullname, out_obj, "classes[%i].fullname", out_idx);
-    set_string(visibility, out_obj, "classes[%i].visibility", out_idx);
-    set_string(type, out_obj, "classes[%i].type", out_idx);
-    set_integer(abstract, out_obj, "classes[%i].abstract", out_idx);
-    set_integer(sealed, out_obj, "classes[%i].sealed", out_idx);
+    yr_set_string(fullname, out_obj, "classes[%i].fullname", out_idx);
+    yr_set_string(visibility, out_obj, "classes[%i].visibility", out_idx);
+    yr_set_string(type, out_obj, "classes[%i].type", out_idx);
+    yr_set_integer(abstract, out_obj, "classes[%i].abstract", out_idx);
+    yr_set_integer(sealed, out_obj, "classes[%i].sealed", out_idx);
 
     yr_free(fullname);
 
@@ -1608,7 +1608,7 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
     GENERIC_PARAMETERS gen_params = {0};
     parse_generic_params(ctx, false, idx + 1, &gen_params);
 
-    set_integer(
+    yr_set_integer(
         gen_params.len,
         out_obj,
         "classes[%i].number_of_generic_parameters",
@@ -1616,7 +1616,7 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
 
     for (uint32_t i = 0; i < gen_params.len; ++i)
     {
-      set_string(
+      yr_set_string(
           gen_params.names[i],
           out_obj,
           "classes[%i].generic_parameters[%i]",
@@ -1657,7 +1657,7 @@ static void parse_user_types(const CLASS_CONTEXT* ctx)
     out_idx++;
   }
 
-  set_integer(out_idx, ctx->pe->object, "number_of_classes");
+  yr_set_integer(out_idx, ctx->pe->object, "number_of_classes");
 }
 
 void dotnet_parse_guid(
@@ -1697,14 +1697,14 @@ void dotnet_parse_guid(
 
     guid[(16 * 2) + 4] = '\0';
 
-    set_string(guid, pe->object, "guids[%i]", i);
+    yr_set_string(guid, pe->object, "guids[%i]", i);
 
     i++;
     guid_size -= 16;
     guid_offset += 16;
   }
 
-  set_integer(i, pe->object, "number_of_guids");
+  yr_set_integer(i, pe->object, "number_of_guids");
 }
 
 void dotnet_parse_us(PE* pe, int64_t metadata_root, PSTREAM_HEADER us_header)
@@ -1748,7 +1748,7 @@ void dotnet_parse_us(PE* pe, int64_t metadata_root, PSTREAM_HEADER us_header)
     // stream.
     if (blob_result.length > 0 && fits_in_pe(pe, offset, blob_result.length))
     {
-      set_sized_string(
+      yr_set_sized_string(
           (char*) offset,
           blob_result.length,
           pe->object,
@@ -1760,7 +1760,7 @@ void dotnet_parse_us(PE* pe, int64_t metadata_root, PSTREAM_HEADER us_header)
     }
   }
 
-  set_integer(i, pe->object, "number_of_user_strings");
+  yr_set_integer(i, pe->object, "number_of_user_strings");
 }
 
 STREAMS dotnet_parse_stream_headers(
@@ -1800,16 +1800,16 @@ STREAMS dotnet_parse_stream_headers(
     strncpy(stream_name, stream_header->Name, DOTNET_STREAM_NAME_SIZE);
     stream_name[DOTNET_STREAM_NAME_SIZE] = '\0';
 
-    set_string(stream_name, pe->object, "streams[%i].name", i);
+    yr_set_string(stream_name, pe->object, "streams[%i].name", i);
 
     // Offset is relative to metadata_root.
-    set_integer(
+    yr_set_integer(
         metadata_root + yr_le32toh(stream_header->Offset),
         pe->object,
         "streams[%i].offset",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(stream_header->Size), pe->object, "streams[%i].size", i);
 
     // Store necessary bits to parse these later. Not all tables will be
@@ -1839,7 +1839,7 @@ STREAMS dotnet_parse_stream_headers(
         (PSTREAM_HEADER) ((uint8_t*) stream_header + sizeof(STREAM_HEADER) + strlen(stream_name) + 4 - (strlen(stream_name) % 4));
   }
 
-  set_integer(i, pe->object, "number_of_streams");
+  yr_set_integer(i, pe->object, "number_of_streams");
 
   return headers;
 }
@@ -2002,7 +2002,7 @@ void dotnet_parse_tilde_2(
           DOTNET_STRING_INDEX(module_table->Name));
 
       if (name != NULL)
-        set_string(name, pe->object, "module_name");
+        yr_set_string(name, pe->object, "module_name");
 
       row_size = 2 + index_sizes.string + (index_sizes.guid * 3);
 
@@ -2197,7 +2197,7 @@ void dotnet_parse_tilde_2(
           continue;
         }
 
-        set_sized_string(
+        yr_set_sized_string(
             (char*) blob_offset,
             blob_result.length,
             pe->object,
@@ -2208,7 +2208,7 @@ void dotnet_parse_tilde_2(
         row_ptr += row_size;
       }
 
-      set_integer(counter, pe->object, "number_of_constants");
+      yr_set_integer(counter, pe->object, "number_of_constants");
       table_offset += row_size * num_rows;
       break;
 
@@ -2474,7 +2474,7 @@ void dotnet_parse_tilde_2(
             typelib[str_len] = '\0';
           }
 
-          set_string(typelib, pe->object, "typelib");
+          yr_set_string(typelib, pe->object, "typelib");
 
           row_ptr += row_size;
         }
@@ -2604,14 +2604,14 @@ void dotnet_parse_tilde_2(
 
         if (name != NULL)
         {
-          set_string(name, pe->object, "modulerefs[%i]", counter);
+          yr_set_string(name, pe->object, "modulerefs[%i]", counter);
           counter++;
         }
 
         row_ptr += index_sizes.string;
       }
 
-      set_integer(counter, pe->object, "number_of_modulerefs");
+      yr_set_integer(counter, pe->object, "number_of_modulerefs");
 
       row_size = index_sizes.string;
 
@@ -2665,14 +2665,14 @@ void dotnet_parse_tilde_2(
 
         if (field_offset >= 0)
         {
-          set_integer(field_offset, pe->object, "field_offsets[%i]", counter);
+          yr_set_integer(field_offset, pe->object, "field_offsets[%i]", counter);
           counter++;
         }
 
         row_ptr += row_size;
       }
 
-      set_integer(counter, pe->object, "number_of_field_offsets");
+      yr_set_integer(counter, pe->object, "number_of_field_offsets");
 
       table_offset += row_size * num_rows;
       break;
@@ -2695,19 +2695,19 @@ void dotnet_parse_tilde_2(
       row_ptr = table_offset;
       assembly_table = (PASSEMBLY_TABLE) table_offset;
 
-      set_integer(
+      yr_set_integer(
           yr_le16toh(assembly_table->MajorVersion),
           pe->object,
           "assembly.version.major");
-      set_integer(
+      yr_set_integer(
           yr_le16toh(assembly_table->MinorVersion),
           pe->object,
           "assembly.version.minor");
-      set_integer(
+      yr_set_integer(
           yr_le16toh(assembly_table->BuildNumber),
           pe->object,
           "assembly.version.build_number");
-      set_integer(
+      yr_set_integer(
           yr_le16toh(assembly_table->RevisionNumber),
           pe->object,
           "assembly.version.revision_number");
@@ -2731,7 +2731,7 @@ void dotnet_parse_tilde_2(
                 *(WORD*) (row_ptr + 4 + 2 + 2 + 2 + 2 + 4 + index_sizes.blob)));
 
       if (name != NULL)
-        set_string(name, pe->object, "assembly.name");
+        yr_set_string(name, pe->object, "assembly.name");
 
       // Culture comes after Name.
       if (index_sizes.string == 4)
@@ -2758,7 +2758,7 @@ void dotnet_parse_tilde_2(
       // Sometimes it will be a zero length string. This is technically
       // against the specification but happens from time to time.
       if (name != NULL && strlen(name) > 0)
-        set_string(name, pe->object, "assembly.culture");
+        yr_set_string(name, pe->object, "assembly.culture");
 
       table_offset += row_size * num_rows;
       break;
@@ -2785,22 +2785,22 @@ void dotnet_parse_tilde_2(
 
         assemblyref_table = (PASSEMBLYREF_TABLE) row_ptr;
 
-        set_integer(
+        yr_set_integer(
             yr_le16toh(assemblyref_table->MajorVersion),
             pe->object,
             "assembly_refs[%i].version.major",
             i);
-        set_integer(
+        yr_set_integer(
             yr_le16toh(assemblyref_table->MinorVersion),
             pe->object,
             "assembly_refs[%i].version.minor",
             i);
-        set_integer(
+        yr_set_integer(
             yr_le16toh(assemblyref_table->BuildNumber),
             pe->object,
             "assembly_refs[%i].version.build_number",
             i);
-        set_integer(
+        yr_set_integer(
             yr_le16toh(assemblyref_table->RevisionNumber),
             pe->object,
             "assembly_refs[%i].version.revision_number",
@@ -2829,7 +2829,7 @@ void dotnet_parse_tilde_2(
         // Avoid empty strings.
         if (blob_result.length > 0)
         {
-          set_sized_string(
+          yr_set_sized_string(
               (char*) blob_offset,
               blob_result.length,
               pe->object,
@@ -2856,7 +2856,7 @@ void dotnet_parse_tilde_2(
                   *(WORD*) (row_ptr + 2 + 2 + 2 + 2 + 4 + index_sizes.blob)));
 
         if (name != NULL)
-          set_string(name, pe->object, "assembly_refs[%i].name", i);
+          yr_set_string(name, pe->object, "assembly_refs[%i].name", i);
 
         row_ptr += row_size;
       }
@@ -2865,7 +2865,7 @@ void dotnet_parse_tilde_2(
       tables.assemblyref.RowCount = num_rows;
       tables.assemblyref.RowSize = row_size;
 
-      set_integer(i, pe->object, "number_of_assembly_refs");
+      yr_set_integer(i, pe->object, "number_of_assembly_refs");
       table_offset += row_size * num_rows;
       break;
 
@@ -2957,13 +2957,13 @@ void dotnet_parse_tilde_2(
         }
 
         // Add 4 to skip the size.
-        set_integer(
+        yr_set_integer(
             resource_base + resource_offset + 4,
             pe->object,
             "resources[%i].offset",
             counter);
 
-        set_integer(resource_size, pe->object, "resources[%i].length", counter);
+        yr_set_integer(resource_size, pe->object, "resources[%i].length", counter);
 
         name = pe_get_dotnet_string(
             pe,
@@ -2972,13 +2972,13 @@ void dotnet_parse_tilde_2(
             DOTNET_STRING_INDEX(manifestresource_table->Name));
 
         if (name != NULL)
-          set_string(name, pe->object, "resources[%i].name", counter);
+          yr_set_string(name, pe->object, "resources[%i].name", counter);
 
         row_ptr += row_size;
         counter++;
       }
 
-      set_integer(counter, pe->object, "number_of_resources");
+      yr_set_integer(counter, pe->object, "number_of_resources");
 
       table_offset += row_size * num_rows;
       break;
@@ -3292,11 +3292,11 @@ void dotnet_parse_com(PE* pe)
 
   if (!dotnet_is_dotnet(pe))
   {
-    set_integer(0, pe->object, "is_dotnet");
+    yr_set_integer(0, pe->object, "is_dotnet");
     return;
   }
 
-  set_integer(1, pe->object, "is_dotnet");
+  yr_set_integer(1, pe->object, "is_dotnet");
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR);
   if (directory == NULL)
@@ -3333,7 +3333,7 @@ void dotnet_parse_com(PE* pe)
   end = (char*) memmem((void*) metadata->Version, md_len, "\0", 1);
 
   if (end != NULL)
-    set_sized_string(
+    yr_set_sized_string(
         metadata->Version, (end - metadata->Version), pe->object, "version");
 
   // The metadata structure has some variable length records after the version.

--- a/libyara/modules/elf/elf.c
+++ b/libyara/modules/elf/elf.c
@@ -51,7 +51,7 @@ static int sort_strcmp(const void* a, const void* b)
 
 define_function(telfhash)
 {
-  YR_OBJECT* obj = module();
+  YR_OBJECT* obj = yr_module();
   ELF* elf = (ELF*) obj->data;
   if (elf == NULL)
     return_string(YR_UNDEFINED);
@@ -186,7 +186,7 @@ cleanup:
 
 define_function(import_md5)
 {
-  YR_OBJECT* obj = module();
+  YR_OBJECT* obj = yr_module();
   ELF* elf = (ELF*) obj->data;
   if (elf == NULL)
     return_string(YR_UNDEFINED);
@@ -474,20 +474,20 @@ static const char* str_table_entry(
     elf##bits##_section_header_t* section;                                                \
     elf##bits##_program_header_t* segment;                                                \
                                                                                           \
-    set_integer(yr_##bo##16toh(elf->type), elf_obj, "type");                              \
-    set_integer(yr_##bo##16toh(elf->machine), elf_obj, "machine");                        \
-    set_integer(yr_##bo##bits##toh(elf->sh_offset), elf_obj, "sh_offset");                \
-    set_integer(yr_##bo##16toh(elf->sh_entry_size), elf_obj, "sh_entry_size");            \
-    set_integer(                                                                          \
+    yr_set_integer(yr_##bo##16toh(elf->type), elf_obj, "type");                              \
+    yr_set_integer(yr_##bo##16toh(elf->machine), elf_obj, "machine");                        \
+    yr_set_integer(yr_##bo##bits##toh(elf->sh_offset), elf_obj, "sh_offset");                \
+    yr_set_integer(yr_##bo##16toh(elf->sh_entry_size), elf_obj, "sh_entry_size");            \
+    yr_set_integer(                                                                          \
         yr_##bo##16toh(elf->sh_entry_count), elf_obj, "number_of_sections");              \
-    set_integer(yr_##bo##bits##toh(elf->ph_offset), elf_obj, "ph_offset");                \
-    set_integer(yr_##bo##16toh(elf->ph_entry_size), elf_obj, "ph_entry_size");            \
-    set_integer(                                                                          \
+    yr_set_integer(yr_##bo##bits##toh(elf->ph_offset), elf_obj, "ph_offset");                \
+    yr_set_integer(yr_##bo##16toh(elf->ph_entry_size), elf_obj, "ph_entry_size");            \
+    yr_set_integer(                                                                          \
         yr_##bo##16toh(elf->ph_entry_count), elf_obj, "number_of_segments");              \
                                                                                           \
     if (yr_##bo##bits##toh(elf->entry) != 0)                                              \
     {                                                                                     \
-      set_integer(                                                                        \
+      yr_set_integer(                                                                        \
           flags& SCAN_FLAGS_PROCESS_MEMORY                                                \
               ? base_address + yr_##bo##bits##toh(elf->entry)                             \
               : elf_rva_to_offset_##bits##_##bo(                                          \
@@ -520,24 +520,24 @@ static const char* str_table_entry(
                                                                                           \
       for (i = 0; i < yr_##bo##16toh(elf->sh_entry_count); i++, section++)                \
       {                                                                                   \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##32toh(section->type), elf_obj, "sections[%i].type", i);              \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(section->flags),                                           \
             elf_obj,                                                                      \
             "sections[%i].flags",                                                         \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(section->addr),                                            \
             elf_obj,                                                                      \
             "sections[%i].address",                                                       \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(section->size),                                            \
             elf_obj,                                                                      \
             "sections[%i].size",                                                          \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(section->offset),                                          \
             elf_obj,                                                                      \
             "sections[%i].offset",                                                        \
@@ -549,7 +549,7 @@ static const char* str_table_entry(
               str_table, elf_raw + elf_size, yr_##bo##32toh(section->name));              \
                                                                                           \
           if (section_name)                                                               \
-            set_string(section_name, elf_obj, "sections[%i].name", i);                    \
+            yr_set_string(section_name, elf_obj, "sections[%i].name", i);                    \
         }                                                                                 \
                                                                                           \
         if (yr_##bo##32toh(section->type) == ELF_SHT_SYMTAB &&                            \
@@ -619,7 +619,7 @@ static const char* str_table_entry(
                                                                                           \
           if (sym_name)                                                                   \
           {                                                                               \
-            set_string(sym_name, elf_obj, "symtab[%i].name", j);                          \
+            yr_set_string(sym_name, elf_obj, "symtab[%i].name", j);                          \
             (*symbol)->name = (char*) yr_malloc(strlen(sym_name) + 1);                    \
             if ((*symbol)->name == NULL)                                                  \
               return ERROR_INSUFFICIENT_MEMORY;                                           \
@@ -629,24 +629,24 @@ static const char* str_table_entry(
                                                                                           \
           int bind = sym->info >> 4;                                                      \
           (*symbol)->bind = bind;                                                         \
-          set_integer(bind, elf_obj, "symtab[%i].bind", j);                               \
+          yr_set_integer(bind, elf_obj, "symtab[%i].bind", j);                               \
                                                                                           \
           int type = sym->info & 0xf;                                                     \
           (*symbol)->type = type;                                                         \
-          set_integer(type, elf_obj, "symtab[%i].type", j);                               \
+          yr_set_integer(type, elf_obj, "symtab[%i].type", j);                               \
                                                                                           \
           int shndx = yr_##bo##16toh(sym->shndx);                                         \
           (*symbol)->shndx = shndx;                                                       \
-          set_integer(shndx, elf_obj, "symtab[%i].shndx", j);                             \
+          yr_set_integer(shndx, elf_obj, "symtab[%i].shndx", j);                             \
                                                                                           \
           int value = yr_##bo##bits##toh(sym->value);                                     \
           (*symbol)->value = value;                                                       \
-          set_integer(                                                                    \
+          yr_set_integer(                                                                    \
               yr_##bo##bits##toh(sym->value), elf_obj, "symtab[%i].value", j);            \
                                                                                           \
           int size = yr_##bo##bits##toh(sym->size);                                       \
           (*symbol)->size = size;                                                         \
-          set_integer(                                                                    \
+          yr_set_integer(                                                                    \
               yr_##bo##bits##toh(sym->size), elf_obj, "symtab[%i].size", j);              \
                                                                                           \
           int other = yr_##bo##bits##toh(sym->other);                                     \
@@ -656,7 +656,7 @@ static const char* str_table_entry(
         }                                                                                 \
                                                                                           \
         elf_data->symtab->count = j;                                                      \
-        set_integer(j, elf_obj, "symtab_entries");                                        \
+        yr_set_integer(j, elf_obj, "symtab_entries");                                        \
       }                                                                                   \
                                                                                           \
       if (is_valid_ptr(                                                                   \
@@ -691,7 +691,7 @@ static const char* str_table_entry(
                                                                                           \
           if (dynsym_name)                                                                \
           {                                                                               \
-            set_string(dynsym_name, elf_obj, "dynsym[%i].name", m);                       \
+            yr_set_string(dynsym_name, elf_obj, "dynsym[%i].name", m);                       \
             (*symbol)->name = (char*) yr_malloc(strlen(dynsym_name) + 1);                 \
             if ((*symbol)->name == NULL)                                                  \
               return ERROR_INSUFFICIENT_MEMORY;                                           \
@@ -701,20 +701,20 @@ static const char* str_table_entry(
                                                                                           \
           int bind = dynsym->info >> 4;                                                   \
           (*symbol)->bind = bind;                                                         \
-          set_integer(dynsym->info >> 4, elf_obj, "dynsym[%i].bind", m);                  \
+          yr_set_integer(dynsym->info >> 4, elf_obj, "dynsym[%i].bind", m);                  \
                                                                                           \
           int type = dynsym->info & 0xf;                                                  \
           (*symbol)->type = type;                                                         \
-          set_integer(dynsym->info & 0xf, elf_obj, "dynsym[%i].type", m);                 \
+          yr_set_integer(dynsym->info & 0xf, elf_obj, "dynsym[%i].type", m);                 \
                                                                                           \
           int shndx = yr_##bo##16toh(dynsym->shndx);                                      \
           (*symbol)->shndx = shndx;                                                       \
-          set_integer(                                                                    \
+          yr_set_integer(                                                                    \
               yr_##bo##16toh(dynsym->shndx), elf_obj, "dynsym[%i].shndx", m);             \
                                                                                           \
           int value = yr_##bo##bits##toh(dynsym->value);                                  \
           (*symbol)->value = value;                                                       \
-          set_integer(                                                                    \
+          yr_set_integer(                                                                    \
               yr_##bo##bits##toh(dynsym->value),                                          \
               elf_obj,                                                                    \
               "dynsym[%i].value",                                                         \
@@ -722,7 +722,7 @@ static const char* str_table_entry(
                                                                                           \
           int size = yr_##bo##bits##toh(dynsym->size);                                    \
           (*symbol)->size = size;                                                         \
-          set_integer(                                                                    \
+          yr_set_integer(                                                                    \
               yr_##bo##bits##toh(dynsym->size),                                           \
               elf_obj,                                                                    \
               "dynsym[%i].size",                                                          \
@@ -735,7 +735,7 @@ static const char* str_table_entry(
         }                                                                                 \
                                                                                           \
         elf_data->dynsym->count = m;                                                      \
-        set_integer(m, elf_obj, "dynsym_entries");                                        \
+        yr_set_integer(m, elf_obj, "dynsym_entries");                                        \
       }                                                                                   \
     }                                                                                     \
                                                                                           \
@@ -752,36 +752,36 @@ static const char* str_table_entry(
                                                                                           \
       for (i = 0; i < yr_##bo##16toh(elf->ph_entry_count); i++, segment++)                \
       {                                                                                   \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##32toh(segment->type), elf_obj, "segments[%i].type", i);              \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##32toh(segment->flags), elf_obj, "segments[%i].flags", i);            \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->offset),                                          \
             elf_obj,                                                                      \
             "segments[%i].offset",                                                        \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->virt_addr),                                       \
             elf_obj,                                                                      \
             "segments[%i].virtual_address",                                               \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->phys_addr),                                       \
             elf_obj,                                                                      \
             "segments[%i].physical_address",                                              \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->file_size),                                       \
             elf_obj,                                                                      \
             "segments[%i].file_size",                                                     \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->mem_size),                                        \
             elf_obj,                                                                      \
             "segments[%i].memory_size",                                                   \
             i);                                                                           \
-        set_integer(                                                                      \
+        yr_set_integer(                                                                      \
             yr_##bo##bits##toh(segment->alignment),                                       \
             elf_obj,                                                                      \
             "segments[%i].alignment",                                                     \
@@ -794,9 +794,9 @@ static const char* str_table_entry(
                                                                                           \
           for (j = 0; IS_VALID_PTR(elf, elf_size, dyn); dyn++, j++)                       \
           {                                                                               \
-            set_integer(                                                                  \
+            yr_set_integer(                                                                  \
                 yr_##bo##bits##toh(dyn->tag), elf_obj, "dynamic[%i].type", j);            \
-            set_integer(                                                                  \
+            yr_set_integer(                                                                  \
                 yr_##bo##bits##toh(dyn->val), elf_obj, "dynamic[%i].val", j);             \
                                                                                           \
             if (dyn->tag == ELF_DT_NULL)                                                  \
@@ -805,7 +805,7 @@ static const char* str_table_entry(
               break;                                                                      \
             }                                                                             \
           }                                                                               \
-          set_integer(j, elf_obj, "dynamic_section_entries");                             \
+          yr_set_integer(j, elf_obj, "dynamic_section_entries");                             \
         }                                                                                 \
       }                                                                                   \
     }                                                                                     \
@@ -1010,103 +1010,103 @@ int module_load(
   elf32_header_t* elf_header32;
   elf64_header_t* elf_header64;
 
-  set_integer(ELF_ET_NONE, module_object, "ET_NONE");
-  set_integer(ELF_ET_REL, module_object, "ET_REL");
-  set_integer(ELF_ET_EXEC, module_object, "ET_EXEC");
-  set_integer(ELF_ET_DYN, module_object, "ET_DYN");
-  set_integer(ELF_ET_CORE, module_object, "ET_CORE");
+  yr_set_integer(ELF_ET_NONE, module_object, "ET_NONE");
+  yr_set_integer(ELF_ET_REL, module_object, "ET_REL");
+  yr_set_integer(ELF_ET_EXEC, module_object, "ET_EXEC");
+  yr_set_integer(ELF_ET_DYN, module_object, "ET_DYN");
+  yr_set_integer(ELF_ET_CORE, module_object, "ET_CORE");
 
-  set_integer(ELF_EM_NONE, module_object, "EM_NONE");
-  set_integer(ELF_EM_M32, module_object, "EM_M32");
-  set_integer(ELF_EM_SPARC, module_object, "EM_SPARC");
-  set_integer(ELF_EM_386, module_object, "EM_386");
-  set_integer(ELF_EM_68K, module_object, "EM_68K");
-  set_integer(ELF_EM_88K, module_object, "EM_88K");
-  set_integer(ELF_EM_860, module_object, "EM_860");
-  set_integer(ELF_EM_MIPS, module_object, "EM_MIPS");
-  set_integer(ELF_EM_MIPS_RS3_LE, module_object, "EM_MIPS_RS3_LE");
-  set_integer(ELF_EM_PPC, module_object, "EM_PPC");
-  set_integer(ELF_EM_PPC64, module_object, "EM_PPC64");
-  set_integer(ELF_EM_ARM, module_object, "EM_ARM");
-  set_integer(ELF_EM_X86_64, module_object, "EM_X86_64");
-  set_integer(ELF_EM_AARCH64, module_object, "EM_AARCH64");
+  yr_set_integer(ELF_EM_NONE, module_object, "EM_NONE");
+  yr_set_integer(ELF_EM_M32, module_object, "EM_M32");
+  yr_set_integer(ELF_EM_SPARC, module_object, "EM_SPARC");
+  yr_set_integer(ELF_EM_386, module_object, "EM_386");
+  yr_set_integer(ELF_EM_68K, module_object, "EM_68K");
+  yr_set_integer(ELF_EM_88K, module_object, "EM_88K");
+  yr_set_integer(ELF_EM_860, module_object, "EM_860");
+  yr_set_integer(ELF_EM_MIPS, module_object, "EM_MIPS");
+  yr_set_integer(ELF_EM_MIPS_RS3_LE, module_object, "EM_MIPS_RS3_LE");
+  yr_set_integer(ELF_EM_PPC, module_object, "EM_PPC");
+  yr_set_integer(ELF_EM_PPC64, module_object, "EM_PPC64");
+  yr_set_integer(ELF_EM_ARM, module_object, "EM_ARM");
+  yr_set_integer(ELF_EM_X86_64, module_object, "EM_X86_64");
+  yr_set_integer(ELF_EM_AARCH64, module_object, "EM_AARCH64");
 
-  set_integer(ELF_SHT_NULL, module_object, "SHT_NULL");
-  set_integer(ELF_SHT_PROGBITS, module_object, "SHT_PROGBITS");
-  set_integer(ELF_SHT_SYMTAB, module_object, "SHT_SYMTAB");
-  set_integer(ELF_SHT_STRTAB, module_object, "SHT_STRTAB");
-  set_integer(ELF_SHT_RELA, module_object, "SHT_RELA");
-  set_integer(ELF_SHT_HASH, module_object, "SHT_HASH");
-  set_integer(ELF_SHT_DYNAMIC, module_object, "SHT_DYNAMIC");
-  set_integer(ELF_SHT_NOTE, module_object, "SHT_NOTE");
-  set_integer(ELF_SHT_NOBITS, module_object, "SHT_NOBITS");
-  set_integer(ELF_SHT_REL, module_object, "SHT_REL");
-  set_integer(ELF_SHT_SHLIB, module_object, "SHT_SHLIB");
-  set_integer(ELF_SHT_DYNSYM, module_object, "SHT_DYNSYM");
+  yr_set_integer(ELF_SHT_NULL, module_object, "SHT_NULL");
+  yr_set_integer(ELF_SHT_PROGBITS, module_object, "SHT_PROGBITS");
+  yr_set_integer(ELF_SHT_SYMTAB, module_object, "SHT_SYMTAB");
+  yr_set_integer(ELF_SHT_STRTAB, module_object, "SHT_STRTAB");
+  yr_set_integer(ELF_SHT_RELA, module_object, "SHT_RELA");
+  yr_set_integer(ELF_SHT_HASH, module_object, "SHT_HASH");
+  yr_set_integer(ELF_SHT_DYNAMIC, module_object, "SHT_DYNAMIC");
+  yr_set_integer(ELF_SHT_NOTE, module_object, "SHT_NOTE");
+  yr_set_integer(ELF_SHT_NOBITS, module_object, "SHT_NOBITS");
+  yr_set_integer(ELF_SHT_REL, module_object, "SHT_REL");
+  yr_set_integer(ELF_SHT_SHLIB, module_object, "SHT_SHLIB");
+  yr_set_integer(ELF_SHT_DYNSYM, module_object, "SHT_DYNSYM");
 
-  set_integer(ELF_SHF_WRITE, module_object, "SHF_WRITE");
-  set_integer(ELF_SHF_ALLOC, module_object, "SHF_ALLOC");
-  set_integer(ELF_SHF_EXECINSTR, module_object, "SHF_EXECINSTR");
+  yr_set_integer(ELF_SHF_WRITE, module_object, "SHF_WRITE");
+  yr_set_integer(ELF_SHF_ALLOC, module_object, "SHF_ALLOC");
+  yr_set_integer(ELF_SHF_EXECINSTR, module_object, "SHF_EXECINSTR");
 
-  set_integer(ELF_PT_NULL, module_object, "PT_NULL");
-  set_integer(ELF_PT_LOAD, module_object, "PT_LOAD");
-  set_integer(ELF_PT_DYNAMIC, module_object, "PT_DYNAMIC");
-  set_integer(ELF_PT_INTERP, module_object, "PT_INTERP");
-  set_integer(ELF_PT_NOTE, module_object, "PT_NOTE");
-  set_integer(ELF_PT_SHLIB, module_object, "PT_SHLIB");
-  set_integer(ELF_PT_PHDR, module_object, "PT_PHDR");
-  set_integer(ELF_PT_TLS, module_object, "PT_TLS");
-  set_integer(ELF_PT_GNU_EH_FRAME, module_object, "PT_GNU_EH_FRAME");
-  set_integer(ELF_PT_GNU_STACK, module_object, "PT_GNU_STACK");
+  yr_set_integer(ELF_PT_NULL, module_object, "PT_NULL");
+  yr_set_integer(ELF_PT_LOAD, module_object, "PT_LOAD");
+  yr_set_integer(ELF_PT_DYNAMIC, module_object, "PT_DYNAMIC");
+  yr_set_integer(ELF_PT_INTERP, module_object, "PT_INTERP");
+  yr_set_integer(ELF_PT_NOTE, module_object, "PT_NOTE");
+  yr_set_integer(ELF_PT_SHLIB, module_object, "PT_SHLIB");
+  yr_set_integer(ELF_PT_PHDR, module_object, "PT_PHDR");
+  yr_set_integer(ELF_PT_TLS, module_object, "PT_TLS");
+  yr_set_integer(ELF_PT_GNU_EH_FRAME, module_object, "PT_GNU_EH_FRAME");
+  yr_set_integer(ELF_PT_GNU_STACK, module_object, "PT_GNU_STACK");
 
-  set_integer(ELF_DT_NULL, module_object, "DT_NULL");
-  set_integer(ELF_DT_NEEDED, module_object, "DT_NEEDED");
-  set_integer(ELF_DT_PLTRELSZ, module_object, "DT_PLTRELSZ");
-  set_integer(ELF_DT_PLTGOT, module_object, "DT_PLTGOT");
-  set_integer(ELF_DT_HASH, module_object, "DT_HASH");
-  set_integer(ELF_DT_STRTAB, module_object, "DT_STRTAB");
-  set_integer(ELF_DT_SYMTAB, module_object, "DT_SYMTAB");
-  set_integer(ELF_DT_RELA, module_object, "DT_RELA");
-  set_integer(ELF_DT_RELASZ, module_object, "DT_RELASZ");
-  set_integer(ELF_DT_RELAENT, module_object, "DT_RELAENT");
-  set_integer(ELF_DT_STRSZ, module_object, "DT_STRSZ");
-  set_integer(ELF_DT_SYMENT, module_object, "DT_SYMENT");
-  set_integer(ELF_DT_INIT, module_object, "DT_INIT");
-  set_integer(ELF_DT_FINI, module_object, "DT_FINI");
-  set_integer(ELF_DT_SONAME, module_object, "DT_SONAME");
-  set_integer(ELF_DT_RPATH, module_object, "DT_RPATH");
-  set_integer(ELF_DT_SYMBOLIC, module_object, "DT_SYMBOLIC");
-  set_integer(ELF_DT_REL, module_object, "DT_REL");
-  set_integer(ELF_DT_RELSZ, module_object, "DT_RELSZ");
-  set_integer(ELF_DT_RELENT, module_object, "DT_RELENT");
-  set_integer(ELF_DT_PLTREL, module_object, "DT_PLTREL");
-  set_integer(ELF_DT_DEBUG, module_object, "DT_DEBUG");
-  set_integer(ELF_DT_TEXTREL, module_object, "DT_TEXTREL");
-  set_integer(ELF_DT_JMPREL, module_object, "DT_JMPREL");
-  set_integer(ELF_DT_BIND_NOW, module_object, "DT_BIND_NOW");
-  set_integer(ELF_DT_INIT_ARRAY, module_object, "DT_INIT_ARRAY");
-  set_integer(ELF_DT_FINI_ARRAY, module_object, "DT_FINI_ARRAY");
-  set_integer(ELF_DT_INIT_ARRAYSZ, module_object, "DT_INIT_ARRAYSZ");
-  set_integer(ELF_DT_FINI_ARRAYSZ, module_object, "DT_FINI_ARRAYSZ");
-  set_integer(ELF_DT_RUNPATH, module_object, "DT_RUNPATH");
-  set_integer(ELF_DT_FLAGS, module_object, "DT_FLAGS");
-  set_integer(ELF_DT_ENCODING, module_object, "DT_ENCODING");
+  yr_set_integer(ELF_DT_NULL, module_object, "DT_NULL");
+  yr_set_integer(ELF_DT_NEEDED, module_object, "DT_NEEDED");
+  yr_set_integer(ELF_DT_PLTRELSZ, module_object, "DT_PLTRELSZ");
+  yr_set_integer(ELF_DT_PLTGOT, module_object, "DT_PLTGOT");
+  yr_set_integer(ELF_DT_HASH, module_object, "DT_HASH");
+  yr_set_integer(ELF_DT_STRTAB, module_object, "DT_STRTAB");
+  yr_set_integer(ELF_DT_SYMTAB, module_object, "DT_SYMTAB");
+  yr_set_integer(ELF_DT_RELA, module_object, "DT_RELA");
+  yr_set_integer(ELF_DT_RELASZ, module_object, "DT_RELASZ");
+  yr_set_integer(ELF_DT_RELAENT, module_object, "DT_RELAENT");
+  yr_set_integer(ELF_DT_STRSZ, module_object, "DT_STRSZ");
+  yr_set_integer(ELF_DT_SYMENT, module_object, "DT_SYMENT");
+  yr_set_integer(ELF_DT_INIT, module_object, "DT_INIT");
+  yr_set_integer(ELF_DT_FINI, module_object, "DT_FINI");
+  yr_set_integer(ELF_DT_SONAME, module_object, "DT_SONAME");
+  yr_set_integer(ELF_DT_RPATH, module_object, "DT_RPATH");
+  yr_set_integer(ELF_DT_SYMBOLIC, module_object, "DT_SYMBOLIC");
+  yr_set_integer(ELF_DT_REL, module_object, "DT_REL");
+  yr_set_integer(ELF_DT_RELSZ, module_object, "DT_RELSZ");
+  yr_set_integer(ELF_DT_RELENT, module_object, "DT_RELENT");
+  yr_set_integer(ELF_DT_PLTREL, module_object, "DT_PLTREL");
+  yr_set_integer(ELF_DT_DEBUG, module_object, "DT_DEBUG");
+  yr_set_integer(ELF_DT_TEXTREL, module_object, "DT_TEXTREL");
+  yr_set_integer(ELF_DT_JMPREL, module_object, "DT_JMPREL");
+  yr_set_integer(ELF_DT_BIND_NOW, module_object, "DT_BIND_NOW");
+  yr_set_integer(ELF_DT_INIT_ARRAY, module_object, "DT_INIT_ARRAY");
+  yr_set_integer(ELF_DT_FINI_ARRAY, module_object, "DT_FINI_ARRAY");
+  yr_set_integer(ELF_DT_INIT_ARRAYSZ, module_object, "DT_INIT_ARRAYSZ");
+  yr_set_integer(ELF_DT_FINI_ARRAYSZ, module_object, "DT_FINI_ARRAYSZ");
+  yr_set_integer(ELF_DT_RUNPATH, module_object, "DT_RUNPATH");
+  yr_set_integer(ELF_DT_FLAGS, module_object, "DT_FLAGS");
+  yr_set_integer(ELF_DT_ENCODING, module_object, "DT_ENCODING");
 
-  set_integer(ELF_STT_NOTYPE, module_object, "STT_NOTYPE");
-  set_integer(ELF_STT_OBJECT, module_object, "STT_OBJECT");
-  set_integer(ELF_STT_FUNC, module_object, "STT_FUNC");
-  set_integer(ELF_STT_SECTION, module_object, "STT_SECTION");
-  set_integer(ELF_STT_FILE, module_object, "STT_FILE");
-  set_integer(ELF_STT_COMMON, module_object, "STT_COMMON");
-  set_integer(ELF_STT_TLS, module_object, "STT_TLS");
+  yr_set_integer(ELF_STT_NOTYPE, module_object, "STT_NOTYPE");
+  yr_set_integer(ELF_STT_OBJECT, module_object, "STT_OBJECT");
+  yr_set_integer(ELF_STT_FUNC, module_object, "STT_FUNC");
+  yr_set_integer(ELF_STT_SECTION, module_object, "STT_SECTION");
+  yr_set_integer(ELF_STT_FILE, module_object, "STT_FILE");
+  yr_set_integer(ELF_STT_COMMON, module_object, "STT_COMMON");
+  yr_set_integer(ELF_STT_TLS, module_object, "STT_TLS");
 
-  set_integer(ELF_STB_LOCAL, module_object, "STB_LOCAL");
-  set_integer(ELF_STB_GLOBAL, module_object, "STB_GLOBAL");
-  set_integer(ELF_STB_WEAK, module_object, "STB_WEAK");
+  yr_set_integer(ELF_STB_LOCAL, module_object, "STB_LOCAL");
+  yr_set_integer(ELF_STB_GLOBAL, module_object, "STB_GLOBAL");
+  yr_set_integer(ELF_STB_WEAK, module_object, "STB_WEAK");
 
-  set_integer(ELF_PF_X, module_object, "PF_X");
-  set_integer(ELF_PF_W, module_object, "PF_W");
-  set_integer(ELF_PF_R, module_object, "PF_R");
+  yr_set_integer(ELF_PF_X, module_object, "PF_X");
+  yr_set_integer(ELF_PF_W, module_object, "PF_W");
+  yr_set_integer(ELF_PF_R, module_object, "PF_R");
 
   uint64_t parse_result = ERROR_SUCCESS;
 

--- a/libyara/modules/hash/hash.c
+++ b/libyara/modules/hash/hash.c
@@ -266,7 +266,7 @@ define_function(data_md5)
 
   bool past_first_block = false;
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -303,7 +303,7 @@ define_function(data_md5)
     return_string(YR_UNDEFINED);
   }
 
-  cached_ascii_digest = get_from_cache(module(), "md5", arg_offset, arg_length);
+  cached_ascii_digest = get_from_cache(yr_module(), "md5", arg_offset, arg_length);
 
   if (cached_ascii_digest != NULL)
   {
@@ -380,7 +380,7 @@ define_function(data_md5)
   digest_to_ascii(digest, digest_ascii, YR_MD5_LEN);
 
   FAIL_ON_ERROR(
-      add_to_cache(module(), "md5", arg_offset, arg_length, digest_ascii));
+      add_to_cache(yr_module(), "md5", arg_offset, arg_length, digest_ascii));
 
   YR_DEBUG_FPRINTF(2, stderr, "} // %s() = 0x%s\n", __FUNCTION__, digest_ascii);
   return_string(digest_ascii);
@@ -402,7 +402,7 @@ define_function(data_sha1)
   int64_t offset = arg_offset;
   int64_t length = arg_length;
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -434,7 +434,7 @@ define_function(data_sha1)
   }
 
   cached_ascii_digest = get_from_cache(
-      module(), "sha1", arg_offset, arg_length);
+      yr_module(), "sha1", arg_offset, arg_length);
 
   if (cached_ascii_digest != NULL)
   {
@@ -509,7 +509,7 @@ define_function(data_sha1)
   digest_to_ascii(digest, digest_ascii, YR_SHA1_LEN);
 
   FAIL_ON_ERROR(
-      add_to_cache(module(), "sha1", arg_offset, arg_length, digest_ascii));
+      add_to_cache(yr_module(), "sha1", arg_offset, arg_length, digest_ascii));
 
   YR_DEBUG_FPRINTF(2, stderr, "} // %s() = 0x%s\n", __FUNCTION__, digest_ascii);
   return_string(digest_ascii);
@@ -531,7 +531,7 @@ define_function(data_sha256)
   int64_t offset = arg_offset;
   int64_t length = arg_length;
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -563,7 +563,7 @@ define_function(data_sha256)
   }
 
   cached_ascii_digest = get_from_cache(
-      module(), "sha256", arg_offset, arg_length);
+      yr_module(), "sha256", arg_offset, arg_length);
 
   if (cached_ascii_digest != NULL)
   {
@@ -637,7 +637,7 @@ define_function(data_sha256)
   digest_to_ascii(digest, digest_ascii, YR_SHA256_LEN);
 
   FAIL_ON_ERROR(
-      add_to_cache(module(), "sha256", arg_offset, arg_length, digest_ascii));
+      add_to_cache(yr_module(), "sha256", arg_offset, arg_length, digest_ascii));
 
   YR_DEBUG_FPRINTF(2, stderr, "} // %s() = 0x%s\n", __FUNCTION__, digest_ascii);
   return_string(digest_ascii);
@@ -656,7 +656,7 @@ define_function(data_checksum32)
       offset,
       length);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -740,7 +740,7 @@ define_function(data_crc32)
   int64_t length = integer_argument(2);  // length of bytes we want hash on
   uint32_t checksum = 0xFFFFFFFF;
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 

--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -167,16 +167,16 @@ static void swap_entry_point_command(yr_entry_point_command_t* ep_command)
 
 bool macho_rva_to_offset(uint64_t address, uint64_t* result, YR_OBJECT* object)
 {
-  uint64_t segment_count = get_integer(object, "number_of_segments");
+  uint64_t segment_count = yr_get_integer(object, "number_of_segments");
 
   for (int i = 0; i < segment_count; i++)
   {
-    uint64_t start = get_integer(object, "segments[%i].vmaddr", i);
-    uint64_t end = start + get_integer(object, "segments[%i].vmsize", i);
+    uint64_t start = yr_get_integer(object, "segments[%i].vmaddr", i);
+    uint64_t end = start + yr_get_integer(object, "segments[%i].vmsize", i);
 
     if (address >= start && address < end)
     {
-      uint64_t fileoff = get_integer(object, "segments[%i].fileoff", i);
+      uint64_t fileoff = yr_get_integer(object, "segments[%i].fileoff", i);
       *result = fileoff + (address - start);
       return true;
     }
@@ -189,16 +189,16 @@ bool macho_rva_to_offset(uint64_t address, uint64_t* result, YR_OBJECT* object)
 
 int macho_offset_to_rva(uint64_t offset, uint64_t* result, YR_OBJECT* object)
 {
-  uint64_t segment_count = get_integer(object, "number_of_segments");
+  uint64_t segment_count = yr_get_integer(object, "number_of_segments");
 
   for (int i = 0; i < segment_count; i++)
   {
-    uint64_t start = get_integer(object, "segments[%i].fileoff", i);
-    uint64_t end = start + get_integer(object, "segments[%i].filesize", i);
+    uint64_t start = yr_get_integer(object, "segments[%i].fileoff", i);
+    uint64_t end = start + yr_get_integer(object, "segments[%i].filesize", i);
 
     if (offset >= start && offset < end)
     {
-      uint64_t vmaddr = get_integer(object, "segments[%i].vmaddr", i);
+      uint64_t vmaddr = yr_get_integer(object, "segments[%i].vmaddr", i);
       *result = vmaddr + (offset - start);
       return true;
     }
@@ -214,7 +214,7 @@ void macho_handle_unixthread(
     YR_OBJECT* object,
     YR_SCAN_CONTEXT* context)
 {
-  int should_swap = should_swap_bytes(get_integer(object, "magic"));
+  int should_swap = should_swap_bytes(yr_get_integer(object, "magic"));
   bool is64 = false;
 
   if (size < sizeof(yr_thread_command_t))
@@ -240,7 +240,7 @@ void macho_handle_unixthread(
 
   uint64_t address = 0;
 
-  switch (get_integer(object, "cputype"))
+  switch (yr_get_integer(object, "cputype"))
   {
   case CPU_TYPE_MC680X0:
   {
@@ -314,14 +314,14 @@ void macho_handle_unixthread(
 
   if (context->flags & SCAN_FLAGS_PROCESS_MEMORY)
   {
-    set_integer(address, object, "entry_point");
+    yr_set_integer(address, object, "entry_point");
   }
   else
   {
     uint64_t offset = 0;
     if (macho_rva_to_offset(address, &offset, object))
     {
-      set_integer(offset, object, "entry_point");
+      yr_set_integer(offset, object, "entry_point");
     }
   }
 }
@@ -341,7 +341,7 @@ void macho_handle_main(
 
   memcpy(&ep_command, data, sizeof(yr_entry_point_command_t));
 
-  if (should_swap_bytes(get_integer(object, "magic")))
+  if (should_swap_bytes(yr_get_integer(object, "magic")))
     swap_entry_point_command(&ep_command);
 
   if (context->flags & SCAN_FLAGS_PROCESS_MEMORY)
@@ -349,14 +349,14 @@ void macho_handle_main(
     uint64_t address = 0;
     if (macho_offset_to_rva(ep_command.entryoff, &address, object))
     {
-      set_integer(address, object, "entry_point");
+      yr_set_integer(address, object, "entry_point");
     }
   }
   else
   {
-    set_integer(ep_command.entryoff, object, "entry_point");
+    yr_set_integer(ep_command.entryoff, object, "entry_point");
   }
-  set_integer(ep_command.stacksize, object, "stack_size");
+  yr_set_integer(ep_command.stacksize, object, "stack_size");
 }
 
 // Load segment and its sections.
@@ -374,22 +374,22 @@ void macho_handle_segment(
 
   memcpy(&sg, data, sizeof(yr_segment_command_32_t));
 
-  int should_swap = should_swap_bytes(get_integer(object, "magic"));
+  int should_swap = should_swap_bytes(yr_get_integer(object, "magic"));
 
   if (should_swap)
     swap_segment_command(&sg);
 
-  set_sized_string(
+  yr_set_sized_string(
       sg.segname, strnlen(sg.segname, 16), object, "segments[%i].segname", i);
 
-  set_integer(sg.vmaddr, object, "segments[%i].vmaddr", i);
-  set_integer(sg.vmsize, object, "segments[%i].vmsize", i);
-  set_integer(sg.fileoff, object, "segments[%i].fileoff", i);
-  set_integer(sg.filesize, object, "segments[%i].fsize", i);
-  set_integer(sg.maxprot, object, "segments[%i].maxprot", i);
-  set_integer(sg.initprot, object, "segments[%i].initprot", i);
-  set_integer(sg.nsects, object, "segments[%i].nsects", i);
-  set_integer(sg.flags, object, "segments[%i].flags", i);
+  yr_set_integer(sg.vmaddr, object, "segments[%i].vmaddr", i);
+  yr_set_integer(sg.vmsize, object, "segments[%i].vmsize", i);
+  yr_set_integer(sg.fileoff, object, "segments[%i].fileoff", i);
+  yr_set_integer(sg.filesize, object, "segments[%i].fsize", i);
+  yr_set_integer(sg.maxprot, object, "segments[%i].maxprot", i);
+  yr_set_integer(sg.initprot, object, "segments[%i].initprot", i);
+  yr_set_integer(sg.nsects, object, "segments[%i].nsects", i);
+  yr_set_integer(sg.flags, object, "segments[%i].flags", i);
 
   uint64_t parsed_size = sizeof(yr_segment_command_32_t);
 
@@ -411,7 +411,7 @@ void macho_handle_segment(
     if (should_swap)
       swap_section(&sec);
 
-    set_sized_string(
+    yr_set_sized_string(
         sec.segname,
         strnlen(sec.segname, 16),
         object,
@@ -419,7 +419,7 @@ void macho_handle_segment(
         i,
         j);
 
-    set_sized_string(
+    yr_set_sized_string(
         sec.sectname,
         strnlen(sec.sectname, 16),
         object,
@@ -427,24 +427,24 @@ void macho_handle_segment(
         i,
         j);
 
-    set_integer(sec.addr, object, "segments[%i].sections[%i].addr", i, j);
+    yr_set_integer(sec.addr, object, "segments[%i].sections[%i].addr", i, j);
 
-    set_integer(sec.size, object, "segments[%i].sections[%i].size", i, j);
+    yr_set_integer(sec.size, object, "segments[%i].sections[%i].size", i, j);
 
-    set_integer(sec.offset, object, "segments[%i].sections[%i].offset", i, j);
+    yr_set_integer(sec.offset, object, "segments[%i].sections[%i].offset", i, j);
 
-    set_integer(sec.align, object, "segments[%i].sections[%i].align", i, j);
+    yr_set_integer(sec.align, object, "segments[%i].sections[%i].align", i, j);
 
-    set_integer(sec.reloff, object, "segments[%i].sections[%i].reloff", i, j);
+    yr_set_integer(sec.reloff, object, "segments[%i].sections[%i].reloff", i, j);
 
-    set_integer(sec.nreloc, object, "segments[%i].sections[%i].nreloc", i, j);
+    yr_set_integer(sec.nreloc, object, "segments[%i].sections[%i].nreloc", i, j);
 
-    set_integer(sec.flags, object, "segments[%i].sections[%i].flags", i, j);
+    yr_set_integer(sec.flags, object, "segments[%i].sections[%i].flags", i, j);
 
-    set_integer(
+    yr_set_integer(
         sec.reserved1, object, "segments[%i].sections[%i].reserved1", i, j);
 
-    set_integer(
+    yr_set_integer(
         sec.reserved2, object, "segments[%i].sections[%i].reserved2", i, j);
   }
 }
@@ -462,22 +462,22 @@ void macho_handle_segment_64(
 
   memcpy(&sg, data, sizeof(yr_segment_command_64_t));
 
-  int should_swap = should_swap_bytes(get_integer(object, "magic"));
+  int should_swap = should_swap_bytes(yr_get_integer(object, "magic"));
 
   if (should_swap)
     swap_segment_command_64(&sg);
 
-  set_sized_string(
+  yr_set_sized_string(
       sg.segname, strnlen(sg.segname, 16), object, "segments[%i].segname", i);
 
-  set_integer(sg.vmaddr, object, "segments[%i].vmaddr", i);
-  set_integer(sg.vmsize, object, "segments[%i].vmsize", i);
-  set_integer(sg.fileoff, object, "segments[%i].fileoff", i);
-  set_integer(sg.filesize, object, "segments[%i].fsize", i);
-  set_integer(sg.maxprot, object, "segments[%i].maxprot", i);
-  set_integer(sg.initprot, object, "segments[%i].initprot", i);
-  set_integer(sg.nsects, object, "segments[%i].nsects", i);
-  set_integer(sg.flags, object, "segments[%i].flags", i);
+  yr_set_integer(sg.vmaddr, object, "segments[%i].vmaddr", i);
+  yr_set_integer(sg.vmsize, object, "segments[%i].vmsize", i);
+  yr_set_integer(sg.fileoff, object, "segments[%i].fileoff", i);
+  yr_set_integer(sg.filesize, object, "segments[%i].fsize", i);
+  yr_set_integer(sg.maxprot, object, "segments[%i].maxprot", i);
+  yr_set_integer(sg.initprot, object, "segments[%i].initprot", i);
+  yr_set_integer(sg.nsects, object, "segments[%i].nsects", i);
+  yr_set_integer(sg.flags, object, "segments[%i].flags", i);
 
   uint64_t parsed_size = sizeof(yr_segment_command_64_t);
 
@@ -498,7 +498,7 @@ void macho_handle_segment_64(
     if (should_swap)
       swap_section_64(&sec);
 
-    set_sized_string(
+    yr_set_sized_string(
         sec.segname,
         strnlen(sec.segname, 16),
         object,
@@ -506,7 +506,7 @@ void macho_handle_segment_64(
         i,
         j);
 
-    set_sized_string(
+    yr_set_sized_string(
         sec.sectname,
         strnlen(sec.sectname, 16),
         object,
@@ -514,27 +514,27 @@ void macho_handle_segment_64(
         i,
         j);
 
-    set_integer(sec.addr, object, "segments[%i].sections[%i].addr", i, j);
+    yr_set_integer(sec.addr, object, "segments[%i].sections[%i].addr", i, j);
 
-    set_integer(sec.size, object, "segments[%i].sections[%i].size", i, j);
+    yr_set_integer(sec.size, object, "segments[%i].sections[%i].size", i, j);
 
-    set_integer(sec.offset, object, "segments[%i].sections[%i].offset", i, j);
+    yr_set_integer(sec.offset, object, "segments[%i].sections[%i].offset", i, j);
 
-    set_integer(sec.align, object, "segments[%i].sections[%i].align", i, j);
+    yr_set_integer(sec.align, object, "segments[%i].sections[%i].align", i, j);
 
-    set_integer(sec.reloff, object, "segments[%i].sections[%i].reloff", i, j);
+    yr_set_integer(sec.reloff, object, "segments[%i].sections[%i].reloff", i, j);
 
-    set_integer(sec.nreloc, object, "segments[%i].sections[%i].nreloc", i, j);
+    yr_set_integer(sec.nreloc, object, "segments[%i].sections[%i].nreloc", i, j);
 
-    set_integer(sec.flags, object, "segments[%i].sections[%i].flags", i, j);
+    yr_set_integer(sec.flags, object, "segments[%i].sections[%i].flags", i, j);
 
-    set_integer(
+    yr_set_integer(
         sec.reserved1, object, "segments[%i].sections[%i].reserved1", i, j);
 
-    set_integer(
+    yr_set_integer(
         sec.reserved2, object, "segments[%i].sections[%i].reserved2", i, j);
 
-    set_integer(
+    yr_set_integer(
         sec.reserved3, object, "segments[%i].sections[%i].reserved3", i, j);
   }
 }
@@ -567,17 +567,17 @@ void macho_parse_file(
   if (should_swap)
     swap_mach_header(&header);
 
-  set_integer(header.magic, object, "magic");
-  set_integer(header.cputype, object, "cputype");
-  set_integer(header.cpusubtype, object, "cpusubtype");
-  set_integer(header.filetype, object, "filetype");
-  set_integer(header.ncmds, object, "ncmds");
-  set_integer(header.sizeofcmds, object, "sizeofcmds");
-  set_integer(header.flags, object, "flags");
+  yr_set_integer(header.magic, object, "magic");
+  yr_set_integer(header.cputype, object, "cputype");
+  yr_set_integer(header.cpusubtype, object, "cpusubtype");
+  yr_set_integer(header.filetype, object, "filetype");
+  yr_set_integer(header.ncmds, object, "ncmds");
+  yr_set_integer(header.sizeofcmds, object, "sizeofcmds");
+  yr_set_integer(header.flags, object, "flags");
 
   // The "reserved" field exists only in 64 bits files.
   if (!macho_is_32(data))
-    set_integer(header.reserved, object, "reserved");
+    yr_set_integer(header.reserved, object, "reserved");
 
   // The first command parsing pass handles only segments.
   uint64_t seg_count = 0;
@@ -616,7 +616,7 @@ void macho_parse_file(
     parsed_size += command_struct.cmdsize;
   }
 
-  set_integer(seg_count, object, "number_of_segments");
+  yr_set_integer(seg_count, object, "number_of_segments");
 
   // The second command parsing pass handles others, who use segment count.
   parsed_size = header_size;
@@ -704,10 +704,10 @@ void macho_parse_fat_file(
   /* All data in Mach-O fat binary headers are in big-endian byte order. */
 
   const yr_fat_header_t* header = (yr_fat_header_t*) data;
-  set_integer(yr_be32toh(header->magic), object, "fat_magic");
+  yr_set_integer(yr_be32toh(header->magic), object, "fat_magic");
 
   uint32_t count = yr_be32toh(header->nfat_arch);
-  set_integer(count, object, "nfat_arch");
+  yr_set_integer(count, object, "nfat_arch");
 
   if (size < sizeof(yr_fat_header_t) + count * fat_arch_sz)
     return;
@@ -718,12 +718,12 @@ void macho_parse_fat_file(
   {
     macho_load_fat_arch_header(data, size, i, &arch);
 
-    set_integer(arch.cputype, object, "fat_arch[%i].cputype", i);
-    set_integer(arch.cpusubtype, object, "fat_arch[%i].cpusubtype", i);
-    set_integer(arch.offset, object, "fat_arch[%i].offset", i);
-    set_integer(arch.size, object, "fat_arch[%i].size", i);
-    set_integer(arch.align, object, "fat_arch[%i].align", i);
-    set_integer(arch.reserved, object, "fat_arch[%i].reserved", i);
+    yr_set_integer(arch.cputype, object, "fat_arch[%i].cputype", i);
+    yr_set_integer(arch.cpusubtype, object, "fat_arch[%i].cpusubtype", i);
+    yr_set_integer(arch.offset, object, "fat_arch[%i].offset", i);
+    yr_set_integer(arch.size, object, "fat_arch[%i].size", i);
+    yr_set_integer(arch.align, object, "fat_arch[%i].align", i);
+    yr_set_integer(arch.reserved, object, "fat_arch[%i].reserved", i);
 
     // Check for integer overflow.
     if (arch.offset + arch.size < arch.offset)
@@ -733,13 +733,13 @@ void macho_parse_fat_file(
       continue;
 
     // Force 'file' array entry creation.
-    set_integer(YR_UNDEFINED, object, "file[%i].magic", i);
+    yr_set_integer(YR_UNDEFINED, object, "file[%i].magic", i);
 
     // Get specific Mach-O file data.
     macho_parse_file(
         data + arch.offset,
         arch.size,
-        get_object(object, "file[%i]", i),
+        yr_get_object(object, "file[%i]", i),
         context);
   }
 }
@@ -750,210 +750,210 @@ void macho_set_definitions(YR_OBJECT* object)
 {
   // Magic constants
 
-  set_integer(MH_MAGIC, object, "MH_MAGIC");
-  set_integer(MH_CIGAM, object, "MH_CIGAM");
-  set_integer(MH_MAGIC_64, object, "MH_MAGIC_64");
-  set_integer(MH_CIGAM_64, object, "MH_CIGAM_64");
+  yr_set_integer(MH_MAGIC, object, "MH_MAGIC");
+  yr_set_integer(MH_CIGAM, object, "MH_CIGAM");
+  yr_set_integer(MH_MAGIC_64, object, "MH_MAGIC_64");
+  yr_set_integer(MH_CIGAM_64, object, "MH_CIGAM_64");
 
   // Fat magic constants
 
-  set_integer(FAT_MAGIC, object, "FAT_MAGIC");
-  set_integer(FAT_CIGAM, object, "FAT_CIGAM");
-  set_integer(FAT_MAGIC_64, object, "FAT_MAGIC_64");
-  set_integer(FAT_CIGAM_64, object, "FAT_CIGAM_64");
+  yr_set_integer(FAT_MAGIC, object, "FAT_MAGIC");
+  yr_set_integer(FAT_CIGAM, object, "FAT_CIGAM");
+  yr_set_integer(FAT_MAGIC_64, object, "FAT_MAGIC_64");
+  yr_set_integer(FAT_CIGAM_64, object, "FAT_CIGAM_64");
 
   // 64-bit masks
 
-  set_integer(CPU_ARCH_ABI64, object, "CPU_ARCH_ABI64");
-  set_integer(CPU_SUBTYPE_LIB64, object, "CPU_SUBTYPE_LIB64");
+  yr_set_integer(CPU_ARCH_ABI64, object, "CPU_ARCH_ABI64");
+  yr_set_integer(CPU_SUBTYPE_LIB64, object, "CPU_SUBTYPE_LIB64");
 
   // CPU types
 
-  set_integer(CPU_TYPE_MC680X0, object, "CPU_TYPE_MC680X0");
-  set_integer(CPU_TYPE_X86, object, "CPU_TYPE_X86");
-  set_integer(CPU_TYPE_X86, object, "CPU_TYPE_I386");
-  set_integer(CPU_TYPE_X86_64, object, "CPU_TYPE_X86_64");
-  set_integer(CPU_TYPE_MIPS, object, "CPU_TYPE_MIPS");
-  set_integer(CPU_TYPE_MC98000, object, "CPU_TYPE_MC98000");
-  set_integer(CPU_TYPE_ARM, object, "CPU_TYPE_ARM");
-  set_integer(CPU_TYPE_ARM64, object, "CPU_TYPE_ARM64");
-  set_integer(CPU_TYPE_MC88000, object, "CPU_TYPE_MC88000");
-  set_integer(CPU_TYPE_SPARC, object, "CPU_TYPE_SPARC");
-  set_integer(CPU_TYPE_POWERPC, object, "CPU_TYPE_POWERPC");
-  set_integer(CPU_TYPE_POWERPC64, object, "CPU_TYPE_POWERPC64");
+  yr_set_integer(CPU_TYPE_MC680X0, object, "CPU_TYPE_MC680X0");
+  yr_set_integer(CPU_TYPE_X86, object, "CPU_TYPE_X86");
+  yr_set_integer(CPU_TYPE_X86, object, "CPU_TYPE_I386");
+  yr_set_integer(CPU_TYPE_X86_64, object, "CPU_TYPE_X86_64");
+  yr_set_integer(CPU_TYPE_MIPS, object, "CPU_TYPE_MIPS");
+  yr_set_integer(CPU_TYPE_MC98000, object, "CPU_TYPE_MC98000");
+  yr_set_integer(CPU_TYPE_ARM, object, "CPU_TYPE_ARM");
+  yr_set_integer(CPU_TYPE_ARM64, object, "CPU_TYPE_ARM64");
+  yr_set_integer(CPU_TYPE_MC88000, object, "CPU_TYPE_MC88000");
+  yr_set_integer(CPU_TYPE_SPARC, object, "CPU_TYPE_SPARC");
+  yr_set_integer(CPU_TYPE_POWERPC, object, "CPU_TYPE_POWERPC");
+  yr_set_integer(CPU_TYPE_POWERPC64, object, "CPU_TYPE_POWERPC64");
 
   // CPU sub-types
 
-  set_integer(
+  yr_set_integer(
       CPU_SUBTYPE_INTEL_MODEL_ALL, object, "CPU_SUBTYPE_INTEL_MODEL_ALL");
-  set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_386");
-  set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_I386_ALL");
-  set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_X86_64_ALL");
-  set_integer(CPU_SUBTYPE_486, object, "CPU_SUBTYPE_486");
-  set_integer(CPU_SUBTYPE_486SX, object, "CPU_SUBTYPE_486SX");
-  set_integer(CPU_SUBTYPE_586, object, "CPU_SUBTYPE_586");
-  set_integer(CPU_SUBTYPE_PENT, object, "CPU_SUBTYPE_PENT");
-  set_integer(CPU_SUBTYPE_PENTPRO, object, "CPU_SUBTYPE_PENTPRO");
-  set_integer(CPU_SUBTYPE_PENTII_M3, object, "CPU_SUBTYPE_PENTII_M3");
-  set_integer(CPU_SUBTYPE_PENTII_M5, object, "CPU_SUBTYPE_PENTII_M5");
-  set_integer(CPU_SUBTYPE_CELERON, object, "CPU_SUBTYPE_CELERON");
-  set_integer(CPU_SUBTYPE_CELERON_MOBILE, object, "CPU_SUBTYPE_CELERON_MOBILE");
-  set_integer(CPU_SUBTYPE_PENTIUM_3, object, "CPU_SUBTYPE_PENTIUM_3");
-  set_integer(CPU_SUBTYPE_PENTIUM_3_M, object, "CPU_SUBTYPE_PENTIUM_3_M");
-  set_integer(CPU_SUBTYPE_PENTIUM_3_XEON, object, "CPU_SUBTYPE_PENTIUM_3_XEON");
-  set_integer(CPU_SUBTYPE_PENTIUM_M, object, "CPU_SUBTYPE_PENTIUM_M");
-  set_integer(CPU_SUBTYPE_PENTIUM_4, object, "CPU_SUBTYPE_PENTIUM_4");
-  set_integer(CPU_SUBTYPE_PENTIUM_4_M, object, "CPU_SUBTYPE_PENTIUM_4_M");
-  set_integer(CPU_SUBTYPE_ITANIUM, object, "CPU_SUBTYPE_ITANIUM");
-  set_integer(CPU_SUBTYPE_ITANIUM_2, object, "CPU_SUBTYPE_ITANIUM_2");
-  set_integer(CPU_SUBTYPE_XEON, object, "CPU_SUBTYPE_XEON");
-  set_integer(CPU_SUBTYPE_XEON_MP, object, "CPU_SUBTYPE_XEON_MP");
-  set_integer(CPU_SUBTYPE_ARM_ALL, object, "CPU_SUBTYPE_ARM_ALL");
-  set_integer(CPU_SUBTYPE_ARM_V4T, object, "CPU_SUBTYPE_ARM_V4T");
-  set_integer(CPU_SUBTYPE_ARM_V6, object, "CPU_SUBTYPE_ARM_V6");
-  set_integer(CPU_SUBTYPE_ARM_V5, object, "CPU_SUBTYPE_ARM_V5");
-  set_integer(CPU_SUBTYPE_ARM_V5TEJ, object, "CPU_SUBTYPE_ARM_V5TEJ");
-  set_integer(CPU_SUBTYPE_ARM_XSCALE, object, "CPU_SUBTYPE_ARM_XSCALE");
-  set_integer(CPU_SUBTYPE_ARM_V7, object, "CPU_SUBTYPE_ARM_V7");
-  set_integer(CPU_SUBTYPE_ARM_V7F, object, "CPU_SUBTYPE_ARM_V7F");
-  set_integer(CPU_SUBTYPE_ARM_V7S, object, "CPU_SUBTYPE_ARM_V7S");
-  set_integer(CPU_SUBTYPE_ARM_V7K, object, "CPU_SUBTYPE_ARM_V7K");
-  set_integer(CPU_SUBTYPE_ARM_V6M, object, "CPU_SUBTYPE_ARM_V6M");
-  set_integer(CPU_SUBTYPE_ARM_V7M, object, "CPU_SUBTYPE_ARM_V7M");
-  set_integer(CPU_SUBTYPE_ARM_V7EM, object, "CPU_SUBTYPE_ARM_V7EM");
-  set_integer(CPU_SUBTYPE_ARM64_ALL, object, "CPU_SUBTYPE_ARM64_ALL");
-  set_integer(CPU_SUBTYPE_SPARC_ALL, object, "CPU_SUBTYPE_SPARC_ALL");
-  set_integer(CPU_SUBTYPE_POWERPC_ALL, object, "CPU_SUBTYPE_POWERPC_ALL");
-  set_integer(CPU_SUBTYPE_MC980000_ALL, object, "CPU_SUBTYPE_MC980000_ALL");
-  set_integer(CPU_SUBTYPE_POWERPC_601, object, "CPU_SUBTYPE_POWERPC_601");
-  set_integer(CPU_SUBTYPE_MC98601, object, "CPU_SUBTYPE_MC98601");
-  set_integer(CPU_SUBTYPE_POWERPC_602, object, "CPU_SUBTYPE_POWERPC_602");
-  set_integer(CPU_SUBTYPE_POWERPC_603, object, "CPU_SUBTYPE_POWERPC_603");
-  set_integer(CPU_SUBTYPE_POWERPC_603e, object, "CPU_SUBTYPE_POWERPC_603e");
-  set_integer(CPU_SUBTYPE_POWERPC_603ev, object, "CPU_SUBTYPE_POWERPC_603ev");
-  set_integer(CPU_SUBTYPE_POWERPC_604, object, "CPU_SUBTYPE_POWERPC_604");
-  set_integer(CPU_SUBTYPE_POWERPC_604e, object, "CPU_SUBTYPE_POWERPC_604e");
-  set_integer(CPU_SUBTYPE_POWERPC_620, object, "CPU_SUBTYPE_POWERPC_620");
-  set_integer(CPU_SUBTYPE_POWERPC_750, object, "CPU_SUBTYPE_POWERPC_750");
-  set_integer(CPU_SUBTYPE_POWERPC_7400, object, "CPU_SUBTYPE_POWERPC_7400");
-  set_integer(CPU_SUBTYPE_POWERPC_7450, object, "CPU_SUBTYPE_POWERPC_7450");
-  set_integer(CPU_SUBTYPE_POWERPC_970, object, "CPU_SUBTYPE_POWERPC_970");
+  yr_set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_386");
+  yr_set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_I386_ALL");
+  yr_set_integer(CPU_SUBTYPE_386, object, "CPU_SUBTYPE_X86_64_ALL");
+  yr_set_integer(CPU_SUBTYPE_486, object, "CPU_SUBTYPE_486");
+  yr_set_integer(CPU_SUBTYPE_486SX, object, "CPU_SUBTYPE_486SX");
+  yr_set_integer(CPU_SUBTYPE_586, object, "CPU_SUBTYPE_586");
+  yr_set_integer(CPU_SUBTYPE_PENT, object, "CPU_SUBTYPE_PENT");
+  yr_set_integer(CPU_SUBTYPE_PENTPRO, object, "CPU_SUBTYPE_PENTPRO");
+  yr_set_integer(CPU_SUBTYPE_PENTII_M3, object, "CPU_SUBTYPE_PENTII_M3");
+  yr_set_integer(CPU_SUBTYPE_PENTII_M5, object, "CPU_SUBTYPE_PENTII_M5");
+  yr_set_integer(CPU_SUBTYPE_CELERON, object, "CPU_SUBTYPE_CELERON");
+  yr_set_integer(CPU_SUBTYPE_CELERON_MOBILE, object, "CPU_SUBTYPE_CELERON_MOBILE");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_3, object, "CPU_SUBTYPE_PENTIUM_3");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_3_M, object, "CPU_SUBTYPE_PENTIUM_3_M");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_3_XEON, object, "CPU_SUBTYPE_PENTIUM_3_XEON");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_M, object, "CPU_SUBTYPE_PENTIUM_M");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_4, object, "CPU_SUBTYPE_PENTIUM_4");
+  yr_set_integer(CPU_SUBTYPE_PENTIUM_4_M, object, "CPU_SUBTYPE_PENTIUM_4_M");
+  yr_set_integer(CPU_SUBTYPE_ITANIUM, object, "CPU_SUBTYPE_ITANIUM");
+  yr_set_integer(CPU_SUBTYPE_ITANIUM_2, object, "CPU_SUBTYPE_ITANIUM_2");
+  yr_set_integer(CPU_SUBTYPE_XEON, object, "CPU_SUBTYPE_XEON");
+  yr_set_integer(CPU_SUBTYPE_XEON_MP, object, "CPU_SUBTYPE_XEON_MP");
+  yr_set_integer(CPU_SUBTYPE_ARM_ALL, object, "CPU_SUBTYPE_ARM_ALL");
+  yr_set_integer(CPU_SUBTYPE_ARM_V4T, object, "CPU_SUBTYPE_ARM_V4T");
+  yr_set_integer(CPU_SUBTYPE_ARM_V6, object, "CPU_SUBTYPE_ARM_V6");
+  yr_set_integer(CPU_SUBTYPE_ARM_V5, object, "CPU_SUBTYPE_ARM_V5");
+  yr_set_integer(CPU_SUBTYPE_ARM_V5TEJ, object, "CPU_SUBTYPE_ARM_V5TEJ");
+  yr_set_integer(CPU_SUBTYPE_ARM_XSCALE, object, "CPU_SUBTYPE_ARM_XSCALE");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7, object, "CPU_SUBTYPE_ARM_V7");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7F, object, "CPU_SUBTYPE_ARM_V7F");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7S, object, "CPU_SUBTYPE_ARM_V7S");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7K, object, "CPU_SUBTYPE_ARM_V7K");
+  yr_set_integer(CPU_SUBTYPE_ARM_V6M, object, "CPU_SUBTYPE_ARM_V6M");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7M, object, "CPU_SUBTYPE_ARM_V7M");
+  yr_set_integer(CPU_SUBTYPE_ARM_V7EM, object, "CPU_SUBTYPE_ARM_V7EM");
+  yr_set_integer(CPU_SUBTYPE_ARM64_ALL, object, "CPU_SUBTYPE_ARM64_ALL");
+  yr_set_integer(CPU_SUBTYPE_SPARC_ALL, object, "CPU_SUBTYPE_SPARC_ALL");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_ALL, object, "CPU_SUBTYPE_POWERPC_ALL");
+  yr_set_integer(CPU_SUBTYPE_MC980000_ALL, object, "CPU_SUBTYPE_MC980000_ALL");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_601, object, "CPU_SUBTYPE_POWERPC_601");
+  yr_set_integer(CPU_SUBTYPE_MC98601, object, "CPU_SUBTYPE_MC98601");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_602, object, "CPU_SUBTYPE_POWERPC_602");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_603, object, "CPU_SUBTYPE_POWERPC_603");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_603e, object, "CPU_SUBTYPE_POWERPC_603e");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_603ev, object, "CPU_SUBTYPE_POWERPC_603ev");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_604, object, "CPU_SUBTYPE_POWERPC_604");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_604e, object, "CPU_SUBTYPE_POWERPC_604e");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_620, object, "CPU_SUBTYPE_POWERPC_620");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_750, object, "CPU_SUBTYPE_POWERPC_750");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_7400, object, "CPU_SUBTYPE_POWERPC_7400");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_7450, object, "CPU_SUBTYPE_POWERPC_7450");
+  yr_set_integer(CPU_SUBTYPE_POWERPC_970, object, "CPU_SUBTYPE_POWERPC_970");
 
   // File types
 
-  set_integer(MH_OBJECT, object, "MH_OBJECT");
-  set_integer(MH_EXECUTE, object, "MH_EXECUTE");
-  set_integer(MH_FVMLIB, object, "MH_FVMLIB");
-  set_integer(MH_CORE, object, "MH_CORE");
-  set_integer(MH_PRELOAD, object, "MH_PRELOAD");
-  set_integer(MH_DYLIB, object, "MH_DYLIB");
-  set_integer(MH_DYLINKER, object, "MH_DYLINKER");
-  set_integer(MH_BUNDLE, object, "MH_BUNDLE");
-  set_integer(MH_DYLIB_STUB, object, "MH_DYLIB_STUB");
-  set_integer(MH_DSYM, object, "MH_DSYM");
-  set_integer(MH_KEXT_BUNDLE, object, "MH_KEXT_BUNDLE");
+  yr_set_integer(MH_OBJECT, object, "MH_OBJECT");
+  yr_set_integer(MH_EXECUTE, object, "MH_EXECUTE");
+  yr_set_integer(MH_FVMLIB, object, "MH_FVMLIB");
+  yr_set_integer(MH_CORE, object, "MH_CORE");
+  yr_set_integer(MH_PRELOAD, object, "MH_PRELOAD");
+  yr_set_integer(MH_DYLIB, object, "MH_DYLIB");
+  yr_set_integer(MH_DYLINKER, object, "MH_DYLINKER");
+  yr_set_integer(MH_BUNDLE, object, "MH_BUNDLE");
+  yr_set_integer(MH_DYLIB_STUB, object, "MH_DYLIB_STUB");
+  yr_set_integer(MH_DSYM, object, "MH_DSYM");
+  yr_set_integer(MH_KEXT_BUNDLE, object, "MH_KEXT_BUNDLE");
 
   // Header flags
 
-  set_integer(MH_NOUNDEFS, object, "MH_NOUNDEFS");
-  set_integer(MH_INCRLINK, object, "MH_INCRLINK");
-  set_integer(MH_DYLDLINK, object, "MH_DYLDLINK");
-  set_integer(MH_BINDATLOAD, object, "MH_BINDATLOAD");
-  set_integer(MH_PREBOUND, object, "MH_PREBOUND");
-  set_integer(MH_SPLIT_SEGS, object, "MH_SPLIT_SEGS");
-  set_integer(MH_LAZY_INIT, object, "MH_LAZY_INIT");
-  set_integer(MH_TWOLEVEL, object, "MH_TWOLEVEL");
-  set_integer(MH_FORCE_FLAT, object, "MH_FORCE_FLAT");
-  set_integer(MH_NOMULTIDEFS, object, "MH_NOMULTIDEFS");
-  set_integer(MH_NOFIXPREBINDING, object, "MH_NOFIXPREBINDING");
-  set_integer(MH_PREBINDABLE, object, "MH_PREBINDABLE");
-  set_integer(MH_ALLMODSBOUND, object, "MH_ALLMODSBOUND");
-  set_integer(MH_SUBSECTIONS_VIA_SYMBOLS, object, "MH_SUBSECTIONS_VIA_SYMBOLS");
-  set_integer(MH_CANONICAL, object, "MH_CANONICAL");
-  set_integer(MH_WEAK_DEFINES, object, "MH_WEAK_DEFINES");
-  set_integer(MH_BINDS_TO_WEAK, object, "MH_BINDS_TO_WEAK");
-  set_integer(MH_ALLOW_STACK_EXECUTION, object, "MH_ALLOW_STACK_EXECUTION");
-  set_integer(MH_ROOT_SAFE, object, "MH_ROOT_SAFE");
-  set_integer(MH_SETUID_SAFE, object, "MH_SETUID_SAFE");
-  set_integer(MH_NO_REEXPORTED_DYLIBS, object, "MH_NO_REEXPORTED_DYLIBS");
-  set_integer(MH_PIE, object, "MH_PIE");
-  set_integer(MH_DEAD_STRIPPABLE_DYLIB, object, "MH_DEAD_STRIPPABLE_DYLIB");
-  set_integer(MH_HAS_TLV_DESCRIPTORS, object, "MH_HAS_TLV_DESCRIPTORS");
-  set_integer(MH_NO_HEAP_EXECUTION, object, "MH_NO_HEAP_EXECUTION");
-  set_integer(MH_APP_EXTENSION_SAFE, object, "MH_APP_EXTENSION_SAFE");
+  yr_set_integer(MH_NOUNDEFS, object, "MH_NOUNDEFS");
+  yr_set_integer(MH_INCRLINK, object, "MH_INCRLINK");
+  yr_set_integer(MH_DYLDLINK, object, "MH_DYLDLINK");
+  yr_set_integer(MH_BINDATLOAD, object, "MH_BINDATLOAD");
+  yr_set_integer(MH_PREBOUND, object, "MH_PREBOUND");
+  yr_set_integer(MH_SPLIT_SEGS, object, "MH_SPLIT_SEGS");
+  yr_set_integer(MH_LAZY_INIT, object, "MH_LAZY_INIT");
+  yr_set_integer(MH_TWOLEVEL, object, "MH_TWOLEVEL");
+  yr_set_integer(MH_FORCE_FLAT, object, "MH_FORCE_FLAT");
+  yr_set_integer(MH_NOMULTIDEFS, object, "MH_NOMULTIDEFS");
+  yr_set_integer(MH_NOFIXPREBINDING, object, "MH_NOFIXPREBINDING");
+  yr_set_integer(MH_PREBINDABLE, object, "MH_PREBINDABLE");
+  yr_set_integer(MH_ALLMODSBOUND, object, "MH_ALLMODSBOUND");
+  yr_set_integer(MH_SUBSECTIONS_VIA_SYMBOLS, object, "MH_SUBSECTIONS_VIA_SYMBOLS");
+  yr_set_integer(MH_CANONICAL, object, "MH_CANONICAL");
+  yr_set_integer(MH_WEAK_DEFINES, object, "MH_WEAK_DEFINES");
+  yr_set_integer(MH_BINDS_TO_WEAK, object, "MH_BINDS_TO_WEAK");
+  yr_set_integer(MH_ALLOW_STACK_EXECUTION, object, "MH_ALLOW_STACK_EXECUTION");
+  yr_set_integer(MH_ROOT_SAFE, object, "MH_ROOT_SAFE");
+  yr_set_integer(MH_SETUID_SAFE, object, "MH_SETUID_SAFE");
+  yr_set_integer(MH_NO_REEXPORTED_DYLIBS, object, "MH_NO_REEXPORTED_DYLIBS");
+  yr_set_integer(MH_PIE, object, "MH_PIE");
+  yr_set_integer(MH_DEAD_STRIPPABLE_DYLIB, object, "MH_DEAD_STRIPPABLE_DYLIB");
+  yr_set_integer(MH_HAS_TLV_DESCRIPTORS, object, "MH_HAS_TLV_DESCRIPTORS");
+  yr_set_integer(MH_NO_HEAP_EXECUTION, object, "MH_NO_HEAP_EXECUTION");
+  yr_set_integer(MH_APP_EXTENSION_SAFE, object, "MH_APP_EXTENSION_SAFE");
 
   // Segment flags masks
 
-  set_integer(SG_HIGHVM, object, "SG_HIGHVM");
-  set_integer(SG_FVMLIB, object, "SG_FVMLIB");
-  set_integer(SG_NORELOC, object, "SG_NORELOC");
-  set_integer(SG_PROTECTED_VERSION_1, object, "SG_PROTECTED_VERSION_1");
+  yr_set_integer(SG_HIGHVM, object, "SG_HIGHVM");
+  yr_set_integer(SG_FVMLIB, object, "SG_FVMLIB");
+  yr_set_integer(SG_NORELOC, object, "SG_NORELOC");
+  yr_set_integer(SG_PROTECTED_VERSION_1, object, "SG_PROTECTED_VERSION_1");
 
   // Section flags masks
 
-  set_integer(SECTION_TYPE, object, "SECTION_TYPE");
-  set_integer(SECTION_ATTRIBUTES, object, "SECTION_ATTRIBUTES");
+  yr_set_integer(SECTION_TYPE, object, "SECTION_TYPE");
+  yr_set_integer(SECTION_ATTRIBUTES, object, "SECTION_ATTRIBUTES");
 
   // Section types
 
-  set_integer(S_REGULAR, object, "S_REGULAR");
-  set_integer(S_ZEROFILL, object, "S_ZEROFILL");
-  set_integer(S_CSTRING_LITERALS, object, "S_CSTRING_LITERALS");
-  set_integer(S_4BYTE_LITERALS, object, "S_4BYTE_LITERALS");
-  set_integer(S_8BYTE_LITERALS, object, "S_8BYTE_LITERALS");
-  set_integer(S_NON_LAZY_SYMBOL_POINTERS, object, "S_NON_LAZY_SYMBOL_POINTERS");
-  set_integer(S_LAZY_SYMBOL_POINTERS, object, "S_LAZY_SYMBOL_POINTERS");
-  set_integer(S_LITERAL_POINTERS, object, "S_LITERAL_POINTERS");
-  set_integer(S_SYMBOL_STUBS, object, "S_SYMBOL_STUBS");
-  set_integer(S_MOD_INIT_FUNC_POINTERS, object, "S_MOD_INIT_FUNC_POINTERS");
-  set_integer(S_MOD_TERM_FUNC_POINTERS, object, "S_MOD_TERM_FUNC_POINTERS");
-  set_integer(S_COALESCED, object, "S_COALESCED");
-  set_integer(S_GB_ZEROFILL, object, "S_GB_ZEROFILL");
-  set_integer(S_INTERPOSING, object, "S_INTERPOSING");
-  set_integer(S_16BYTE_LITERALS, object, "S_16BYTE_LITERALS");
-  set_integer(S_DTRACE_DOF, object, "S_DTRACE_DOF");
-  set_integer(
+  yr_set_integer(S_REGULAR, object, "S_REGULAR");
+  yr_set_integer(S_ZEROFILL, object, "S_ZEROFILL");
+  yr_set_integer(S_CSTRING_LITERALS, object, "S_CSTRING_LITERALS");
+  yr_set_integer(S_4BYTE_LITERALS, object, "S_4BYTE_LITERALS");
+  yr_set_integer(S_8BYTE_LITERALS, object, "S_8BYTE_LITERALS");
+  yr_set_integer(S_NON_LAZY_SYMBOL_POINTERS, object, "S_NON_LAZY_SYMBOL_POINTERS");
+  yr_set_integer(S_LAZY_SYMBOL_POINTERS, object, "S_LAZY_SYMBOL_POINTERS");
+  yr_set_integer(S_LITERAL_POINTERS, object, "S_LITERAL_POINTERS");
+  yr_set_integer(S_SYMBOL_STUBS, object, "S_SYMBOL_STUBS");
+  yr_set_integer(S_MOD_INIT_FUNC_POINTERS, object, "S_MOD_INIT_FUNC_POINTERS");
+  yr_set_integer(S_MOD_TERM_FUNC_POINTERS, object, "S_MOD_TERM_FUNC_POINTERS");
+  yr_set_integer(S_COALESCED, object, "S_COALESCED");
+  yr_set_integer(S_GB_ZEROFILL, object, "S_GB_ZEROFILL");
+  yr_set_integer(S_INTERPOSING, object, "S_INTERPOSING");
+  yr_set_integer(S_16BYTE_LITERALS, object, "S_16BYTE_LITERALS");
+  yr_set_integer(S_DTRACE_DOF, object, "S_DTRACE_DOF");
+  yr_set_integer(
       S_LAZY_DYLIB_SYMBOL_POINTERS, object, "S_LAZY_DYLIB_SYMBOL_POINTERS");
-  set_integer(S_THREAD_LOCAL_REGULAR, object, "S_THREAD_LOCAL_REGULAR");
-  set_integer(S_THREAD_LOCAL_ZEROFILL, object, "S_THREAD_LOCAL_ZEROFILL");
-  set_integer(S_THREAD_LOCAL_VARIABLES, object, "S_THREAD_LOCAL_VARIABLES");
-  set_integer(
+  yr_set_integer(S_THREAD_LOCAL_REGULAR, object, "S_THREAD_LOCAL_REGULAR");
+  yr_set_integer(S_THREAD_LOCAL_ZEROFILL, object, "S_THREAD_LOCAL_ZEROFILL");
+  yr_set_integer(S_THREAD_LOCAL_VARIABLES, object, "S_THREAD_LOCAL_VARIABLES");
+  yr_set_integer(
       S_THREAD_LOCAL_VARIABLE_POINTERS,
       object,
       "S_THREAD_LOCAL_VARIABLE_POINTERS");
-  set_integer(
+  yr_set_integer(
       S_THREAD_LOCAL_INIT_FUNCTION_POINTERS,
       object,
       "S_THREAD_LOCAL_INIT_FUNCTION_POINTERS");
 
   // Section attributes
 
-  set_integer(S_ATTR_PURE_INSTRUCTIONS, object, "S_ATTR_PURE_INSTRUCTIONS");
-  set_integer(S_ATTR_NO_TOC, object, "S_ATTR_NO_TOC");
-  set_integer(S_ATTR_STRIP_STATIC_SYMS, object, "S_ATTR_STRIP_STATIC_SYMS");
-  set_integer(S_ATTR_NO_DEAD_STRIP, object, "S_ATTR_NO_DEAD_STRIP");
-  set_integer(S_ATTR_LIVE_SUPPORT, object, "S_ATTR_LIVE_SUPPORT");
-  set_integer(S_ATTR_SELF_MODIFYING_CODE, object, "S_ATTR_SELF_MODIFYING_CODE");
-  set_integer(S_ATTR_DEBUG, object, "S_ATTR_DEBUG");
-  set_integer(S_ATTR_SOME_INSTRUCTIONS, object, "S_ATTR_SOME_INSTRUCTIONS");
-  set_integer(S_ATTR_EXT_RELOC, object, "S_ATTR_EXT_RELOC");
-  set_integer(S_ATTR_LOC_RELOC, object, "S_ATTR_LOC_RELOC");
+  yr_set_integer(S_ATTR_PURE_INSTRUCTIONS, object, "S_ATTR_PURE_INSTRUCTIONS");
+  yr_set_integer(S_ATTR_NO_TOC, object, "S_ATTR_NO_TOC");
+  yr_set_integer(S_ATTR_STRIP_STATIC_SYMS, object, "S_ATTR_STRIP_STATIC_SYMS");
+  yr_set_integer(S_ATTR_NO_DEAD_STRIP, object, "S_ATTR_NO_DEAD_STRIP");
+  yr_set_integer(S_ATTR_LIVE_SUPPORT, object, "S_ATTR_LIVE_SUPPORT");
+  yr_set_integer(S_ATTR_SELF_MODIFYING_CODE, object, "S_ATTR_SELF_MODIFYING_CODE");
+  yr_set_integer(S_ATTR_DEBUG, object, "S_ATTR_DEBUG");
+  yr_set_integer(S_ATTR_SOME_INSTRUCTIONS, object, "S_ATTR_SOME_INSTRUCTIONS");
+  yr_set_integer(S_ATTR_EXT_RELOC, object, "S_ATTR_EXT_RELOC");
+  yr_set_integer(S_ATTR_LOC_RELOC, object, "S_ATTR_LOC_RELOC");
 }
 
 // Get Mach-O file index in fat file by cputype field.
 
 define_function(file_index_type)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   int64_t type_arg = integer_argument(1);
 
-  uint64_t nfat = get_integer(module, "nfat_arch");
-  if (is_undefined(module, "nfat_arch"))
+  uint64_t nfat = yr_get_integer(module, "nfat_arch");
+  if (yr_is_undefined(module, "nfat_arch"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < nfat; i++)
   {
-    int64_t type = get_integer(module, "file[%i].cputype", i);
+    int64_t type = yr_get_integer(module, "file[%i].cputype", i);
     if (type == type_arg)
     {
       return_integer(i);
@@ -966,18 +966,18 @@ define_function(file_index_type)
 
 define_function(file_index_subtype)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   int64_t type_arg = integer_argument(1);
   int64_t subtype_arg = integer_argument(2);
-  uint64_t nfat = get_integer(module, "nfat_arch");
+  uint64_t nfat = yr_get_integer(module, "nfat_arch");
 
-  if (is_undefined(module, "nfat_arch"))
+  if (yr_is_undefined(module, "nfat_arch"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < nfat; i++)
   {
-    int64_t type = get_integer(module, "file[%i].cputype", i);
-    int64_t subtype = get_integer(module, "file[%i].cpusubtype", i);
+    int64_t type = yr_get_integer(module, "file[%i].cputype", i);
+    int64_t subtype = yr_get_integer(module, "file[%i].cpusubtype", i);
 
     if (type == type_arg && subtype == subtype_arg)
     {
@@ -992,20 +992,20 @@ define_function(file_index_subtype)
 
 define_function(ep_for_arch_type)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   int64_t type_arg = integer_argument(1);
-  uint64_t nfat = get_integer(module, "nfat_arch");
+  uint64_t nfat = yr_get_integer(module, "nfat_arch");
 
-  if (is_undefined(module, "nfat_arch"))
+  if (yr_is_undefined(module, "nfat_arch"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < nfat; i++)
   {
-    int64_t type = get_integer(module, "fat_arch[%i].cputype", i);
+    int64_t type = yr_get_integer(module, "fat_arch[%i].cputype", i);
     if (type == type_arg)
     {
-      uint64_t file_offset = get_integer(module, "fat_arch[%i].offset", i);
-      uint64_t entry_point = get_integer(module, "file[%i].entry_point", i);
+      uint64_t file_offset = yr_get_integer(module, "fat_arch[%i].offset", i);
+      uint64_t entry_point = yr_get_integer(module, "file[%i].entry_point", i);
       return_integer(file_offset + entry_point);
     }
   }
@@ -1017,23 +1017,23 @@ define_function(ep_for_arch_type)
 
 define_function(ep_for_arch_subtype)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   int64_t type_arg = integer_argument(1);
   int64_t subtype_arg = integer_argument(2);
-  uint64_t nfat = get_integer(module, "nfat_arch");
+  uint64_t nfat = yr_get_integer(module, "nfat_arch");
 
-  if (is_undefined(module, "nfat_arch"))
+  if (yr_is_undefined(module, "nfat_arch"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < nfat; i++)
   {
-    int64_t type = get_integer(module, "fat_arch[%i].cputype", i);
-    int64_t subtype = get_integer(module, "fat_arch[%i].cpusubtype", i);
+    int64_t type = yr_get_integer(module, "fat_arch[%i].cputype", i);
+    int64_t subtype = yr_get_integer(module, "fat_arch[%i].cpusubtype", i);
 
     if (type == type_arg && subtype == subtype_arg)
     {
-      uint64_t file_offset = get_integer(module, "fat_arch[%i].offset", i);
-      uint64_t entry_point = get_integer(module, "file[%i].entry_point", i);
+      uint64_t file_offset = yr_get_integer(module, "fat_arch[%i].offset", i);
+      uint64_t entry_point = yr_get_integer(module, "file[%i].entry_point", i);
       return_integer(file_offset + entry_point);
     }
   }

--- a/libyara/modules/magic/magic.c
+++ b/libyara/modules/magic/magic.c
@@ -87,7 +87,7 @@ static int get_cache(MAGIC_CACHE** cache)
 
 define_function(magic_mime_type)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block;
   MAGIC_CACHE* cache;
 
@@ -122,7 +122,7 @@ define_function(magic_type)
 {
   MAGIC_CACHE* cache;
   YR_MEMORY_BLOCK* block;
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   const uint8_t* block_data;
 

--- a/libyara/modules/math/math.c
+++ b/libyara/modules/math/math.c
@@ -197,7 +197,7 @@ define_function(data_entropy)
   int64_t offset = integer_argument(1);  // offset where to start
   int64_t length = integer_argument(2);  // length of bytes we want entropy on
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   size_t i;
 
@@ -250,7 +250,7 @@ define_function(data_deviation)
   size_t total_len = 0;
   size_t i;
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* data = get_distribution(offset, length, context);
   if (data == NULL)
@@ -285,7 +285,7 @@ define_function(data_mean)
   int64_t offset = integer_argument(1);
   int64_t length = integer_argument(2);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   size_t total_len = 0;
   size_t i;
@@ -314,7 +314,7 @@ define_function(data_serial_correlation)
   int64_t offset = integer_argument(1);
   int64_t length = integer_argument(2);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -435,7 +435,7 @@ define_function(data_monte_carlo_pi)
   int64_t offset = integer_argument(1);
   int64_t length = integer_argument(2);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
@@ -598,7 +598,7 @@ define_function(count_range)
   int64_t offset = integer_argument(2);
   int64_t length = integer_argument(3);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution(offset, length, context);
   if (distribution == NULL)
@@ -614,7 +614,7 @@ define_function(count_global)
 {
   uint8_t byte = (uint8_t) integer_argument(1);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution_global(context);
   if (distribution == NULL)
@@ -632,7 +632,7 @@ define_function(percentage_range)
   int64_t offset = integer_argument(2);
   int64_t length = integer_argument(3);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution(offset, length, context);
   if (distribution == NULL) {
@@ -652,7 +652,7 @@ define_function(percentage_global)
 {
   uint8_t byte = (uint8_t) integer_argument(1);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution_global(context);
   if (distribution == NULL) {
@@ -673,7 +673,7 @@ define_function(mode_range)
   int64_t offset = integer_argument(1);
   int64_t length = integer_argument(2);
 
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution(offset, length, context);
   if (distribution == NULL) {
@@ -695,7 +695,7 @@ define_function(mode_range)
 
 define_function(mode_global)
 {
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   uint32_t* distribution = get_distribution_global(context);
   if (distribution == NULL) {
@@ -756,7 +756,7 @@ int module_load(
     void* module_data,
     size_t module_data_size)
 {
-  set_float(127.5, module_object, "MEAN_BYTES");
+  yr_set_float(127.5, module_object, "MEAN_BYTES");
   return ERROR_SUCCESS;
 }
 

--- a/libyara/modules/pb_tests/pb_tests.c
+++ b/libyara/modules/pb_tests/pb_tests.c
@@ -96,45 +96,45 @@ int module_load(
   if (pb == NULL)
     return ERROR_INVALID_MODULE_DATA;
 
-  set_integer(0, module_object, "struct.enum.FIRST");
-  set_integer(1, module_object, "struct.enum.SECOND");
+  yr_set_integer(0, module_object, "struct.enum.FIRST");
+  yr_set_integer(1, module_object, "struct.enum.SECOND");
 
   if (pb->has_f_int32)
   {
-    set_integer(pb->f_int32, module_object, "f_int32");
+    yr_set_integer(pb->f_int32, module_object, "f_int32");
   }
 
   if (pb->has_f_int64)
   {
-    set_integer(pb->f_int64, module_object, "f_int64");
+    yr_set_integer(pb->f_int64, module_object, "f_int64");
   }
 
   if (pb->has_f_sint32)
   {
-    set_integer(pb->f_sint32, module_object, "f_sint32");
+    yr_set_integer(pb->f_sint32, module_object, "f_sint32");
   }
 
   if (pb->has_f_sint64)
   {
-    set_integer(pb->f_sint64, module_object, "f_sint64");
+    yr_set_integer(pb->f_sint64, module_object, "f_sint64");
   }
 
   if (pb->has_f_sfixed32)
   {
-    set_integer(pb->f_sfixed32, module_object, "f_sfixed32");
+    yr_set_integer(pb->f_sfixed32, module_object, "f_sfixed32");
   }
 
   if (pb->has_f_sfixed64)
   {
-    set_integer(pb->f_sfixed64, module_object, "f_sfixed64");
+    yr_set_integer(pb->f_sfixed64, module_object, "f_sfixed64");
   }
 
   if (pb->has_f_bool)
   {
-    set_integer(pb->f_bool, module_object, "f_bool");
+    yr_set_integer(pb->f_bool, module_object, "f_bool");
   }
-  set_string(pb->f_string, module_object, "f_string");
-  set_sized_string(
+  yr_set_string(pb->f_string, module_object, "f_string");
+  yr_set_sized_string(
       (const char*) pb->f_bytes.data,
       pb->f_bytes.len,
       module_object,
@@ -144,7 +144,7 @@ int module_load(
   {
     if (pb->f_struct_array[i] != NULL)
     {
-      set_string(
+      yr_set_string(
           pb->f_struct_array[i]->f_string,
           module_object,
           "f_struct_array[%i].f_string",
@@ -152,7 +152,7 @@ int module_load(
 
       if (pb->f_struct_array[i]->has_f_enum)
       {
-        set_integer(
+        yr_set_integer(
             pb->f_struct_array[i]->f_enum,
             module_object,
             "f_struct_array[%i].f_enum",
@@ -163,13 +163,13 @@ int module_load(
       {
         if (pb->f_struct_array[i]->f_nested_struct->has_f_int32)
         {
-          set_integer(
+          yr_set_integer(
               pb->f_struct_array[i]->f_nested_struct->f_int32,
               module_object,
               "f_struct_array[%i].f_nested_struct.f_int32",
               i);
         }
-        set_string(
+        yr_set_string(
             pb->f_struct_array[i]->f_nested_struct->f_string,
             module_object,
             "f_struct_array[%i].f_nested_struct.f_string",
@@ -182,14 +182,14 @@ int module_load(
         {
           if (pb->f_struct_array[i]->f_nested_struct_array[j]->has_f_int32)
           {
-            set_integer(
+            yr_set_integer(
                 pb->f_struct_array[i]->f_nested_struct_array[j]->f_int32,
                 module_object,
                 "f_struct_array[%i].f_nested_struct_array[%i].f_int32",
                 i,
                 j);
           }
-          set_string(
+          yr_set_string(
               pb->f_struct_array[i]->f_nested_struct_array[j]->f_string,
               module_object,
               "f_struct_array[%i].f_nested_struct_array[%i].f_string",
@@ -206,7 +206,7 @@ int module_load(
     {
       if (pb->f_map_int32[i]->has_value)
       {
-        set_integer(
+        yr_set_integer(
             pb->f_map_int32[i]->value,
             module_object,
             "f_map_int32[%s]",
@@ -221,7 +221,7 @@ int module_load(
     {
       if (pb->f_map_bool[i]->has_value)
       {
-        set_integer(
+        yr_set_integer(
             pb->f_map_bool[i]->value,
             module_object,
             "f_map_bool[%s]",
@@ -234,7 +234,7 @@ int module_load(
   {
     if (pb->f_map_string[i] != NULL)
     {
-      set_string(
+      yr_set_string(
           pb->f_map_string[i]->value,
           module_object,
           "f_map_string[%s]",
@@ -248,7 +248,7 @@ int module_load(
     {
       if (pb->f_map_float[i]->has_value)
       {
-        set_float(
+        yr_set_float(
             pb->f_map_float[i]->value,
             module_object,
             "f_map_float[%s]",
@@ -265,7 +265,7 @@ int module_load(
       {
         if (pb->f_map_struct[i]->value->has_f_int32)
         {
-          set_integer(
+          yr_set_integer(
               pb->f_map_struct[i]->value->f_int32,
               module_object,
               "f_map_struct[%s].f_int32",
@@ -274,7 +274,7 @@ int module_load(
 
         if (pb->f_map_struct[i]->value->has_f_int64)
         {
-          set_integer(
+          yr_set_integer(
               pb->f_map_struct[i]->value->f_int64,
               module_object,
               "f_map_struct[%s].f_int64",
@@ -286,7 +286,7 @@ int module_load(
 
   if (pb->f_oneof_case == 20)
   {
-    set_string(pb->f_oneof_string, module_object, "f_oneof_string");
+    yr_set_string(pb->f_oneof_string, module_object, "f_oneof_string");
   }
 
   if (pb->f_oneof_case == 21)
@@ -295,7 +295,7 @@ int module_load(
     {
       if (pb->f_oneof_struct->has_f_int32)
       {
-        set_integer(
+        yr_set_integer(
             pb->f_oneof_struct->f_int32,
             module_object,
             "f_oneof_struct.f_int32");
@@ -303,14 +303,14 @@ int module_load(
 
       if (pb->f_oneof_struct->has_f_int64)
       {
-        set_integer(
+        yr_set_integer(
             pb->f_oneof_struct->f_int64,
             module_object,
             "f_oneof_struct.f_int64");
       }
     }
   }
-  set_string(pb->f_renamed, module_object, "f_yara_name");
+  yr_set_string(pb->f_renamed, module_object, "f_yara_name");
 
 
   test__root_message__free_unpacked(pb, &allocator);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -223,14 +223,14 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
 
   memcpy(raw_data, rich_signature, rich_len);
 
-  set_integer(
+  yr_set_integer(
       base_address + ((uint8_t*) rich_signature - pe->data),
       pe->object,
       "rich_signature.offset");
 
-  set_integer(rich_len, pe->object, "rich_signature.length");
+  yr_set_integer(rich_len, pe->object, "rich_signature.length");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(rich_signature->key1), pe->object, "rich_signature.key");
 
   clear_data = (BYTE*) yr_malloc(rich_len);
@@ -251,10 +251,10 @@ static void pe_parse_rich_signature(PE* pe, uint64_t base_address)
     *rich_ptr ^= rich_signature->key1;
   }
 
-  set_sized_string(
+  yr_set_sized_string(
       (char*) raw_data, rich_len, pe->object, "rich_signature.raw_data");
 
-  set_sized_string(
+  yr_set_sized_string(
       (char*) clear_data, rich_len, pe->object, "rich_signature.clear_data");
 
   yr_free(raw_data);
@@ -356,7 +356,7 @@ static void pe_parse_debug_directory(PE* pe)
 
       if (pdb_path_len > 0 && pdb_path_len < MAX_PATH)
       {
-        set_sized_string(pdb_path, pdb_path_len, pe->object, "pdb_path");
+        yr_set_sized_string(pdb_path, pdb_path_len, pe->object, "pdb_path");
         break;
       }
     }
@@ -364,7 +364,7 @@ static void pe_parse_debug_directory(PE* pe)
 }
 
 // Return a pointer to the resource directory string or NULL.
-// The callback function will parse this and call set_sized_string().
+// The callback function will parse this and call yr_set_sized_string().
 // The pointer is guaranteed to have enough space to contain the entire string.
 
 static const PIMAGE_RESOURCE_DIR_STRING_U parse_resource_name(
@@ -553,17 +553,17 @@ static int pe_iterate_resources(
 
     if (struct_fits_in_pe(pe, rsrc_dir, IMAGE_RESOURCE_DIRECTORY))
     {
-      set_integer(
+      yr_set_integer(
           yr_le32toh(rsrc_dir->TimeDateStamp),
           pe->object,
           "resource_timestamp");
 
-      set_integer(
+      yr_set_integer(
           yr_le16toh(rsrc_dir->MajorVersion),
           pe->object,
           "resource_version.major");
 
-      set_integer(
+      yr_set_integer(
           yr_le16toh(rsrc_dir->MinorVersion),
           pe->object,
           "resource_version.minor");
@@ -663,12 +663,12 @@ static void pe_parse_version_info(PIMAGE_RESOURCE_DATA_ENTRY rsrc_data, PE* pe)
           if (yr_le16toh(string->ValueLength) == 0)
             value[yr_le16toh(string->ValueLength)] = '\0';
 
-          set_string(value, pe->object, "version_info[%s]", key);
+          yr_set_string(value, pe->object, "version_info[%s]", key);
 
-          set_string(
+          yr_set_string(
               key, pe->object, "version_info_list[%i].key", pe->version_infos);
 
-          set_string(
+          yr_set_string(
               value,
               pe->object,
               "version_info_list[%i].value",
@@ -699,7 +699,7 @@ static void pe_set_resource_string_or_id(
     // If not, the name becomes UNDEFINED by default.
     if (fits_in_pe(pe, rsrc_string->NameString, length))
     {
-      set_sized_string(
+      yr_set_sized_string(
           (char*) rsrc_string->NameString,
           length,
           pe->object,
@@ -709,7 +709,7 @@ static void pe_set_resource_string_or_id(
   }
   else
   {
-    set_integer(rsrc_int, pe->object, int_description, pe->resources);
+    yr_set_integer(rsrc_int, pe->object, int_description, pe->resources);
   }
 }
 
@@ -727,7 +727,7 @@ static int pe_collect_resources(
   if (pe->resources > MAX_RESOURCES)
     return RESOURCE_CALLBACK_CONTINUE;
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(rsrc_data->OffsetToData),
       pe->object,
       "resources[%i].rva",
@@ -738,9 +738,9 @@ static int pe_collect_resources(
   if (offset < 0)
     offset = YR_UNDEFINED;
 
-  set_integer(offset, pe->object, "resources[%i].offset", pe->resources);
+  yr_set_integer(offset, pe->object, "resources[%i].offset", pe->resources);
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(rsrc_data->Size),
       pe->object,
       "resources[%i].length",
@@ -998,14 +998,14 @@ void pe_set_imports(
     for (IMPORT_FUNCTION* func = dll->functions; func != NULL;
          func = func->next, fun_cnt++)
     {
-      set_string(func->name, pe->object, fun_name, dll_cnt, fun_cnt);
+      yr_set_string(func->name, pe->object, fun_name, dll_cnt, fun_cnt);
       if (func->has_ordinal)
-        set_integer(func->ordinal, pe->object, fun_ordinal, dll_cnt, fun_cnt);
+        yr_set_integer(func->ordinal, pe->object, fun_ordinal, dll_cnt, fun_cnt);
       else
-        set_integer(YR_UNDEFINED, pe->object, fun_ordinal, dll_cnt, fun_cnt);
+        yr_set_integer(YR_UNDEFINED, pe->object, fun_ordinal, dll_cnt, fun_cnt);
     }
-    set_string(dll->name, pe->object, dll_name, dll_cnt);
-    set_integer(fun_cnt, pe->object, dll_number_of_functions, dll_cnt);
+    yr_set_string(dll->name, pe->object, dll_name, dll_cnt);
+    yr_set_integer(fun_cnt, pe->object, dll_number_of_functions, dll_cnt);
   }
 }
 
@@ -1028,8 +1028,8 @@ static IMPORTED_DLL* pe_parse_imports(PE* pe)
   PIMAGE_DATA_DIRECTORY directory;
 
   // Default to 0 imports until we know there are any
-  set_integer(0, pe->object, "number_of_imports");
-  set_integer(0, pe->object, "number_of_imported_functions");
+  yr_set_integer(0, pe->object, "number_of_imports");
+  yr_set_integer(0, pe->object, "number_of_imported_functions");
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_IMPORT);
 
@@ -1096,8 +1096,8 @@ static IMPORTED_DLL* pe_parse_imports(PE* pe)
     imports++;
   }
 
-  set_integer(num_imports, pe->object, "number_of_imports");
-  set_integer(num_function_imports, pe->object, "number_of_imported_functions");
+  yr_set_integer(num_imports, pe->object, "number_of_imports");
+  yr_set_integer(num_function_imports, pe->object, "number_of_imported_functions");
   pe_set_imports(
       pe,
       head,
@@ -1209,8 +1209,8 @@ static void* pe_parse_delayed_imports(PE* pe)
   PIMAGE_DATA_DIRECTORY directory = NULL;
 
   // Default to 0 imports until we know there are any
-  set_integer(0, pe->object, "number_of_delayed_imports");
-  set_integer(0, pe->object, "number_of_delayed_imported_functions");
+  yr_set_integer(0, pe->object, "number_of_delayed_imports");
+  yr_set_integer(0, pe->object, "number_of_delayed_imported_functions");
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT);
 
@@ -1376,8 +1376,8 @@ static void* pe_parse_delayed_imports(PE* pe)
     tail_dll = imported_dll;
   }
 
-  set_integer(num_imports, pe->object, "number_of_delayed_imports");
-  set_integer(
+  yr_set_integer(num_imports, pe->object, "number_of_delayed_imports");
+  yr_set_integer(
       num_function_imports, pe->object, "number_of_delayed_imported_functions");
 
   pe_set_imports(
@@ -1424,7 +1424,7 @@ static void pe_parse_exports(PE* pe)
     return;
 
   // Default to 0 exports until we know there are any
-  set_integer(0, pe->object, "number_of_exports");
+  yr_set_integer(0, pe->object, "number_of_exports");
 
   directory = pe_get_directory_entry(pe, IMAGE_DIRECTORY_ENTRY_EXPORT);
 
@@ -1452,7 +1452,7 @@ static void pe_parse_exports(PE* pe)
 
   ordinal_base = yr_le32toh(exports->Base);
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(exports->TimeDateStamp), pe->object, "export_timestamp");
 
   offset = pe_rva_to_offset(pe, yr_le32toh(exports->Name));
@@ -1461,7 +1461,7 @@ static void pe_parse_exports(PE* pe)
   {
     remaining = pe->data_size - (size_t) offset;
     name_len = strnlen((char*) (pe->data + offset), remaining);
-    set_sized_string(
+    yr_set_sized_string(
         (char*) (pe->data + offset), name_len, pe->object, "dll_name");
   }
 
@@ -1539,7 +1539,7 @@ static void pe_parse_exports(PE* pe)
 
   for (i = 0; i < number_of_exports; i++)
   {
-    set_integer(
+    yr_set_integer(
         ordinal_base + i, pe->object, "export_details[%i].ordinal", exp_sz);
 
     // Don't check for a failure here since some packers make this an invalid
@@ -1551,7 +1551,7 @@ static void pe_parse_exports(PE* pe)
       remaining = pe->data_size - (size_t) offset;
       name_len = strnlen((char*) (pe->data + offset), remaining);
 
-      set_sized_string(
+      yr_set_sized_string(
           (char*) (pe->data + offset),
           yr_min(name_len, MAX_EXPORT_NAME_LENGTH),
           pe->object,
@@ -1560,7 +1560,7 @@ static void pe_parse_exports(PE* pe)
     }
     else
     {
-      set_integer(offset, pe->object, "export_details[%i].offset", exp_sz);
+      yr_set_integer(offset, pe->object, "export_details[%i].offset", exp_sz);
     }
 
     if (names != NULL)
@@ -1576,7 +1576,7 @@ static void pe_parse_exports(PE* pe)
             remaining = pe->data_size - (size_t) offset;
             name_len = strnlen((char*) (pe->data + offset), remaining);
 
-            set_sized_string(
+            yr_set_sized_string(
                 (char*) (pe->data + offset),
                 yr_min(name_len, MAX_EXPORT_NAME_LENGTH),
                 pe->object,
@@ -1590,7 +1590,7 @@ static void pe_parse_exports(PE* pe)
     exp_sz++;
   }
 
-  set_integer(exp_sz, pe->object, "number_of_exports");
+  yr_set_integer(exp_sz, pe->object, "number_of_exports");
 }
 
 // BoringSSL (https://boringssl.googlesource.com/boringssl/) doesn't support
@@ -1606,19 +1606,19 @@ static void pe_parse_exports(PE* pe)
     for (int j = 0; j < cert->sha1.len; ++j)                                   \
       sprintf(thumbprint_ascii + (j * 2), "%02x", cert->sha1.data[j]);         \
                                                                                \
-    set_string(                                                                \
+    yr_set_string(                                                                \
         (char*) thumbprint_ascii, pe->object, fmt ".thumbprint", __VA_ARGS__); \
                                                                                \
-    set_string(cert->issuer, pe->object, fmt ".issuer", __VA_ARGS__);          \
-    set_string(cert->subject, pe->object, fmt ".subject", __VA_ARGS__);        \
+    yr_set_string(cert->issuer, pe->object, fmt ".issuer", __VA_ARGS__);          \
+    yr_set_string(cert->subject, pe->object, fmt ".subject", __VA_ARGS__);        \
     /* Versions are zero based, so add one.  */                                \
-    set_integer(cert->version + 1, pe->object, fmt ".version", __VA_ARGS__);   \
-    set_string(cert->sig_alg, pe->object, fmt ".algorithm", __VA_ARGS__);      \
-    set_string(                                                                \
+    yr_set_integer(cert->version + 1, pe->object, fmt ".version", __VA_ARGS__);   \
+    yr_set_string(cert->sig_alg, pe->object, fmt ".algorithm", __VA_ARGS__);      \
+    yr_set_string(                                                                \
         cert->sig_alg_oid, pe->object, fmt ".algorithm_oid", __VA_ARGS__);     \
-    set_string(cert->serial, pe->object, fmt ".serial", __VA_ARGS__);          \
-    set_integer(cert->not_before, pe->object, fmt ".not_before", __VA_ARGS__); \
-    set_integer(cert->not_after, pe->object, fmt ".not_after", __VA_ARGS__);   \
+    yr_set_string(cert->serial, pe->object, fmt ".serial", __VA_ARGS__);          \
+    yr_set_integer(cert->not_before, pe->object, fmt ".not_before", __VA_ARGS__); \
+    yr_set_integer(cert->not_after, pe->object, fmt ".not_after", __VA_ARGS__);   \
   } while (0)
 
 void _process_authenticode(
@@ -1640,10 +1640,10 @@ void _process_authenticode(
                           ? true
                           : false;
 
-    set_integer(
+    yr_set_integer(
         signature_valid, pe->object, "signatures[%i].verified", *sig_count);
 
-    set_string(
+    yr_set_string(
         authenticode->digest_alg,
         pe->object,
         "signatures[%i].digest_alg",
@@ -1655,7 +1655,7 @@ void _process_authenticode(
       for (int j = 0; j < authenticode->digest.len; ++j)
         sprintf(digest_ascii + (j * 2), "%02x", authenticode->digest.data[j]);
 
-      set_string(digest_ascii, pe->object, "signatures[%i].digest", *sig_count);
+      yr_set_string(digest_ascii, pe->object, "signatures[%i].digest", *sig_count);
       yr_free(digest_ascii);
     }
 
@@ -1666,14 +1666,14 @@ void _process_authenticode(
         sprintf(
             digest_ascii + (j * 2), "%02x", authenticode->file_digest.data[j]);
 
-      set_string(
+      yr_set_string(
           digest_ascii, pe->object, "signatures[%i].file_digest", *sig_count);
       yr_free(digest_ascii);
     }
 
     if (authenticode->certs)
     {
-      set_integer(
+      yr_set_integer(
           authenticode->certs->count,
           pe->object,
           "signatures[%i].number_of_certificates",
@@ -1701,12 +1701,12 @@ void _process_authenticode(
         write_certificate(sign_cert, pe, "signatures[%i]", *sig_count);
       }
 
-      set_string(
+      yr_set_string(
           signer->program_name,
           pe->object,
           "signatures[%i].signer_info.program_name",
           *sig_count);
-      set_string(
+      yr_set_string(
           signer->digest_alg,
           pe->object,
           "signatures[%i].signer_info.digest_alg",
@@ -1718,7 +1718,7 @@ void _process_authenticode(
         for (int j = 0; j < signer->digest.len; ++j)
           sprintf(digest_ascii + (j * 2), "%02x", signer->digest.data[j]);
 
-        set_string(
+        yr_set_string(
             digest_ascii,
             pe->object,
             "signatures[%i].signer_info.digest",
@@ -1728,7 +1728,7 @@ void _process_authenticode(
 
       if (signer->chain)
       {
-        set_integer(
+        yr_set_integer(
             signer->chain->count,
             pe->object,
             "signatures[%i].signer_info.length_of_chain",
@@ -1747,7 +1747,7 @@ void _process_authenticode(
     }
     if (authenticode->countersigs)
     {
-      set_integer(
+      yr_set_integer(
           authenticode->countersigs->count,
           pe->object,
           "signatures[%i].number_of_countersignatures",
@@ -1758,19 +1758,19 @@ void _process_authenticode(
         const Countersignature* counter =
             authenticode->countersigs->counters[j];
 
-        set_integer(
+        yr_set_integer(
             counter->verify_flags == COUNTERSIGNATURE_VFY_VALID,
             pe->object,
             "signatures[%i].countersignatures[%i].verified",
             *sig_count,
             j);
-        set_string(
+        yr_set_string(
             counter->digest_alg,
             pe->object,
             "signatures[%i].countersignatures[%i].digest_alg",
             *sig_count,
             j);
-        set_integer(
+        yr_set_integer(
             counter->sign_time,
             pe->object,
             "signatures[%i].countersignatures[%i].sign_time",
@@ -1783,7 +1783,7 @@ void _process_authenticode(
           for (int j = 0; j < counter->digest.len; ++j)
             sprintf(digest_ascii + (j * 2), "%02x", counter->digest.data[j]);
 
-          set_string(
+          yr_set_string(
               digest_ascii,
               pe->object,
               "signatures[%i].countersignatures[%i].digest",
@@ -1794,7 +1794,7 @@ void _process_authenticode(
 
         if (counter->chain)
         {
-          set_integer(
+          yr_set_integer(
               counter->chain->count,
               pe->object,
               "signatures[%i].countersignatures[%i].length_of_chain",
@@ -1818,7 +1818,7 @@ void _process_authenticode(
     (*sig_count)++;
   }
 
-  set_integer(signature_valid, pe->object, "is_signed");
+  yr_set_integer(signature_valid, pe->object, "is_signed");
 }
 
 static void pe_parse_certificates(PE* pe)
@@ -1832,7 +1832,7 @@ static void pe_parse_certificates(PE* pe)
     return;
 
   // Default to 0 signatures until we know otherwise.
-  set_integer(0, pe->object, "number_of_signatures");
+  yr_set_integer(0, pe->object, "number_of_signatures");
 
   // directory->VirtualAddress is a file offset. Don't call pe_rva_to_offset().
   if (yr_le32toh(directory->VirtualAddress) == 0 ||
@@ -1848,7 +1848,7 @@ static void pe_parse_certificates(PE* pe)
   _process_authenticode(pe, auth_array, &counter);
   authenticode_array_free(auth_array);
 
-  set_integer(counter, pe->object, "number_of_signatures");
+  yr_set_integer(counter, pe->object, "number_of_signatures");
 }
 
 #endif  // defined(HAVE_LIBCRYPTO)
@@ -1930,42 +1930,42 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
   uint64_t section_end;
   uint64_t last_section_end;
 
-  set_integer(1, pe->object, "is_pe");
+  yr_set_integer(1, pe->object, "is_pe");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(pe->header->FileHeader.Machine), pe->object, "machine");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(pe->header->FileHeader.NumberOfSections),
       pe->object,
       "number_of_sections");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(pe->header->FileHeader.TimeDateStamp),
       pe->object,
       "timestamp");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(pe->header->FileHeader.PointerToSymbolTable),
       pe->object,
       "pointer_to_symbol_table");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(pe->header->FileHeader.NumberOfSymbols),
       pe->object,
       "number_of_symbols");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(pe->header->FileHeader.SizeOfOptionalHeader),
       pe->object,
       "size_of_optional_header");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(pe->header->FileHeader.Characteristics),
       pe->object,
       "characteristics");
 
-  set_integer(
+  yr_set_integer(
       flags & SCAN_FLAGS_PROCESS_MEMORY
           ? base_address + yr_le32toh(OptionalHeader(pe, AddressOfEntryPoint))
           : pe_rva_to_offset(
@@ -1973,147 +1973,147 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
       pe->object,
       "entry_point");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, AddressOfEntryPoint)),
       pe->object,
       "entry_point_raw");
 
-  set_integer(
+  yr_set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, ImageBase))
                        : yr_le32toh(OptionalHeader(pe, ImageBase)),
       pe->object,
       "image_base");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, NumberOfRvaAndSizes)),
       pe->object,
       "number_of_rva_and_sizes");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, Magic)), pe->object, "opthdr_magic");
 
-  set_integer(
+  yr_set_integer(
       OptionalHeader(pe, MajorLinkerVersion),
       pe->object,
       "linker_version.major");
 
-  set_integer(
+  yr_set_integer(
       OptionalHeader(pe, MinorLinkerVersion),
       pe->object,
       "linker_version.minor");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SizeOfCode)), pe->object, "size_of_code");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SizeOfInitializedData)),
       pe->object,
       "size_of_initialized_data");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SizeOfUninitializedData)),
       pe->object,
       "size_of_uninitialized_data");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, BaseOfCode)), pe->object, "base_of_code");
 
   if (!IS_64BITS_PE(pe))
   {
-    set_integer(
+    yr_set_integer(
         yr_le32toh(pe->header->OptionalHeader.BaseOfData),
         pe->object,
         "base_of_data");
   }
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SectionAlignment)),
       pe->object,
       "section_alignment");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, FileAlignment)),
       pe->object,
       "file_alignment");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MajorOperatingSystemVersion)),
       pe->object,
       "os_version.major");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MinorOperatingSystemVersion)),
       pe->object,
       "os_version.minor");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MajorImageVersion)),
       pe->object,
       "image_version.major");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MinorImageVersion)),
       pe->object,
       "image_version.minor");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MajorSubsystemVersion)),
       pe->object,
       "subsystem_version.major");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, MinorSubsystemVersion)),
       pe->object,
       "subsystem_version.minor");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, Win32VersionValue)),
       pe->object,
       "win32_version_value");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SizeOfImage)), pe->object, "size_of_image");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, SizeOfHeaders)),
       pe->object,
       "size_of_headers");
 
-  set_integer(yr_le32toh(OptionalHeader(pe, CheckSum)), pe->object, "checksum");
+  yr_set_integer(yr_le32toh(OptionalHeader(pe, CheckSum)), pe->object, "checksum");
 
-  set_integer(
+  yr_set_integer(
       yr_le16toh(OptionalHeader(pe, Subsystem)), pe->object, "subsystem");
 
-  set_integer(
+  yr_set_integer(
       OptionalHeader(pe, DllCharacteristics),
       pe->object,
       "dll_characteristics");
 
-  set_integer(
+  yr_set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, SizeOfStackReserve))
                        : yr_le32toh(OptionalHeader(pe, SizeOfStackReserve)),
       pe->object,
       "size_of_stack_reserve");
 
-  set_integer(
+  yr_set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, SizeOfStackCommit))
                        : yr_le32toh(OptionalHeader(pe, SizeOfStackCommit)),
       pe->object,
       "size_of_stack_commit");
 
-  set_integer(
+  yr_set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, SizeOfHeapReserve))
                        : yr_le32toh(OptionalHeader(pe, SizeOfHeapReserve)),
       pe->object,
       "size_of_heap_reserve");
 
-  set_integer(
+  yr_set_integer(
       IS_64BITS_PE(pe) ? yr_le64toh(OptionalHeader(pe, SizeOfHeapCommit))
                        : yr_le32toh(OptionalHeader(pe, SizeOfHeapCommit)),
       pe->object,
       "size_of_heap_commit");
 
-  set_integer(
+  yr_set_integer(
       yr_le32toh(OptionalHeader(pe, LoaderFlags)), pe->object, "loader_flags");
 
   data_dir = IS_64BITS_PE(pe) ? pe->header64->OptionalHeader.DataDirectory
@@ -2127,13 +2127,13 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
     if (!struct_fits_in_pe(pe, data_dir, IMAGE_DATA_DIRECTORY))
       break;
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(data_dir->VirtualAddress),
         pe->object,
         "data_directories[%i].virtual_address",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(data_dir->Size), pe->object, "data_directories[%i].size", i);
 
     data_dir++;
@@ -2142,8 +2142,8 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
   pe_iterate_resources(
       pe, (RESOURCE_CALLBACK_FUNC) pe_collect_resources, (void*) pe);
 
-  set_integer(pe->resources, pe->object, "number_of_resources");
-  set_integer(pe->version_infos, pe->object, "number_of_version_infos");
+  yr_set_integer(pe->resources, pe->object, "number_of_resources");
+  yr_set_integer(pe->version_infos, pe->object, "number_of_version_infos");
 
   section = IMAGE_FIRST_SECTION(pe->header);
 
@@ -2173,69 +2173,69 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
     const char* full_section_name = pe_get_section_full_name(
         pe, section_name, sect_name_length + 1, &sect_full_name_length);
 
-    set_sized_string(
+    yr_set_sized_string(
         (char*) section_name,
         sect_name_length + 1,
         pe->object,
         "sections[%i].name",
         i);
 
-    set_sized_string(
+    yr_set_sized_string(
         full_section_name,
         sect_full_name_length,
         pe->object,
         "sections[%i].full_name",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->Characteristics),
         pe->object,
         "sections[%i].characteristics",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->SizeOfRawData),
         pe->object,
         "sections[%i].raw_data_size",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->PointerToRawData),
         pe->object,
         "sections[%i].raw_data_offset",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->VirtualAddress),
         pe->object,
         "sections[%i].virtual_address",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->Misc.VirtualSize),
         pe->object,
         "sections[%i].virtual_size",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->PointerToRelocations),
         pe->object,
         "sections[%i].pointer_to_relocations",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->PointerToLinenumbers),
         pe->object,
         "sections[%i].pointer_to_line_numbers",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->NumberOfRelocations),
         pe->object,
         "sections[%i].number_of_relocations",
         i);
 
-    set_integer(
+    yr_set_integer(
         yr_le32toh(section->NumberOfLinenumbers),
         pe->object,
         "sections[%i].number_of_line_numbers",
@@ -2268,13 +2268,13 @@ static void pe_parse_header(PE* pe, uint64_t base_address, int flags)
   // file is not a PE file (or is a malformed PE) both fields are YR_UNDEFINED.
   if (last_section_end && (pe->data_size > last_section_end))
   {
-    set_integer(last_section_end, pe->object, "overlay.offset");
-    set_integer(pe->data_size - last_section_end, pe->object, "overlay.size");
+    yr_set_integer(last_section_end, pe->object, "overlay.offset");
+    yr_set_integer(pe->data_size - last_section_end, pe->object, "overlay.size");
   }
   else
   {
-    set_integer(0, pe->object, "overlay.offset");
-    set_integer(0, pe->object, "overlay.size");
+    yr_set_integer(0, pe->object, "overlay.offset");
+    yr_set_integer(0, pe->object, "overlay.size");
   }
 }
 
@@ -2288,45 +2288,45 @@ define_function(valid_on)
   int64_t not_before;
   int64_t not_after;
 
-  if (is_undefined(parent(), "not_before") ||
-      is_undefined(parent(), "not_after"))
+  if (yr_is_undefined(yr_parent(), "not_before") ||
+      yr_is_undefined(yr_parent(), "not_after"))
   {
     return_integer(YR_UNDEFINED);
   }
 
   timestamp = integer_argument(1);
 
-  not_before = get_integer(parent(), "not_before");
-  not_after = get_integer(parent(), "not_after");
+  not_before = yr_get_integer(yr_parent(), "not_before");
+  not_after = yr_get_integer(yr_parent(), "not_after");
 
   return_integer(timestamp >= not_before && timestamp <= not_after);
 }
 
 define_function(section_index_addr)
 {
-  YR_OBJECT* module = module();
-  YR_SCAN_CONTEXT* context = scan_context();
+  YR_OBJECT* module = yr_module();
+  YR_SCAN_CONTEXT* context = yr_scan_context();
 
   int64_t offset;
   int64_t size;
 
   int64_t addr = integer_argument(1);
-  int64_t n = get_integer(module, "number_of_sections");
+  int64_t n = yr_get_integer(module, "number_of_sections");
 
-  if (is_undefined(module, "number_of_sections"))
+  if (yr_is_undefined(module, "number_of_sections"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < yr_min(n, MAX_PE_SECTIONS); i++)
   {
     if (context->flags & SCAN_FLAGS_PROCESS_MEMORY)
     {
-      offset = get_integer(module, "sections[%i].virtual_address", i);
-      size = get_integer(module, "sections[%i].virtual_size", i);
+      offset = yr_get_integer(module, "sections[%i].virtual_address", i);
+      size = yr_get_integer(module, "sections[%i].virtual_size", i);
     }
     else
     {
-      offset = get_integer(module, "sections[%i].raw_data_offset", i);
-      size = get_integer(module, "sections[%i].raw_data_size", i);
+      offset = yr_get_integer(module, "sections[%i].raw_data_offset", i);
+      size = yr_get_integer(module, "sections[%i].raw_data_size", i);
     }
 
     if (addr >= offset && addr < offset + size)
@@ -2338,18 +2338,18 @@ define_function(section_index_addr)
 
 define_function(section_index_name)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
 
   char* name = string_argument(1);
 
-  int64_t n = get_integer(module, "number_of_sections");
+  int64_t n = yr_get_integer(module, "number_of_sections");
 
-  if (is_undefined(module, "number_of_sections"))
+  if (yr_is_undefined(module, "number_of_sections"))
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < yr_min(n, MAX_PE_SECTIONS); i++)
   {
-    SIZED_STRING* sect = get_string(module, "sections[%i].name", i);
+    SIZED_STRING* sect = yr_get_string(module, "sections[%i].name", i);
 
     if (sect != NULL && strcmp(name, sect->c_string) == 0)
       return_integer(i);
@@ -2363,7 +2363,7 @@ define_function(exports)
   SIZED_STRING* search_name = sized_string_argument(1);
 
   SIZED_STRING* function_name = NULL;
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2371,14 +2371,14 @@ define_function(exports)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(0);
 
   for (int i = 0; i < n; i++)
   {
-    function_name = get_string(module, "export_details[%i].name", i);
+    function_name = yr_get_string(module, "export_details[%i].name", i);
 
     if (function_name == NULL)
       continue;
@@ -2395,7 +2395,7 @@ define_function(exports_regexp)
   RE* regex = regexp_argument(1);
 
   SIZED_STRING* function_name = NULL;
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2403,18 +2403,18 @@ define_function(exports_regexp)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(0);
 
   for (int i = 0; i < n; i++)
   {
-    function_name = get_string(module, "export_details[%i].name", i);
+    function_name = yr_get_string(module, "export_details[%i].name", i);
     if (function_name == NULL)
       continue;
 
-    if (yr_re_match(scan_context(), regex, function_name->c_string) != -1)
+    if (yr_re_match(yr_scan_context(), regex, function_name->c_string) != -1)
       return_integer(1);
   }
 
@@ -2425,7 +2425,7 @@ define_function(exports_ordinal)
 {
   int64_t ordinal = integer_argument(1);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2433,7 +2433,7 @@ define_function(exports_ordinal)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(0);
@@ -2458,7 +2458,7 @@ define_function(exports_index_name)
   SIZED_STRING* search_name = sized_string_argument(1);
 
   SIZED_STRING* function_name = NULL;
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2466,14 +2466,14 @@ define_function(exports_index_name)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < n; i++)
   {
-    function_name = get_string(module, "export_details[%i].name", i);
+    function_name = yr_get_string(module, "export_details[%i].name", i);
 
     if (function_name == NULL)
       continue;
@@ -2489,7 +2489,7 @@ define_function(exports_index_ordinal)
 {
   int64_t ordinal = integer_argument(1);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2497,7 +2497,7 @@ define_function(exports_index_ordinal)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(YR_UNDEFINED);
@@ -2522,7 +2522,7 @@ define_function(exports_index_regex)
   RE* regex = regexp_argument(1);
 
   SIZED_STRING* function_name = NULL;
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   // If not a PE, return YR_UNDEFINED.
@@ -2530,18 +2530,18 @@ define_function(exports_index_regex)
     return_integer(YR_UNDEFINED);
 
   // If PE, but no exported functions, return false.
-  int n = (int) get_integer(module, "number_of_exports");
+  int n = (int) yr_get_integer(module, "number_of_exports");
 
   if (n == 0)
     return_integer(YR_UNDEFINED);
 
   for (int i = 0; i < n; i++)
   {
-    function_name = get_string(module, "export_details[%i].name", i);
+    function_name = yr_get_string(module, "export_details[%i].name", i);
     if (function_name == NULL)
       continue;
 
-    if (yr_re_match(scan_context(), regex, function_name->c_string) != -1)
+    if (yr_re_match(yr_scan_context(), regex, function_name->c_string) != -1)
     {
       return_integer(i);
     }
@@ -2562,7 +2562,7 @@ define_function(exports_index_regex)
 
 define_function(imphash)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
 
   IMPORTED_DLL* dll;
   yr_md5_ctx ctx;
@@ -2775,7 +2775,7 @@ define_function(imports_standard)
   char* dll_name = string_argument(1);
   char* function_name = string_argument(2);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2790,7 +2790,7 @@ define_function(imports)
   char* dll_name = string_argument(2);
   char* function_name = string_argument(3);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2816,7 +2816,7 @@ define_function(imports_standard_ordinal)
   char* dll_name = string_argument(1);
   int64_t ordinal = integer_argument(2);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2831,7 +2831,7 @@ define_function(imports_ordinal)
   char* dll_name = string_argument(2);
   int64_t ordinal = integer_argument(3);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2857,14 +2857,14 @@ define_function(imports_standard_regex)
   RE* dll_name = regexp_argument(1);
   RE* function_name = regexp_argument(2);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
     return_integer(YR_UNDEFINED);
 
   return_integer(pe_imports_regexp(
-      scan_context(), pe->imported_dlls, dll_name, function_name))
+      yr_scan_context(), pe->imported_dlls, dll_name, function_name))
 }
 
 define_function(imports_regex)
@@ -2873,7 +2873,7 @@ define_function(imports_regex)
   RE* dll_name = regexp_argument(2);
   RE* function_name = regexp_argument(3);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2883,11 +2883,11 @@ define_function(imports_regex)
 
   if (flags & IMPORT_STANDARD)
     result += pe_imports_regexp(
-        scan_context(), pe->imported_dlls, dll_name, function_name);
+        yr_scan_context(), pe->imported_dlls, dll_name, function_name);
 
   if (flags & IMPORT_DELAYED)
     result += pe_imports_regexp(
-        scan_context(), pe->delay_imported_dlls, dll_name, function_name);
+        yr_scan_context(), pe->delay_imported_dlls, dll_name, function_name);
 
   return_integer(result);
 }
@@ -2896,7 +2896,7 @@ define_function(imports_standard_dll)
 {
   char* dll_name = string_argument(1);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2910,7 +2910,7 @@ define_function(imports_dll)
   int64_t flags = integer_argument(1);
   char* dll_name = string_argument(2);
 
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (!pe)
@@ -2929,12 +2929,12 @@ define_function(imports_dll)
 
 define_function(locale)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   uint64_t locale = integer_argument(1);
 
-  if (is_undefined(module, "number_of_resources"))
+  if (yr_is_undefined(module, "number_of_resources"))
     return_integer(YR_UNDEFINED);
 
   // If not a PE file, return YR_UNDEFINED
@@ -2942,11 +2942,11 @@ define_function(locale)
   if (pe == NULL)
     return_integer(YR_UNDEFINED);
 
-  int n = (int) get_integer(module, "number_of_resources");
+  int n = (int) yr_get_integer(module, "number_of_resources");
 
   for (int i = 0; i < n; i++)
   {
-    uint64_t rsrc_language = get_integer(module, "resources[%i].language", i);
+    uint64_t rsrc_language = yr_get_integer(module, "resources[%i].language", i);
 
     if ((rsrc_language & 0xFFFF) == locale)
       return_integer(1);
@@ -2957,12 +2957,12 @@ define_function(locale)
 
 define_function(language)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   uint64_t language = integer_argument(1);
 
-  if (is_undefined(module, "number_of_resources"))
+  if (yr_is_undefined(module, "number_of_resources"))
     return_integer(YR_UNDEFINED);
 
   // If not a PE file, return YR_UNDEFINED
@@ -2970,11 +2970,11 @@ define_function(language)
   if (pe == NULL)
     return_integer(YR_UNDEFINED);
 
-  int n = (int) get_integer(module, "number_of_resources");
+  int n = (int) yr_get_integer(module, "number_of_resources");
 
   for (int i = 0; i < n; i++)
   {
-    uint64_t rsrc_language = get_integer(module, "resources[%i].language", i);
+    uint64_t rsrc_language = yr_get_integer(module, "resources[%i].language", i);
 
     if ((rsrc_language & 0xFF) == language)
       return_integer(1);
@@ -2986,18 +2986,18 @@ define_function(language)
 define_function(is_dll)
 {
   int64_t characteristics;
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
 
-  if (is_undefined(module, "characteristics"))
+  if (yr_is_undefined(module, "characteristics"))
     return_integer(YR_UNDEFINED);
 
-  characteristics = get_integer(module, "characteristics");
+  characteristics = yr_get_integer(module, "characteristics");
   return_integer(characteristics & IMAGE_FILE_DLL);
 }
 
 define_function(is_32bit)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (pe == NULL)
@@ -3008,7 +3008,7 @@ define_function(is_32bit)
 
 define_function(is_64bit)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   if (pe == NULL)
@@ -3036,11 +3036,11 @@ static uint64_t _rich_version(
   uint64_t result = 0;
 
   // Check if the required fields are set
-  if (is_undefined(module, "rich_signature.length"))
+  if (yr_is_undefined(module, "rich_signature.length"))
     return YR_UNDEFINED;
 
-  rich_length = get_integer(module, "rich_signature.length");
-  rich_string = get_string(module, "rich_signature.clear_data");
+  rich_length = yr_get_integer(module, "rich_signature.length");
+  rich_string = yr_get_string(module, "rich_signature.clear_data");
 
   // If the clear_data was not set, return YR_UNDEFINED
   if (rich_string == NULL)
@@ -3075,29 +3075,29 @@ static uint64_t _rich_version(
 
 define_function(rich_version)
 {
-  return_integer(_rich_version(module(), integer_argument(1), YR_UNDEFINED));
+  return_integer(_rich_version(yr_module(), integer_argument(1), YR_UNDEFINED));
 }
 
 define_function(rich_version_toolid)
 {
   return_integer(
-      _rich_version(module(), integer_argument(1), integer_argument(2)));
+      _rich_version(yr_module(), integer_argument(1), integer_argument(2)));
 }
 
 define_function(rich_toolid)
 {
-  return_integer(_rich_version(module(), YR_UNDEFINED, integer_argument(1)));
+  return_integer(_rich_version(yr_module(), YR_UNDEFINED, integer_argument(1)));
 }
 
 define_function(rich_toolid_version)
 {
   return_integer(
-      _rich_version(module(), integer_argument(2), integer_argument(1)));
+      _rich_version(yr_module(), integer_argument(2), integer_argument(1)));
 }
 
 define_function(calculate_checksum)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   uint64_t csum = 0;
@@ -3145,7 +3145,7 @@ define_function(calculate_checksum)
 
 define_function(rva_to_offset)
 {
-  YR_OBJECT* module = module();
+  YR_OBJECT* module = yr_module();
   PE* pe = (PE*) module->data;
 
   uint64_t rva;
@@ -3636,320 +3636,320 @@ int module_load(
   const uint8_t* block_data = NULL;
   PE* pe = NULL;
 
-  set_integer(IMPORT_DELAYED, module_object, "IMPORT_DELAYED");
-  set_integer(IMPORT_STANDARD, module_object, "IMPORT_STANDARD");
-  set_integer(IMPORT_ANY, module_object, "IMPORT_ANY");
+  yr_set_integer(IMPORT_DELAYED, module_object, "IMPORT_DELAYED");
+  yr_set_integer(IMPORT_STANDARD, module_object, "IMPORT_STANDARD");
+  yr_set_integer(IMPORT_ANY, module_object, "IMPORT_ANY");
 
-  set_integer(IMAGE_FILE_MACHINE_UNKNOWN, module_object, "MACHINE_UNKNOWN");
-  set_integer(IMAGE_FILE_MACHINE_AM33, module_object, "MACHINE_AM33");
-  set_integer(IMAGE_FILE_MACHINE_AMD64, module_object, "MACHINE_AMD64");
-  set_integer(IMAGE_FILE_MACHINE_ARM, module_object, "MACHINE_ARM");
-  set_integer(IMAGE_FILE_MACHINE_ARMNT, module_object, "MACHINE_ARMNT");
-  set_integer(IMAGE_FILE_MACHINE_ARM64, module_object, "MACHINE_ARM64");
-  set_integer(IMAGE_FILE_MACHINE_EBC, module_object, "MACHINE_EBC");
-  set_integer(IMAGE_FILE_MACHINE_I386, module_object, "MACHINE_I386");
-  set_integer(IMAGE_FILE_MACHINE_IA64, module_object, "MACHINE_IA64");
-  set_integer(IMAGE_FILE_MACHINE_M32R, module_object, "MACHINE_M32R");
-  set_integer(IMAGE_FILE_MACHINE_MIPS16, module_object, "MACHINE_MIPS16");
-  set_integer(IMAGE_FILE_MACHINE_MIPSFPU, module_object, "MACHINE_MIPSFPU");
-  set_integer(IMAGE_FILE_MACHINE_MIPSFPU16, module_object, "MACHINE_MIPSFPU16");
-  set_integer(IMAGE_FILE_MACHINE_POWERPC, module_object, "MACHINE_POWERPC");
-  set_integer(IMAGE_FILE_MACHINE_POWERPCFP, module_object, "MACHINE_POWERPCFP");
-  set_integer(IMAGE_FILE_MACHINE_R4000, module_object, "MACHINE_R4000");
-  set_integer(IMAGE_FILE_MACHINE_SH3, module_object, "MACHINE_SH3");
-  set_integer(IMAGE_FILE_MACHINE_SH3DSP, module_object, "MACHINE_SH3DSP");
-  set_integer(IMAGE_FILE_MACHINE_SH4, module_object, "MACHINE_SH4");
-  set_integer(IMAGE_FILE_MACHINE_SH5, module_object, "MACHINE_SH5");
-  set_integer(IMAGE_FILE_MACHINE_THUMB, module_object, "MACHINE_THUMB");
-  set_integer(IMAGE_FILE_MACHINE_WCEMIPSV2, module_object, "MACHINE_WCEMIPSV2");
-  set_integer(
+  yr_set_integer(IMAGE_FILE_MACHINE_UNKNOWN, module_object, "MACHINE_UNKNOWN");
+  yr_set_integer(IMAGE_FILE_MACHINE_AM33, module_object, "MACHINE_AM33");
+  yr_set_integer(IMAGE_FILE_MACHINE_AMD64, module_object, "MACHINE_AMD64");
+  yr_set_integer(IMAGE_FILE_MACHINE_ARM, module_object, "MACHINE_ARM");
+  yr_set_integer(IMAGE_FILE_MACHINE_ARMNT, module_object, "MACHINE_ARMNT");
+  yr_set_integer(IMAGE_FILE_MACHINE_ARM64, module_object, "MACHINE_ARM64");
+  yr_set_integer(IMAGE_FILE_MACHINE_EBC, module_object, "MACHINE_EBC");
+  yr_set_integer(IMAGE_FILE_MACHINE_I386, module_object, "MACHINE_I386");
+  yr_set_integer(IMAGE_FILE_MACHINE_IA64, module_object, "MACHINE_IA64");
+  yr_set_integer(IMAGE_FILE_MACHINE_M32R, module_object, "MACHINE_M32R");
+  yr_set_integer(IMAGE_FILE_MACHINE_MIPS16, module_object, "MACHINE_MIPS16");
+  yr_set_integer(IMAGE_FILE_MACHINE_MIPSFPU, module_object, "MACHINE_MIPSFPU");
+  yr_set_integer(IMAGE_FILE_MACHINE_MIPSFPU16, module_object, "MACHINE_MIPSFPU16");
+  yr_set_integer(IMAGE_FILE_MACHINE_POWERPC, module_object, "MACHINE_POWERPC");
+  yr_set_integer(IMAGE_FILE_MACHINE_POWERPCFP, module_object, "MACHINE_POWERPCFP");
+  yr_set_integer(IMAGE_FILE_MACHINE_R4000, module_object, "MACHINE_R4000");
+  yr_set_integer(IMAGE_FILE_MACHINE_SH3, module_object, "MACHINE_SH3");
+  yr_set_integer(IMAGE_FILE_MACHINE_SH3DSP, module_object, "MACHINE_SH3DSP");
+  yr_set_integer(IMAGE_FILE_MACHINE_SH4, module_object, "MACHINE_SH4");
+  yr_set_integer(IMAGE_FILE_MACHINE_SH5, module_object, "MACHINE_SH5");
+  yr_set_integer(IMAGE_FILE_MACHINE_THUMB, module_object, "MACHINE_THUMB");
+  yr_set_integer(IMAGE_FILE_MACHINE_WCEMIPSV2, module_object, "MACHINE_WCEMIPSV2");
+  yr_set_integer(
       IMAGE_FILE_MACHINE_TARGET_HOST, module_object, "MACHINE_TARGET_HOST");
-  set_integer(IMAGE_FILE_MACHINE_R3000, module_object, "MACHINE_R3000");
-  set_integer(IMAGE_FILE_MACHINE_R10000, module_object, "MACHINE_R10000");
-  set_integer(IMAGE_FILE_MACHINE_ALPHA, module_object, "MACHINE_ALPHA");
-  set_integer(IMAGE_FILE_MACHINE_SH3E, module_object, "MACHINE_SH3E");
-  set_integer(IMAGE_FILE_MACHINE_ALPHA64, module_object, "MACHINE_ALPHA64");
-  set_integer(IMAGE_FILE_MACHINE_AXP64, module_object, "MACHINE_AXP64");
-  set_integer(IMAGE_FILE_MACHINE_TRICORE, module_object, "MACHINE_TRICORE");
-  set_integer(IMAGE_FILE_MACHINE_CEF, module_object, "MACHINE_CEF");
-  set_integer(IMAGE_FILE_MACHINE_CEE, module_object, "MACHINE_CEE");
+  yr_set_integer(IMAGE_FILE_MACHINE_R3000, module_object, "MACHINE_R3000");
+  yr_set_integer(IMAGE_FILE_MACHINE_R10000, module_object, "MACHINE_R10000");
+  yr_set_integer(IMAGE_FILE_MACHINE_ALPHA, module_object, "MACHINE_ALPHA");
+  yr_set_integer(IMAGE_FILE_MACHINE_SH3E, module_object, "MACHINE_SH3E");
+  yr_set_integer(IMAGE_FILE_MACHINE_ALPHA64, module_object, "MACHINE_ALPHA64");
+  yr_set_integer(IMAGE_FILE_MACHINE_AXP64, module_object, "MACHINE_AXP64");
+  yr_set_integer(IMAGE_FILE_MACHINE_TRICORE, module_object, "MACHINE_TRICORE");
+  yr_set_integer(IMAGE_FILE_MACHINE_CEF, module_object, "MACHINE_CEF");
+  yr_set_integer(IMAGE_FILE_MACHINE_CEE, module_object, "MACHINE_CEE");
 
-  set_integer(IMAGE_SUBSYSTEM_UNKNOWN, module_object, "SUBSYSTEM_UNKNOWN");
-  set_integer(IMAGE_SUBSYSTEM_NATIVE, module_object, "SUBSYSTEM_NATIVE");
-  set_integer(
+  yr_set_integer(IMAGE_SUBSYSTEM_UNKNOWN, module_object, "SUBSYSTEM_UNKNOWN");
+  yr_set_integer(IMAGE_SUBSYSTEM_NATIVE, module_object, "SUBSYSTEM_NATIVE");
+  yr_set_integer(
       IMAGE_SUBSYSTEM_WINDOWS_GUI, module_object, "SUBSYSTEM_WINDOWS_GUI");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_WINDOWS_CUI, module_object, "SUBSYSTEM_WINDOWS_CUI");
-  set_integer(IMAGE_SUBSYSTEM_OS2_CUI, module_object, "SUBSYSTEM_OS2_CUI");
-  set_integer(IMAGE_SUBSYSTEM_POSIX_CUI, module_object, "SUBSYSTEM_POSIX_CUI");
-  set_integer(
+  yr_set_integer(IMAGE_SUBSYSTEM_OS2_CUI, module_object, "SUBSYSTEM_OS2_CUI");
+  yr_set_integer(IMAGE_SUBSYSTEM_POSIX_CUI, module_object, "SUBSYSTEM_POSIX_CUI");
+  yr_set_integer(
       IMAGE_SUBSYSTEM_NATIVE_WINDOWS,
       module_object,
       "SUBSYSTEM_NATIVE_WINDOWS");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_WINDOWS_CE_GUI,
       module_object,
       "SUBSYSTEM_WINDOWS_CE_GUI");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_EFI_APPLICATION,
       module_object,
       "SUBSYSTEM_EFI_APPLICATION");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER,
       module_object,
       "SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER,
       module_object,
       "SUBSYSTEM_EFI_RUNTIME_DRIVER");
-  set_integer(
+  yr_set_integer(
       IMAGE_SUBSYSTEM_EFI_ROM_IMAGE, module_object, "SUBSYSTEM_EFI_ROM_IMAGE");
-  set_integer(IMAGE_SUBSYSTEM_XBOX, module_object, "SUBSYSTEM_XBOX");
-  set_integer(
+  yr_set_integer(IMAGE_SUBSYSTEM_XBOX, module_object, "SUBSYSTEM_XBOX");
+  yr_set_integer(
       IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION,
       module_object,
       "SUBSYSTEM_WINDOWS_BOOT_APPLICATION");
 
-  set_integer(
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA,
       module_object,
       "HIGH_ENTROPY_VA");
-  set_integer(
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE, module_object, "DYNAMIC_BASE");
-  set_integer(
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY,
       module_object,
       "FORCE_INTEGRITY");
-  set_integer(IMAGE_DLLCHARACTERISTICS_NX_COMPAT, module_object, "NX_COMPAT");
-  set_integer(
+  yr_set_integer(IMAGE_DLLCHARACTERISTICS_NX_COMPAT, module_object, "NX_COMPAT");
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_NO_ISOLATION, module_object, "NO_ISOLATION");
-  set_integer(IMAGE_DLLCHARACTERISTICS_NO_SEH, module_object, "NO_SEH");
-  set_integer(IMAGE_DLLCHARACTERISTICS_NO_BIND, module_object, "NO_BIND");
-  set_integer(
+  yr_set_integer(IMAGE_DLLCHARACTERISTICS_NO_SEH, module_object, "NO_SEH");
+  yr_set_integer(IMAGE_DLLCHARACTERISTICS_NO_BIND, module_object, "NO_BIND");
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_APPCONTAINER, module_object, "APPCONTAINER");
-  set_integer(IMAGE_DLLCHARACTERISTICS_WDM_DRIVER, module_object, "WDM_DRIVER");
-  set_integer(IMAGE_DLLCHARACTERISTICS_GUARD_CF, module_object, "GUARD_CF");
-  set_integer(
+  yr_set_integer(IMAGE_DLLCHARACTERISTICS_WDM_DRIVER, module_object, "WDM_DRIVER");
+  yr_set_integer(IMAGE_DLLCHARACTERISTICS_GUARD_CF, module_object, "GUARD_CF");
+  yr_set_integer(
       IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE,
       module_object,
       "TERMINAL_SERVER_AWARE");
 
-  set_integer(IMAGE_FILE_RELOCS_STRIPPED, module_object, "RELOCS_STRIPPED");
-  set_integer(IMAGE_FILE_EXECUTABLE_IMAGE, module_object, "EXECUTABLE_IMAGE");
-  set_integer(
+  yr_set_integer(IMAGE_FILE_RELOCS_STRIPPED, module_object, "RELOCS_STRIPPED");
+  yr_set_integer(IMAGE_FILE_EXECUTABLE_IMAGE, module_object, "EXECUTABLE_IMAGE");
+  yr_set_integer(
       IMAGE_FILE_LINE_NUMS_STRIPPED, module_object, "LINE_NUMS_STRIPPED");
-  set_integer(
+  yr_set_integer(
       IMAGE_FILE_LOCAL_SYMS_STRIPPED, module_object, "LOCAL_SYMS_STRIPPED");
-  set_integer(IMAGE_FILE_AGGRESIVE_WS_TRIM, module_object, "AGGRESIVE_WS_TRIM");
-  set_integer(
+  yr_set_integer(IMAGE_FILE_AGGRESIVE_WS_TRIM, module_object, "AGGRESIVE_WS_TRIM");
+  yr_set_integer(
       IMAGE_FILE_LARGE_ADDRESS_AWARE, module_object, "LARGE_ADDRESS_AWARE");
-  set_integer(IMAGE_FILE_BYTES_REVERSED_LO, module_object, "BYTES_REVERSED_LO");
-  set_integer(IMAGE_FILE_32BIT_MACHINE, module_object, "MACHINE_32BIT");
-  set_integer(IMAGE_FILE_DEBUG_STRIPPED, module_object, "DEBUG_STRIPPED");
-  set_integer(
+  yr_set_integer(IMAGE_FILE_BYTES_REVERSED_LO, module_object, "BYTES_REVERSED_LO");
+  yr_set_integer(IMAGE_FILE_32BIT_MACHINE, module_object, "MACHINE_32BIT");
+  yr_set_integer(IMAGE_FILE_DEBUG_STRIPPED, module_object, "DEBUG_STRIPPED");
+  yr_set_integer(
       IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP,
       module_object,
       "REMOVABLE_RUN_FROM_SWAP");
-  set_integer(IMAGE_FILE_NET_RUN_FROM_SWAP, module_object, "NET_RUN_FROM_SWAP");
-  set_integer(IMAGE_FILE_SYSTEM, module_object, "SYSTEM");
-  set_integer(IMAGE_FILE_DLL, module_object, "DLL");
-  set_integer(IMAGE_FILE_UP_SYSTEM_ONLY, module_object, "UP_SYSTEM_ONLY");
-  set_integer(IMAGE_FILE_BYTES_REVERSED_HI, module_object, "BYTES_REVERSED_HI");
+  yr_set_integer(IMAGE_FILE_NET_RUN_FROM_SWAP, module_object, "NET_RUN_FROM_SWAP");
+  yr_set_integer(IMAGE_FILE_SYSTEM, module_object, "SYSTEM");
+  yr_set_integer(IMAGE_FILE_DLL, module_object, "DLL");
+  yr_set_integer(IMAGE_FILE_UP_SYSTEM_ONLY, module_object, "UP_SYSTEM_ONLY");
+  yr_set_integer(IMAGE_FILE_BYTES_REVERSED_HI, module_object, "BYTES_REVERSED_HI");
 
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_EXPORT,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_EXPORT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_IMPORT,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_IMPORT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_RESOURCE,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_RESOURCE");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_EXCEPTION,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_EXCEPTION");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_SECURITY,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_SECURITY");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_BASERELOC,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_BASERELOC");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_DEBUG,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_DEBUG");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_ARCHITECTURE,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_ARCHITECTURE");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_COPYRIGHT,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_COPYRIGHT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_GLOBALPTR,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_GLOBALPTR");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_TLS, module_object, "IMAGE_DIRECTORY_ENTRY_TLS");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_IAT, module_object, "IMAGE_DIRECTORY_ENTRY_IAT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT");
-  set_integer(
+  yr_set_integer(
       IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR,
       module_object,
       "IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR");
 
-  set_integer(
+  yr_set_integer(
       IMAGE_NT_OPTIONAL_HDR32_MAGIC,
       module_object,
       "IMAGE_NT_OPTIONAL_HDR32_MAGIC");
-  set_integer(
+  yr_set_integer(
       IMAGE_NT_OPTIONAL_HDR64_MAGIC,
       module_object,
       "IMAGE_NT_OPTIONAL_HDR64_MAGIC");
-  set_integer(
+  yr_set_integer(
       IMAGE_ROM_OPTIONAL_HDR_MAGIC,
       module_object,
       "IMAGE_ROM_OPTIONAL_HDR_MAGIC");
 
-  set_integer(IMAGE_SCN_TYPE_NO_PAD, module_object, "SECTION_NO_PAD");
-  set_integer(IMAGE_SCN_CNT_CODE, module_object, "SECTION_CNT_CODE");
-  set_integer(
+  yr_set_integer(IMAGE_SCN_TYPE_NO_PAD, module_object, "SECTION_NO_PAD");
+  yr_set_integer(IMAGE_SCN_CNT_CODE, module_object, "SECTION_CNT_CODE");
+  yr_set_integer(
       IMAGE_SCN_CNT_INITIALIZED_DATA,
       module_object,
       "SECTION_CNT_INITIALIZED_DATA");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_CNT_UNINITIALIZED_DATA,
       module_object,
       "SECTION_CNT_UNINITIALIZED_DATA");
-  set_integer(IMAGE_SCN_LNK_OTHER, module_object, "SECTION_LNK_OTHER");
-  set_integer(IMAGE_SCN_LNK_INFO, module_object, "SECTION_LNK_INFO");
-  set_integer(IMAGE_SCN_LNK_REMOVE, module_object, "SECTION_LNK_REMOVE");
-  set_integer(IMAGE_SCN_LNK_COMDAT, module_object, "SECTION_LNK_COMDAT");
-  set_integer(
+  yr_set_integer(IMAGE_SCN_LNK_OTHER, module_object, "SECTION_LNK_OTHER");
+  yr_set_integer(IMAGE_SCN_LNK_INFO, module_object, "SECTION_LNK_INFO");
+  yr_set_integer(IMAGE_SCN_LNK_REMOVE, module_object, "SECTION_LNK_REMOVE");
+  yr_set_integer(IMAGE_SCN_LNK_COMDAT, module_object, "SECTION_LNK_COMDAT");
+  yr_set_integer(
       IMAGE_SCN_NO_DEFER_SPEC_EXC, module_object, "SECTION_NO_DEFER_SPEC_EXC");
-  set_integer(IMAGE_SCN_GPREL, module_object, "SECTION_GPREL");
-  set_integer(IMAGE_SCN_MEM_FARDATA, module_object, "SECTION_MEM_FARDATA");
-  set_integer(IMAGE_SCN_MEM_PURGEABLE, module_object, "SECTION_MEM_PURGEABLE");
-  set_integer(IMAGE_SCN_MEM_16BIT, module_object, "SECTION_MEM_16BIT");
-  set_integer(IMAGE_SCN_MEM_LOCKED, module_object, "SECTION_MEM_LOCKED");
-  set_integer(IMAGE_SCN_MEM_PRELOAD, module_object, "SECTION_MEM_PRELOAD");
-  set_integer(IMAGE_SCN_ALIGN_1BYTES, module_object, "SECTION_ALIGN_1BYTES");
-  set_integer(IMAGE_SCN_ALIGN_2BYTES, module_object, "SECTION_ALIGN_2BYTES");
-  set_integer(IMAGE_SCN_ALIGN_4BYTES, module_object, "SECTION_ALIGN_4BYTES");
-  set_integer(IMAGE_SCN_ALIGN_8BYTES, module_object, "SECTION_ALIGN_8BYTES");
-  set_integer(IMAGE_SCN_ALIGN_16BYTES, module_object, "SECTION_ALIGN_16BYTES");
-  set_integer(IMAGE_SCN_ALIGN_32BYTES, module_object, "SECTION_ALIGN_32BYTES");
-  set_integer(IMAGE_SCN_ALIGN_64BYTES, module_object, "SECTION_ALIGN_64BYTES");
-  set_integer(
+  yr_set_integer(IMAGE_SCN_GPREL, module_object, "SECTION_GPREL");
+  yr_set_integer(IMAGE_SCN_MEM_FARDATA, module_object, "SECTION_MEM_FARDATA");
+  yr_set_integer(IMAGE_SCN_MEM_PURGEABLE, module_object, "SECTION_MEM_PURGEABLE");
+  yr_set_integer(IMAGE_SCN_MEM_16BIT, module_object, "SECTION_MEM_16BIT");
+  yr_set_integer(IMAGE_SCN_MEM_LOCKED, module_object, "SECTION_MEM_LOCKED");
+  yr_set_integer(IMAGE_SCN_MEM_PRELOAD, module_object, "SECTION_MEM_PRELOAD");
+  yr_set_integer(IMAGE_SCN_ALIGN_1BYTES, module_object, "SECTION_ALIGN_1BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_2BYTES, module_object, "SECTION_ALIGN_2BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_4BYTES, module_object, "SECTION_ALIGN_4BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_8BYTES, module_object, "SECTION_ALIGN_8BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_16BYTES, module_object, "SECTION_ALIGN_16BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_32BYTES, module_object, "SECTION_ALIGN_32BYTES");
+  yr_set_integer(IMAGE_SCN_ALIGN_64BYTES, module_object, "SECTION_ALIGN_64BYTES");
+  yr_set_integer(
       IMAGE_SCN_ALIGN_128BYTES, module_object, "SECTION_ALIGN_128BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_256BYTES, module_object, "SECTION_ALIGN_256BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_512BYTES, module_object, "SECTION_ALIGN_512BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_1024BYTES, module_object, "SECTION_ALIGN_1024BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_2048BYTES, module_object, "SECTION_ALIGN_2048BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_4096BYTES, module_object, "SECTION_ALIGN_4096BYTES");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_ALIGN_8192BYTES, module_object, "SECTION_ALIGN_8192BYTES");
-  set_integer(IMAGE_SCN_ALIGN_MASK, module_object, "SECTION_ALIGN_MASK");
-  set_integer(
+  yr_set_integer(IMAGE_SCN_ALIGN_MASK, module_object, "SECTION_ALIGN_MASK");
+  yr_set_integer(
       IMAGE_SCN_LNK_NRELOC_OVFL, module_object, "SECTION_LNK_NRELOC_OVFL");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_MEM_DISCARDABLE, module_object, "SECTION_MEM_DISCARDABLE");
-  set_integer(
+  yr_set_integer(
       IMAGE_SCN_MEM_NOT_CACHED, module_object, "SECTION_MEM_NOT_CACHED");
-  set_integer(IMAGE_SCN_MEM_NOT_PAGED, module_object, "SECTION_MEM_NOT_PAGED");
-  set_integer(IMAGE_SCN_MEM_SHARED, module_object, "SECTION_MEM_SHARED");
-  set_integer(IMAGE_SCN_MEM_EXECUTE, module_object, "SECTION_MEM_EXECUTE");
-  set_integer(IMAGE_SCN_MEM_READ, module_object, "SECTION_MEM_READ");
-  set_integer(IMAGE_SCN_MEM_WRITE, module_object, "SECTION_MEM_WRITE");
-  set_integer(IMAGE_SCN_SCALE_INDEX, module_object, "SECTION_SCALE_INDEX");
+  yr_set_integer(IMAGE_SCN_MEM_NOT_PAGED, module_object, "SECTION_MEM_NOT_PAGED");
+  yr_set_integer(IMAGE_SCN_MEM_SHARED, module_object, "SECTION_MEM_SHARED");
+  yr_set_integer(IMAGE_SCN_MEM_EXECUTE, module_object, "SECTION_MEM_EXECUTE");
+  yr_set_integer(IMAGE_SCN_MEM_READ, module_object, "SECTION_MEM_READ");
+  yr_set_integer(IMAGE_SCN_MEM_WRITE, module_object, "SECTION_MEM_WRITE");
+  yr_set_integer(IMAGE_SCN_SCALE_INDEX, module_object, "SECTION_SCALE_INDEX");
 
-  set_integer(RESOURCE_TYPE_CURSOR, module_object, "RESOURCE_TYPE_CURSOR");
-  set_integer(RESOURCE_TYPE_BITMAP, module_object, "RESOURCE_TYPE_BITMAP");
-  set_integer(RESOURCE_TYPE_ICON, module_object, "RESOURCE_TYPE_ICON");
-  set_integer(RESOURCE_TYPE_MENU, module_object, "RESOURCE_TYPE_MENU");
-  set_integer(RESOURCE_TYPE_DIALOG, module_object, "RESOURCE_TYPE_DIALOG");
-  set_integer(RESOURCE_TYPE_STRING, module_object, "RESOURCE_TYPE_STRING");
-  set_integer(RESOURCE_TYPE_FONTDIR, module_object, "RESOURCE_TYPE_FONTDIR");
-  set_integer(RESOURCE_TYPE_FONT, module_object, "RESOURCE_TYPE_FONT");
-  set_integer(
+  yr_set_integer(RESOURCE_TYPE_CURSOR, module_object, "RESOURCE_TYPE_CURSOR");
+  yr_set_integer(RESOURCE_TYPE_BITMAP, module_object, "RESOURCE_TYPE_BITMAP");
+  yr_set_integer(RESOURCE_TYPE_ICON, module_object, "RESOURCE_TYPE_ICON");
+  yr_set_integer(RESOURCE_TYPE_MENU, module_object, "RESOURCE_TYPE_MENU");
+  yr_set_integer(RESOURCE_TYPE_DIALOG, module_object, "RESOURCE_TYPE_DIALOG");
+  yr_set_integer(RESOURCE_TYPE_STRING, module_object, "RESOURCE_TYPE_STRING");
+  yr_set_integer(RESOURCE_TYPE_FONTDIR, module_object, "RESOURCE_TYPE_FONTDIR");
+  yr_set_integer(RESOURCE_TYPE_FONT, module_object, "RESOURCE_TYPE_FONT");
+  yr_set_integer(
       RESOURCE_TYPE_ACCELERATOR, module_object, "RESOURCE_TYPE_ACCELERATOR");
-  set_integer(RESOURCE_TYPE_RCDATA, module_object, "RESOURCE_TYPE_RCDATA");
-  set_integer(
+  yr_set_integer(RESOURCE_TYPE_RCDATA, module_object, "RESOURCE_TYPE_RCDATA");
+  yr_set_integer(
       RESOURCE_TYPE_MESSAGETABLE, module_object, "RESOURCE_TYPE_MESSAGETABLE");
-  set_integer(
+  yr_set_integer(
       RESOURCE_TYPE_GROUP_CURSOR, module_object, "RESOURCE_TYPE_GROUP_CURSOR");
-  set_integer(
+  yr_set_integer(
       RESOURCE_TYPE_GROUP_ICON, module_object, "RESOURCE_TYPE_GROUP_ICON");
-  set_integer(RESOURCE_TYPE_VERSION, module_object, "RESOURCE_TYPE_VERSION");
-  set_integer(
+  yr_set_integer(RESOURCE_TYPE_VERSION, module_object, "RESOURCE_TYPE_VERSION");
+  yr_set_integer(
       RESOURCE_TYPE_DLGINCLUDE, module_object, "RESOURCE_TYPE_DLGINCLUDE");
-  set_integer(RESOURCE_TYPE_PLUGPLAY, module_object, "RESOURCE_TYPE_PLUGPLAY");
-  set_integer(RESOURCE_TYPE_VXD, module_object, "RESOURCE_TYPE_VXD");
-  set_integer(
+  yr_set_integer(RESOURCE_TYPE_PLUGPLAY, module_object, "RESOURCE_TYPE_PLUGPLAY");
+  yr_set_integer(RESOURCE_TYPE_VXD, module_object, "RESOURCE_TYPE_VXD");
+  yr_set_integer(
       RESOURCE_TYPE_ANICURSOR, module_object, "RESOURCE_TYPE_ANICURSOR");
-  set_integer(RESOURCE_TYPE_ANIICON, module_object, "RESOURCE_TYPE_ANIICON");
-  set_integer(RESOURCE_TYPE_HTML, module_object, "RESOURCE_TYPE_HTML");
-  set_integer(RESOURCE_TYPE_MANIFEST, module_object, "RESOURCE_TYPE_MANIFEST");
+  yr_set_integer(RESOURCE_TYPE_ANIICON, module_object, "RESOURCE_TYPE_ANIICON");
+  yr_set_integer(RESOURCE_TYPE_HTML, module_object, "RESOURCE_TYPE_HTML");
+  yr_set_integer(RESOURCE_TYPE_MANIFEST, module_object, "RESOURCE_TYPE_MANIFEST");
 
-  set_integer(
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_UNKNOWN, module_object, "IMAGE_DEBUG_TYPE_UNKNOWN");
-  set_integer(IMAGE_DEBUG_TYPE_COFF, module_object, "IMAGE_DEBUG_TYPE_COFF");
-  set_integer(
+  yr_set_integer(IMAGE_DEBUG_TYPE_COFF, module_object, "IMAGE_DEBUG_TYPE_COFF");
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_CODEVIEW, module_object, "IMAGE_DEBUG_TYPE_CODEVIEW");
-  set_integer(IMAGE_DEBUG_TYPE_FPO, module_object, "IMAGE_DEBUG_TYPE_FPO");
-  set_integer(IMAGE_DEBUG_TYPE_MISC, module_object, "IMAGE_DEBUG_TYPE_MISC");
-  set_integer(
+  yr_set_integer(IMAGE_DEBUG_TYPE_FPO, module_object, "IMAGE_DEBUG_TYPE_FPO");
+  yr_set_integer(IMAGE_DEBUG_TYPE_MISC, module_object, "IMAGE_DEBUG_TYPE_MISC");
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_EXCEPTION, module_object, "IMAGE_DEBUG_TYPE_EXCEPTION");
-  set_integer(IMAGE_DEBUG_TYPE_FIXUP, module_object, "IMAGE_DEBUG_TYPE_FIXUP");
-  set_integer(
+  yr_set_integer(IMAGE_DEBUG_TYPE_FIXUP, module_object, "IMAGE_DEBUG_TYPE_FIXUP");
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_OMAP_TO_SRC,
       module_object,
       "IMAGE_DEBUG_TYPE_OMAP_TO_SRC");
-  set_integer(
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_OMAP_FROM_SRC,
       module_object,
       "IMAGE_DEBUG_TYPE_OMAP_FROM_SRC");
-  set_integer(
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_BORLAND, module_object, "IMAGE_DEBUG_TYPE_BORLAND");
-  set_integer(
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_RESERVED10,
       module_object,
       "IMAGE_DEBUG_TYPE_RESERVED10");
-  set_integer(IMAGE_DEBUG_TYPE_CLSID, module_object, "IMAGE_DEBUG_TYPE_CLSID");
-  set_integer(
+  yr_set_integer(IMAGE_DEBUG_TYPE_CLSID, module_object, "IMAGE_DEBUG_TYPE_CLSID");
+  yr_set_integer(
       IMAGE_DEBUG_TYPE_VC_FEATURE,
       module_object,
       "IMAGE_DEBUG_TYPE_VC_FEATURE");
-  set_integer(IMAGE_DEBUG_TYPE_POGO, module_object, "IMAGE_DEBUG_TYPE_POGO");
-  set_integer(IMAGE_DEBUG_TYPE_ILTCG, module_object, "IMAGE_DEBUG_TYPE_ILTCG");
-  set_integer(IMAGE_DEBUG_TYPE_MPX, module_object, "IMAGE_DEBUG_TYPE_MPX");
-  set_integer(IMAGE_DEBUG_TYPE_REPRO, module_object, "IMAGE_DEBUG_TYPE_REPRO");
+  yr_set_integer(IMAGE_DEBUG_TYPE_POGO, module_object, "IMAGE_DEBUG_TYPE_POGO");
+  yr_set_integer(IMAGE_DEBUG_TYPE_ILTCG, module_object, "IMAGE_DEBUG_TYPE_ILTCG");
+  yr_set_integer(IMAGE_DEBUG_TYPE_MPX, module_object, "IMAGE_DEBUG_TYPE_MPX");
+  yr_set_integer(IMAGE_DEBUG_TYPE_REPRO, module_object, "IMAGE_DEBUG_TYPE_REPRO");
 
-  set_integer(0, module_object, "is_pe");
+  yr_set_integer(0, module_object, "is_pe");
 
   foreach_memory_block(iterator, block)
   {

--- a/libyara/modules/tests/tests.c
+++ b/libyara/modules/tests/tests.c
@@ -80,7 +80,7 @@ define_function(empty)
 define_function(match)
 {
   return_integer(
-      yr_re_match(scan_context(), regexp_argument(1), string_argument(2)));
+      yr_re_match(yr_scan_context(), regexp_argument(1), string_argument(2)));
 }
 
 define_function(foobar)
@@ -169,33 +169,33 @@ int module_load(
     void* module_data,
     size_t module_data_size)
 {
-  set_integer(1, module_object, "constants.one");
-  set_integer(2, module_object, "constants.two");
-  set_string("foo", module_object, "constants.foo");
-  set_string("", module_object, "constants.empty");
+  yr_set_integer(1, module_object, "constants.one");
+  yr_set_integer(2, module_object, "constants.two");
+  yr_set_string("foo", module_object, "constants.foo");
+  yr_set_string("", module_object, "constants.empty");
 
-  set_integer(1, module_object, "struct_array[1].i");
+  yr_set_integer(1, module_object, "struct_array[1].i");
 
-  set_integer(0, module_object, "integer_array[%i]", 0);
-  set_integer(1, module_object, "integer_array[%i]", 1);
-  set_integer(2, module_object, "integer_array[%i]", 2);
-  set_integer(256, module_object, "integer_array[%i]", 256);
+  yr_set_integer(0, module_object, "integer_array[%i]", 0);
+  yr_set_integer(1, module_object, "integer_array[%i]", 1);
+  yr_set_integer(2, module_object, "integer_array[%i]", 2);
+  yr_set_integer(256, module_object, "integer_array[%i]", 256);
 
-  set_string("foo", module_object, "string_array[%i]", 0);
-  set_string("bar", module_object, "string_array[%i]", 1);
-  set_string("baz", module_object, "string_array[%i]", 2);
+  yr_set_string("foo", module_object, "string_array[%i]", 0);
+  yr_set_string("bar", module_object, "string_array[%i]", 1);
+  yr_set_string("baz", module_object, "string_array[%i]", 2);
 
-  set_sized_string("foo\0bar", 7, module_object, "string_array[%i]", 3);
+  yr_set_sized_string("foo\0bar", 7, module_object, "string_array[%i]", 3);
 
-  set_string("foo", module_object, "string_dict[%s]", "foo");
-  set_string("bar", module_object, "string_dict[\"bar\"]");
+  yr_set_string("foo", module_object, "string_dict[%s]", "foo");
+  yr_set_string("bar", module_object, "string_dict[\"bar\"]");
 
-  set_string("foo", module_object, "struct_dict[%s].s", "foo");
-  set_integer(1, module_object, "struct_dict[%s].i", "foo");
+  yr_set_string("foo", module_object, "struct_dict[%s].s", "foo");
+  yr_set_integer(1, module_object, "struct_dict[%s].i", "foo");
 
   if (module_data_size > 0 && module_data != NULL)
   {
-    set_sized_string(
+    yr_set_sized_string(
         (const char*) module_data,
         module_data_size,
         module_object,


### PR DESCRIPTION
Recently I started a project where I used libyara together with [nlohmann/json](https://github.com/nlohmann/json). This library contains several generally named methods like `set_string`, `get_string` etc. However YARA defines a lot of macros with same names. Problem with macros is that once they are defined, they pollute all namespaces, everything, and can cause issues, like in my case, where I wasn't able to compile my project.

The workaround for this is to reorder the includes or `#undef` them after include of `yara.h` but I figured that these generic names like `get/set_integer/string/...` or `module`, `parent` are probably better worth renaming. There is still a lot of macros without such prefix, because I haven't considered them that common, but I can rename all of them if needed.