### PR TITLE
Added RVA to the import details Function Details Structure

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -1333,7 +1333,7 @@ Reference
 
         .. c:member:: rva
 
-            .. versionadded:: 4.2.?
+            .. versionadded:: 4.3.0
 
             Relative virtual address (RVA) of imported function. If rva not found then this value is YR_UNDEFINED
 
@@ -1367,7 +1367,7 @@ Reference
 
         .. c:member:: rva
 
-            .. versionadded:: 4.2.?
+            .. versionadded:: 4.3.0
             
             Relative virtual address (RVA) of imported function. If rva not found then this value is YR_UNDEFINED
 

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -1331,6 +1331,12 @@ Reference
 
             Ordinal of imported function. If ordinal does not exist this value is YR_UNDEFINED
 
+        .. c:member:: rva
+
+            .. versionadded:: 4.2.?
+
+            Relative virtual address (RVA) of imported function. If rva not found then this value is YR_UNDEFINED
+
     *Example: pe.import_details[1].library_name == "library_name"
 
 .. c:type:: delayed_import_details
@@ -1358,6 +1364,12 @@ Reference
         .. c:member:: ordinal
 
             Ordinal of imported function. If ordinal does not exist this value is YR_UNDEFINED
+
+        .. c:member:: rva
+
+            .. versionadded:: 4.2.?
+            
+            Relative virtual address (RVA) of imported function. If rva not found then this value is YR_UNDEFINED
 
     *Example: pe.delayed_import_details[1].name == "library_name"
 

--- a/libyara/include/yara/pe_utils.h
+++ b/libyara/include/yara/pe_utils.h
@@ -42,6 +42,7 @@ typedef struct _IMPORT_FUNCTION
   char* name;
   uint8_t has_ordinal;
   uint16_t ordinal;
+  uint64_t rva;
 
   struct _IMPORT_FUNCTION* next;
 

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -685,6 +685,125 @@ int main(int argc, char** argv)
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
 
+ assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule import_details_rva_32_v1_catch \
+      {\
+          condition:\
+            for any import_detail in pe.import_details: (\
+                import_detail.library_name == \"MSVCR100.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"_initterm\" and\
+                    function.rva == 0x3084 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule import_details_rva_32_v2_catch \
+      {\
+          condition:\
+            for any import_detail in pe.import_details: (\
+                import_detail.library_name == \"KERNEL32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"QueryPerformanceCounter\" and\
+                    function.rva == 0x3054 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule import_details_rva_32_v3_catch \
+      {\
+          condition:\
+            for any import_detail in pe.import_details: (\
+                import_detail.library_name == \"KERNEL32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"CloseHandle\" and\
+                    function.rva == 0xd10c \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "pe_imports");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule import_details_rva_64_v1_catch \
+      {\
+          condition:\
+            for any import_detail in pe.import_details: (\
+                import_detail.library_name == \"KERNEL32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"LoadLibraryExW\" and\
+                    function.rva == 0x2118 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "mtxex_modified_rsrc_rva.dll");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule import_details_rva_64_v2_catch \
+      {\
+          condition:\
+            for any import_detail in pe.import_details: (\
+                import_detail.library_name == \"KERNEL32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"GetCurrentProcessId\" and\
+                    function.rva == 0x21a0 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "mtxex_modified_rsrc_rva.dll");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule delayed_import_details_rva_32_v1_catch \
+      {\
+          condition:\
+            for any import_detail in pe.delayed_import_details: (\
+                import_detail.library_name == \"USER32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"MessageBoxA\" and\
+                    function.rva == 0x13884 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "pe_imports");
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      \
+      rule delayed_import_details_rva_32_v2_catch \
+      {\
+          condition:\
+            for any import_detail in pe.delayed_import_details: (\
+                import_detail.library_name == \"USER32.dll\" and\
+                for any function in import_detail.functions : (\
+                    function.name == \"MessageBeep\" and\
+                    function.rva == 0x13880 \
+                )\
+            )\
+      }",
+      "tests/data/"
+      "pe_imports");
+
   assert_true_rule_file(
       "import \"pe\" \
       \


### PR DESCRIPTION
Added the import function's RVA to the import details functions structure.

Can use it like this:

```
import "pe" 
      rule test_rule 
      {
          condition:
            for any import_detail in pe.delayed_import_details: (
                import_detail.library_name == "USER32.dll" and
                for any function in import_detail.functions : (
                    function.name == "MessageBeep" and
                    function.rva == 0x13880 
                )
            )
      }
```

The goal of this is to work towards: https://twitter.com/xorhex/status/1528604721870540800?s=20&t=hruupMGNXyxgvoweJMv0Tg
