### PR TITLE
Reject non ascii bytes in regex

### DIFF
--- a/libyara/re_lexer.c
+++ b/libyara/re_lexer.c
@@ -1267,70 +1267,77 @@ YY_RULE_SETUP
 {
 
   // Any non-special character is passed as a CHAR token to the scanner.
-
-  yylval->integer = yytext[0];
-  return _CHAR_;
+  if (yytext[0] >= 32 && yytext[0] < 127)
+  {
+    yylval->integer = yytext[0];
+    return _CHAR_;
+  }
+  else
+  {
+    yyerror(yyscanner, lex_env, "non-ascii character");
+    yyterminate();
+  }
 }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 234 "re_lexer.l"
+#line 241 "re_lexer.l"
 {
   return _WORD_CHAR_;
 }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 239 "re_lexer.l"
+#line 246 "re_lexer.l"
 {
   return _NON_WORD_CHAR_;
 }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 244 "re_lexer.l"
+#line 251 "re_lexer.l"
 {
   return _SPACE_;
 }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 249 "re_lexer.l"
+#line 256 "re_lexer.l"
 {
   return _NON_SPACE_;
 }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 254 "re_lexer.l"
+#line 261 "re_lexer.l"
 {
   return _DIGIT_;
 }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 259 "re_lexer.l"
+#line 266 "re_lexer.l"
 {
   return _NON_DIGIT_;
 }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 264 "re_lexer.l"
+#line 271 "re_lexer.l"
 {
   return _WORD_BOUNDARY_;
 }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 268 "re_lexer.l"
+#line 275 "re_lexer.l"
 {
   return _NON_WORD_BOUNDARY_;
 }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 273 "re_lexer.l"
+#line 280 "re_lexer.l"
 {
 
   yyerror(yyscanner, lex_env, "backreferences are not allowed");
@@ -1339,7 +1346,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 280 "re_lexer.l"
+#line 287 "re_lexer.l"
 {
 
   uint8_t c;
@@ -1358,7 +1365,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 297 "re_lexer.l"
+#line 304 "re_lexer.l"
 {
 
   // End of character class.
@@ -1374,7 +1381,7 @@ YY_RULE_SETUP
 case 19:
 /* rule 19 can match eol */
 YY_RULE_SETUP
-#line 311 "re_lexer.l"
+#line 318 "re_lexer.l"
 {
 
   // A range inside a character class. The regexp is...
@@ -1439,7 +1446,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 374 "re_lexer.l"
+#line 381 "re_lexer.l"
 {
 
   for (int i = 0; i < 32; i++)
@@ -1448,7 +1455,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 381 "re_lexer.l"
+#line 388 "re_lexer.l"
 {
 
   for (int i = 0; i < 32; i++)
@@ -1457,7 +1464,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 388 "re_lexer.l"
+#line 395 "re_lexer.l"
 {
 
   for (int i = 0; i < 32; i++)
@@ -1466,7 +1473,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 395 "re_lexer.l"
+#line 402 "re_lexer.l"
 {
 
   for (int i = 0; i < 32; i++)
@@ -1475,7 +1482,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 402 "re_lexer.l"
+#line 409 "re_lexer.l"
 {
 
   for (char c = '0'; c <= '9'; c++)
@@ -1484,7 +1491,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 409 "re_lexer.l"
+#line 416 "re_lexer.l"
 {
 
   for (int i = 0; i < 32; i++)
@@ -1504,7 +1511,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 427 "re_lexer.l"
+#line 434 "re_lexer.l"
 {
 
   uint8_t c;
@@ -1522,7 +1529,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 443 "re_lexer.l"
+#line 450 "re_lexer.l"
 {
 
   if (yytext[0] >= 32 && yytext[0] < 127)
@@ -1540,7 +1547,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(char_class):
-#line 460 "re_lexer.l"
+#line 467 "re_lexer.l"
 {
 
   // End of regexp reached while scanning a character class.
@@ -1551,18 +1558,11 @@ case YY_STATE_EOF(char_class):
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 469 "re_lexer.l"
+#line 476 "re_lexer.l"
 {
-
-  if (yytext[0] >= 32 && yytext[0] < 127)
-  {
-    return yytext[0];
-  }
-  else
-  {
-    yyerror(yyscanner, lex_env, "non-ascii character");
-    yyterminate();
-  }
+  // Non-special characters have already been handled. This is a special character,
+  // which is thus passed as is to the scanner.
+  return yytext[0];
 }
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):

--- a/libyara/re_lexer.l
+++ b/libyara/re_lexer.l
@@ -225,9 +225,16 @@ hex_digit     [0-9a-fA-F]
 [^\\\[\(\)\|\$\.\^\+\*\?] {
 
   // Any non-special character is passed as a CHAR token to the scanner.
-
-  yylval->integer = yytext[0];
-  return _CHAR_;
+  if (yytext[0] >= 32 && yytext[0] < 127)
+  {
+    yylval->integer = yytext[0];
+    return _CHAR_;
+  }
+  else
+  {
+    yyerror(yyscanner, lex_env, "non-ascii character");
+    yyterminate();
+  }
 }
 
 
@@ -467,16 +474,9 @@ hex_digit     [0-9a-fA-F]
 
 
 . {
-
-  if (yytext[0] >= 32 && yytext[0] < 127)
-  {
-    return yytext[0];
-  }
-  else
-  {
-    yyerror(yyscanner, lex_env, "non-ascii character");
-    yyterminate();
-  }
+  // Non-special characters have already been handled. This is a special character,
+  // which is thus passed as is to the scanner.
+  return yytext[0];
 }
 
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -2702,6 +2702,14 @@ void test_re()
       "rule test { strings: $a =/abc([^\"\\\\])*\"/ nocase condition: $a }",
       TEXT_1024_BYTES "abc\xE0\x22");
 
+  // Non ascii characters are rejected in regular expressions.
+  assert_error(
+      "rule test { strings: $a = /¤/ condition: $a }",
+      ERROR_INVALID_REGULAR_EXPRESSION);
+  assert_error(
+      "rule test { strings: $a = /[1-£]/ condition: $a }",
+      ERROR_INVALID_REGULAR_EXPRESSION);
+
   YR_DEBUG_FPRINTF(1, stderr, "} // %s()\n", __FUNCTION__);
 }
 


### PR DESCRIPTION
As far as I know, regexes are not supposed to accept non ascii bytes. This is already rejected inside a char class (so `[<non_ascii_char>]` is rejected), but this is not properly rejected outside of a char class.

This means it is possible to write something like `$foo = /fé+e/` which definitely does not work as expected, even without considering the dependency on the rule encoding.

This PR fixes this by moving the ascii check in the right lex pattern, and adds two quick tests on this.