### PR TITLE
Fixed output of YARA on Windows when output is redirected

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1191,6 +1191,9 @@ static int callback(
 #if defined(_WIN32)
       // In Windows restore stdout to normal text mode as yr_object_print_data
       // calls printf which is not supported in UTF-8 mode.
+      // Explicitly flush the buffer before the switch in case we already printed
+      // something and it haven't been flushed automatically.
+      fflush(stdout);
       _setmode(_fileno(stdout), _O_TEXT);
 #endif
 
@@ -1199,6 +1202,9 @@ static int callback(
 
 #if defined(_WIN32)
       // Go back to UTF-8 mode.
+      // Explicitly flush the buffer before the switch in case we already printed
+      // something and it haven't been flushed automatically.
+      fflush(stdout);
       _setmode(_fileno(stdout), _O_U8TEXT);
 #endif
 


### PR DESCRIPTION
According to the documentation of [_setmode](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170#remarks), stream should be flushed before it is switched to another mode. This was causing issues when you redirected output of YARA on Windows to a pipe or a file. stdout is line buffered when terminal is attached but once the output is redirected, it's usually buffered by a certain buffer size. That's how systems usually do it.

Resolves #1752.

Thank you @wxsBSD for doing most of the research.