### PR TITLE
Export Hash (exphash)

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -1408,6 +1408,15 @@ Reference
 
     *Example: pe.imphash() == "b8bb385806b89680e13fc0cf24f4431e"*
 
+.. c:function:: exphash()
+
+    .. versionadded:: 4.2.3
+
+    Function returning the export hash or exphash for the PE. The export hash
+    is a MD5 hash of the PE's export table.
+
+    *Example: pe.exphash() == "69e300c67958698c5c147b2b563317bc"*
+
 .. c:function:: section_index(name)
 
     Function returning the index into the sections array for the section that has

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -329,6 +329,14 @@ int main(int argc, char** argv)
       }",
       "tests/data/tiny");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.exphash() == \"69e300c67958698c5c147b2b563317bc\" \
+      }",
+      "tests/data/mtxex.dll");
+
 #endif
 
 #if defined(HAVE_LIBCRYPTO)


### PR DESCRIPTION
Much like an imphash, an exphash is simply a MD5 hash of the exports defined in the Export Address Table. This is helpful for comparing PE files which export functions, which can then be compared to others. Found this useful when hunting for DLLs used in DLL-hijacking etc.

If no exports are found, `YR_UNDEFINED` simply returned.

```
import "pe"

rule test_exphash
{
	condition:
		pe.is_dll() and pe.exphash() == "a52adfc0598657d621ede8248dd0ea80"
}
```