### PR TITLE
Add signatures details in PE module when using Wincrypt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,12 @@ if UB_SANITIZER
 AM_CFLAGS+=-fsanitize=undefined -fno-sanitize-recover=undefined
 endif
 
+if LINK_CRYPT32
+  USE_CRYPT32=-lcrypt32
+else
+  USE_CRYPT32=
+endif
+
 # Build the library in the hand subdirectory first.
 SUBDIRS = libyara
 DIST_SUBDIRS = libyara
@@ -64,34 +70,34 @@ tests_mapper_SOURCES = tests/mapper.c
 tests_mapper_CFLAGS = -O0
 
 test_alignment_SOURCES = tests/test-alignment.c tests/util.c
-test_alignment_LDADD = libyara/.libs/libyara.a
+test_alignment_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_arena_SOURCES = tests/test-arena.c tests/util.c
-test_arena_LDADD = libyara/.libs/libyara.a
+test_arena_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_atoms_SOURCES = tests/test-atoms.c tests/util.c
-test_atoms_LDADD = libyara/.libs/libyara.a
+test_atoms_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_rules_SOURCES = tests/test-rules.c tests/util.c
-test_rules_LDADD = libyara/.libs/libyara.a
+test_rules_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 if POSIX
 EXTRA_test_rules_DEPENDENCIES = tests/mapper$(EXEEXT)
 endif
 test_pe_SOURCES = tests/test-pe.c tests/util.c
-test_pe_LDADD = libyara/.libs/libyara.a
+test_pe_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_elf_SOURCES = tests/test-elf.c tests/util.c
-test_elf_LDADD = libyara/.libs/libyara.a
+test_elf_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_version_SOURCES = tests/test-version.c tests/util.c
-test_version_LDADD = libyara/.libs/libyara.a
+test_version_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_api_SOURCES = tests/test-api.c tests/util.c
-test_api_LDADD = libyara/.libs/libyara.a
+test_api_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_bitmask_SOURCES = tests/test-bitmask.c tests/util.c
-test_bitmask_LDADD = libyara/.libs/libyara.a
+test_bitmask_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_math_SOURCES = tests/test-math.c tests/util.c
-test_math_LDADD = libyara/.libs/libyara.a
+test_math_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_stack_SOURCES = tests/test-stack.c tests/util.c
-test_stack_LDADD = libyara/.libs/libyara.a
+test_stack_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_re_split_SOURCES = tests/test-re-split.c tests/util.c
-test_re_split_LDADD = libyara/.libs/libyara.a
+test_re_split_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 test_async_SOURCES = tests/test-async.c tests/util.c
-test_async_LDADD = libyara/.libs/libyara.a
+test_async_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 
 TESTS = $(check_PROGRAMS)
 TESTS_ENVIRONMENT = TOP_SRCDIR=$(top_srcdir) TOP_BUILDDIR=$(top_builddir)
@@ -120,38 +126,38 @@ if POSIX
 if !ADDRESS_SANITIZER
 check_PROGRAMS+=test-exception
 test_exception_SOURCES = tests/test-exception.c tests/util.c
-test_exception_LDADD = libyara/.libs/libyara.a
+test_exception_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 endif
 
 if MACHO_MODULE
 check_PROGRAMS+=test-macho
 test_macho_SOURCES = tests/test-macho.c tests/util.c
-test_macho_LDADD = libyara/.libs/libyara.a
+test_macho_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 
 if DEX_MODULE
 check_PROGRAMS+=test-dex
 test_dex_SOURCES = tests/test-dex.c tests/util.c
-test_dex_LDADD = libyara/.libs/libyara.a
+test_dex_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 
 if DOTNET_MODULE
 check_PROGRAMS+=test-dotnet
 test_dotnet_SOURCES = tests/test-dotnet.c tests/util.c
-test_dotnet_LDADD = libyara/.libs/libyara.a
+test_dotnet_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 
 if MAGIC_MODULE
 check_PROGRAMS+=test-magic
 test_magic_SOURCES = tests/test-magic.c tests/util.c
-test_magic_LDADD = libyara/.libs/libyara.a
+test_magic_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 
 if PB_TESTS_MODULE
 check_PROGRAMS+=test-pb
 test_pb_SOURCES = tests/test-pb.c tests/util.c
-test_pb_LDADD = libyara/.libs/libyara.a
+test_pb_LDADD = libyara/.libs/libyara.a $(USE_CRYPT32)
 endif
 
 # man pages

--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,12 @@ AS_IF([test "x$have_crypto" = "xno"],
 	      AC_MSG_CHECKING([for Microsoft Crypto API])
         AC_CHECK_HEADERS([wincrypt.h],
           [
-	          AC_MSG_RESULT([The "hash" module functions will be provided through the Microsoft Crypto API])
+            PC_LIBS_PRIVATE="$PC_LIBS_PRIVATE -lcrypt32"
+            # We need to link against crypt32, but cannot use AC_SEARCH_LIBS,
+            # as for some reason it fails with mingw i686.
+            # Instead, define a conditional and link against crypt32 in the
+            # Makefile.am file.
+            AC_MSG_RESULT([The "hash" module functions will be provided through the Microsoft Crypto API])
             # FIXME: Add PC_LIBS_PRIVATE entries?
             build_hash_module=true
           ],
@@ -339,7 +344,7 @@ AS_IF([test "x$have_crypto" = "xno"],
   ])
 
 
-
+AM_CONDITIONAL([LINK_CRYPT32], [test x$ac_cv_header_wincrypt_h = xyes])
 AM_CONDITIONAL([GCC], [test "x$GCC" = xyes])
 AM_CONDITIONAL([PROTOC], [test "x${PROTOC}" != "x"])
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -839,23 +839,14 @@ Reference
 
     .. c:member:: issuer
 
-        A string containing information about the issuer. The formatting of
-        those strings depends on the library used, OpenSSL or Wincrypt.
-        These are some examples with OpenSSL::
+        A string containing information about the issuer. These are some
+        examples::
 
             "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Code Signing PCA"
 
             "/C=US/O=VeriSign, Inc./OU=VeriSign Trust Network/OU=Terms of use at https://www.verisign.com/rpa (c)10/CN=VeriSign Class 3 Code Signing 2010 CA"
 
             "/C=GB/ST=Greater Manchester/L=Salford/O=COMODO CA Limited/CN=COMODO Code Signing CA 2"
-
-        And the same examples with Wincrypt::
-
-            "C=US, S=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Code Signing PCA"
-
-            "C=US, O=\"VeriSign, Inc.\", OU=VeriSign Trust Network, OU=Terms of use at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010 CA"
-
-            "C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO Code Signing CA 2"
 
     .. c:member:: subject
 
@@ -889,8 +880,6 @@ Reference
     is functionally equivalent to::
 
             algorithm == "sha1WithRSAEncryption"
-
-    but only when using OpenSSL.
 
     .. c:member:: serial
 

--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -839,8 +839,9 @@ Reference
 
     .. c:member:: issuer
 
-        A string containing information about the issuer. These are some
-        examples::
+        A string containing information about the issuer. The formatting of
+        those strings depends on the library used, OpenSSL or Wincrypt.
+        These are some examples with OpenSSL::
 
             "/C=US/ST=Washington/L=Redmond/O=Microsoft Corporation/CN=Microsoft Code Signing PCA"
 
@@ -848,9 +849,18 @@ Reference
 
             "/C=GB/ST=Greater Manchester/L=Salford/O=COMODO CA Limited/CN=COMODO Code Signing CA 2"
 
+        And the same examples with Wincrypt::
+
+            "C=US, S=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Code Signing PCA"
+
+            "C=US, O=\"VeriSign, Inc.\", OU=VeriSign Trust Network, OU=Terms of use at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010 CA"
+
+            "C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO Code Signing CA 2"
+
     .. c:member:: subject
 
-        A string containing information about the subject.
+        A string containing information about the subject. See documentation
+        on the issuer field for more details on the format.
 
     .. c:member:: version
 
@@ -861,6 +871,7 @@ Reference
         String representation of the algorithm used for this
     signature. Usually "sha1WithRSAEncryption". It depends on the
     X.509 and PKCS#7 implementations and possibly their versions,
+    as well as whether OpenSSL or Wincrypt is used.
     consider using algorithm_oid instead.
 
     .. c:member:: algorithm_oid
@@ -878,6 +889,8 @@ Reference
     is functionally equivalent to::
 
             algorithm == "sha1WithRSAEncryption"
+
+    but only when using OpenSSL.
 
     .. c:member:: serial
 

--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -135,6 +135,12 @@ if GCC
 AM_CFLAGS+=-fvisibility=hidden
 endif
 
+if LINK_CRYPT32
+  USE_CRYPT32=-lcrypt32
+else
+  USE_CRYPT32=
+endif
+
 ACLOCAL_AMFLAGS=-I m4
 
 include_HEADERS = include/yara.h
@@ -196,6 +202,7 @@ dist_noinst_DATA = pb/yara.proto
 lib_LTLIBRARIES = libyara.la
 
 libyara_la_LDFLAGS = -version-number $(ABI_VERSION)
+libyara_la_LIBADD = $(USE_CRYPT32)
 
 BUILT_SOURCES = \
 	lexer.c \

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1616,8 +1616,8 @@ static void pe_parse_exports(PE* pe)
 }
 
 // BoringSSL (https://boringssl.googlesource.com/boringssl/) doesn't support
-// some features used in pe_parse_certificates, if you are using BoringSSL
-// instead of OpenSSL you should define BORINGSSL for YARA to compile properly,
+// some features used here, if you are using BoringSSL instead of OpenSSL
+// you should define BORINGSSL for YARA to compile properly,
 // but you won't have signature-related features in the PE module.
 #if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
 

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -453,7 +453,7 @@ int main(int argc, char** argv)
           pe.signatures[0].issuer == \"/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec Class 3 SHA256 Code Signing CA\" and \
           pe.signatures[0].subject == \"/C=US/ST=California/L=Menlo Park/O=Quicken, Inc./OU=Operations/CN=Quicken, Inc.\" and \
           pe.signatures[0].version == 3 and \
-          pe.signatures[0].algorithm == \"sha256RSA\" and \
+          pe.signatures[0].algorithm == \"sha256WithRSAEncryption\" and \
           pe.signatures[0].algorithm_oid == \"1.2.840.113549.1.1.11\" and \
           pe.signatures[0].serial == \"21:bd:b2:cb:ec:e5:43:1e:24:f7:56:74:d6:0e:9c:1d\" and \
           pe.signatures[0].not_before == 1491955200 and \

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -440,16 +440,18 @@ int main(int argc, char** argv)
 
 #endif
 
-#if defined(HAVE_WINCRYPT_H)
+#if defined(HAVE_LIBCRYPTO) || defined(HAVE_WINCRYPT_H)
 
+  // Simplified version to be compatible with the Wincrypt implementation,
+  // which do not expose the whole set of parameters available with libcrypto.
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \
         condition: \
           pe.number_of_signatures == 1 and \
           pe.signatures[0].thumbprint == \"c1bf1b8f751bf97626ed77f755f0a393106f2454\" and \
-          pe.signatures[0].issuer == \"C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec Class 3 SHA256 Code Signing CA\" and \
-          pe.signatures[0].subject == \"C=US, S=California, L=Menlo Park, O=\\\"Quicken, Inc.\\\", OU=Operations, CN=\\\"Quicken, Inc.\\\"\" and \
+          pe.signatures[0].issuer == \"/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec Class 3 SHA256 Code Signing CA\" and \
+          pe.signatures[0].subject == \"/C=US/ST=California/L=Menlo Park/O=Quicken, Inc./OU=Operations/CN=Quicken, Inc.\" and \
           pe.signatures[0].version == 3 and \
           pe.signatures[0].algorithm == \"sha256RSA\" and \
           pe.signatures[0].algorithm_oid == \"1.2.840.113549.1.1.11\" and \

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -340,12 +340,17 @@ int main(int argc, char** argv)
           pe.is_signed and \
           pe.number_of_signatures == 1 and \
           pe.signatures[0].thumbprint == \"c1bf1b8f751bf97626ed77f755f0a393106f2454\" and \
+          pe.signatures[0].issuer == \"/C=US/O=Symantec Corporation/OU=Symantec Trust Network/CN=Symantec Class 3 SHA256 Code Signing CA\" and \
           pe.signatures[0].subject == \"/C=US/ST=California/L=Menlo Park/O=Quicken, Inc./OU=Operations/CN=Quicken, Inc.\" and \
+          pe.signatures[0].version == 3 and \
+          pe.signatures[0].algorithm == \"sha256WithRSAEncryption\" and \
+          pe.signatures[0].algorithm_oid == \"1.2.840.113549.1.1.11\" and \
+          pe.signatures[0].serial == \"21:bd:b2:cb:ec:e5:43:1e:24:f7:56:74:d6:0e:9c:1d\" and \
+          pe.signatures[0].not_before == 1491955200 and \
+          pe.signatures[0].not_after == 1559692799 and \
           pe.signatures[0].verified and \
           pe.signatures[0].digest_alg == \"sha1\" and \
           pe.signatures[0].digest == \"f4ca190ec9052243b8882d492b1c12d04da7817f\" and \
-          pe.signatures[0].algorithm == \"sha256WithRSAEncryption\" and \
-          pe.signatures[0].algorithm_oid == \"1.2.840.113549.1.1.11\" and \
           pe.signatures[0].file_digest == \"f4ca190ec9052243b8882d492b1c12d04da7817f\" and \
           pe.signatures[0].number_of_certificates == 4 and \
           pe.signatures[0].certificates[0].not_after == 1609372799 and \
@@ -432,6 +437,32 @@ int main(int argc, char** argv)
       }",
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
+#endif
+
+#if defined(HAVE_WINCRYPT_H)
+
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.number_of_signatures == 1 and \
+          pe.signatures[0].thumbprint == \"c1bf1b8f751bf97626ed77f755f0a393106f2454\" and \
+          pe.signatures[0].issuer == \"C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec Class 3 SHA256 Code Signing CA\" and \
+          pe.signatures[0].subject == \"C=US, S=California, L=Menlo Park, O=\\\"Quicken, Inc.\\\", OU=Operations, CN=\\\"Quicken, Inc.\\\"\" and \
+          pe.signatures[0].version == 3 and \
+          pe.signatures[0].algorithm == \"sha256RSA\" and \
+          pe.signatures[0].algorithm_oid == \"1.2.840.113549.1.1.11\" and \
+          pe.signatures[0].serial == \"21:bd:b2:cb:ec:e5:43:1e:24:f7:56:74:d6:0e:9c:1d\" and \
+          pe.signatures[0].not_before == 1491955200 and \
+          pe.signatures[0].not_after == 1559692799 \
+      }",
+      "tests/data/"
+      "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
+#endif
+
+#if defined(HAVE_LIBCRYPTO) || defined(HAVE_WINCRYPT_H)
 
   assert_true_rule_file(
       "import \"pe\" \


### PR DESCRIPTION
The PE signatures fields depends on OpenSSL, which means they are completely missing when using any other crypto API. This PR aims to introduce some support of those fields when using the Windows API (wincrypt).

This support is only done for the 4.2 fields, before the addition of the authenticode dependency. This allows basic support which covers all the existing rules, and support for the newly added fields can be added in the future.

The code is fairly straightforward and not too complex. The only major issues are that three fields are dependent on OpenSSL specifics, which are:

- `algorithm`, which is a human-readable string for the algorithm_oid.
- `issuer` and `subject`, which depends on how OpenSSL converts a X509 name into a human readable string. `X509_NAME_oneline` is used, which is documented as being non standard. The wincrypt API generates another format, which can be seen in the documentation update included in this PR.

For `algorithm`, I have handled a special case for "sha1WithRSAEncryption" and "sha256WithRSAEncryption" so that those names are the same. For the rest, i'm using the wincrypt name. I don't think this is a big issue, as I'm not sure anything other than the previous two algorithms can really happen in authenticode, and the field is already documented as being subject to change, and `algorithm_oid` should be used instead.

For `issuer` and `subject`, in all of the rules that i have found, the matching is done on the content of one component and are not subject to changes on the separation of those components, so afaict the differences should be OK as well.

I have tried to match the existing coding style, If I made any mistakes please tell me and I will correct them.

Let me know if such a feature addition sounds OK for you, it would be a great help for us as we try to avoid depending on OpenSSL.