### PR TITLE
Print module names.

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -1406,7 +1406,8 @@ int _tmain(int argc, const char_t** argv)
   // module functions, just accessing the name pointer for each module.
   if (show_module_names)
   {
-    yr_modules_print_names();
+    for (YR_MODULE* module = yr_modules_get_table(); module->name != NULL; module++)
+      printf("%s\n", module->name);
     return EXIT_SUCCESS;
   }
 

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -149,6 +149,7 @@ static bool show_strings = false;
 static bool show_string_length = false;
 static bool show_xor_key = false;
 static bool show_meta = false;
+static bool show_module_names = false;
 static bool show_namespace = false;
 static bool show_version = false;
 static bool show_help = false;
@@ -272,6 +273,12 @@ args_option_t options[] = {
         _T("print-module-data"),
         &show_module_data,
         _T("print module data")),
+
+    OPT_BOOLEAN(
+        'M',
+        _T("module-names"),
+        &show_module_names,
+        _T("show module names")),
 
     OPT_BOOLEAN(
         'e',
@@ -1393,6 +1400,14 @@ int _tmain(int argc, const char_t** argv)
   {
     fprintf(stderr, "maximum number of threads is %d\n", YR_MAX_THREADS);
     return EXIT_FAILURE;
+  }
+
+  // This can be done before yr_initialize() because we aren't calling any
+  // module functions, just accessing the name pointer for each module.
+  if (show_module_names)
+  {
+    yr_modules_print_names();
+    return EXIT_SUCCESS;
   }
 
   if (argc < 2)

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -322,6 +322,6 @@ int yr_modules_load(const char* module_name, YR_SCAN_CONTEXT* context);
 
 int yr_modules_unload_all(YR_SCAN_CONTEXT* context);
 
-YR_API void yr_modules_print_names(void);
+YR_API YR_MODULE* yr_modules_get_table(void);
 
 #endif

--- a/libyara/include/yara/modules.h
+++ b/libyara/include/yara/modules.h
@@ -322,4 +322,6 @@ int yr_modules_load(const char* module_name, YR_SCAN_CONTEXT* context);
 
 int yr_modules_unload_all(YR_SCAN_CONTEXT* context);
 
+YR_API void yr_modules_print_names(void);
+
 #endif

--- a/libyara/modules.c
+++ b/libyara/modules.c
@@ -56,17 +56,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 YR_MODULE yr_modules_table[] = {
 #include <modules/module_list>
-};
+    {NULL, NULL, NULL, NULL, NULL, NULL}};
 
 #undef MODULE
 
 int yr_modules_initialize()
 {
-  int i;
-
-  for (i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+  for (YR_MODULE* module = yr_modules_table; module->initialize != NULL;
+       module++)
   {
-    int result = yr_modules_table[i].initialize(&yr_modules_table[i]);
+    int result = module->initialize(module);
 
     if (result != ERROR_SUCCESS)
       return result;
@@ -77,11 +76,9 @@ int yr_modules_initialize()
 
 int yr_modules_finalize()
 {
-  int i;
-
-  for (i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+  for (YR_MODULE* module = yr_modules_table; module->finalize != NULL; module++)
   {
-    int result = yr_modules_table[i].finalize(&yr_modules_table[i]);
+    int result = module->finalize(module);
 
     if (result != ERROR_SUCCESS)
       return result;
@@ -94,12 +91,12 @@ int yr_modules_do_declarations(
     const char* module_name,
     YR_OBJECT* main_structure)
 {
-  int i;
-
-  for (i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+  for (YR_MODULE* module = yr_modules_table;
+       module->name != NULL && module->declarations != NULL;
+       module++)
   {
-    if (strcmp(yr_modules_table[i].name, module_name) == 0)
-      return yr_modules_table[i].declarations(main_structure);
+    if (strcmp(module->name, module_name) == 0)
+      return module->declarations(main_structure);
   }
 
   return ERROR_UNKNOWN_MODULE;
@@ -107,7 +104,7 @@ int yr_modules_do_declarations(
 
 int yr_modules_load(const char* module_name, YR_SCAN_CONTEXT* context)
 {
-  int i, result;
+  int result;
 
   YR_MODULE_IMPORT mi;
 
@@ -151,11 +148,13 @@ int yr_modules_load(const char* module_name, YR_SCAN_CONTEXT* context)
           context->objects_table, module_name, NULL, module_structure),
       yr_object_destroy(module_structure));
 
-  for (i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+  for (YR_MODULE* module = yr_modules_table;
+       module->name != NULL && module->load != NULL;
+       module++)
   {
-    if (strcmp(yr_modules_table[i].name, module_name) == 0)
+    if (strcmp(module->name, module_name) == 0)
     {
-      result = yr_modules_table[i].load(
+      result = module->load(
           context, module_structure, mi.module_data, mi.module_data_size);
 
       if (result != ERROR_SUCCESS)
@@ -177,14 +176,16 @@ int yr_modules_load(const char* module_name, YR_SCAN_CONTEXT* context)
 
 int yr_modules_unload_all(YR_SCAN_CONTEXT* context)
 {
-  for (int i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+  for (YR_MODULE* module = yr_modules_table;
+       module->name != NULL && module->unload != NULL;
+       module++)
   {
     YR_OBJECT* module_structure = (YR_OBJECT*) yr_hash_table_remove(
-        context->objects_table, yr_modules_table[i].name, NULL);
+        context->objects_table, module->name, NULL);
 
     if (module_structure != NULL)
     {
-      yr_modules_table[i].unload(module_structure);
+      module->unload(module_structure);
       yr_object_destroy(module_structure);
     }
   }
@@ -192,8 +193,7 @@ int yr_modules_unload_all(YR_SCAN_CONTEXT* context)
   return ERROR_SUCCESS;
 }
 
-void yr_modules_print_names(void)
+YR_MODULE* yr_modules_get_table(void)
 {
-  for (int i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
-    printf("%s\n", yr_modules_table[i].name);
+  return yr_modules_table;
 }

--- a/libyara/modules.c
+++ b/libyara/modules.c
@@ -191,3 +191,9 @@ int yr_modules_unload_all(YR_SCAN_CONTEXT* context)
 
   return ERROR_SUCCESS;
 }
+
+void yr_modules_print_names(void)
+{
+  for (int i = 0; i < sizeof(yr_modules_table) / sizeof(YR_MODULE); i++)
+    printf("%s\n", yr_modules_table[i].name);
+}


### PR DESCRIPTION
Add a -M option to the cli which will print the module names to stdout. As the number of modules has grown it can become confusing to know what modules are available, so this option will display them on stdout.

NOTE: I'm not sure I like how I implemented this. It seems hackish to expose an API that just prints things on stdout but it felt even more hackish to walk the yr_modules_table array from outside of the module code. ;)

Fixes #737.