### PR TITLE
Add pe.import_rva() functions.

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -1373,6 +1373,42 @@ Reference
 
     *Example: pe.delayed_import_details[1].name == "library_name"
 
+.. c:function:: import_rva(dll, function)
+
+    .. versionadded:: 4.3.0
+
+    Function returning the RVA of an import that matches the DLL name and
+    function name.
+
+    *Example: pe.import_rva("PtImageRW.dll", "ord4") == 254924
+
+.. c:function:: import_rva(dll, ordinal)
+
+    .. versionadded:: 4.3.0
+
+    Function returning the RVA of an import that matches the DLL name and
+    ordinal number.
+
+    *Example: pe.import_rva("PtPDF417Decode.dll", 4) == 254924
+
+.. c:function:: delayed_import_rva(dll, function)
+
+    .. versionadded:: 4.3.0
+
+    Function returning the RVA of a delayed import that matches the DLL name and
+    function name.
+
+    *Example: pe.delayed_import_rva("QDB.dll", "ord116") == 6110705
+
+.. c:function:: delayed_import_rva(dll, ordinal)
+
+    .. versionadded:: 4.3.0
+
+    Function returning the RVA of a delayed import that matches the DLL name and
+    ordinal number.
+
+    *Example: pe.delayed_import_rva("QDB.dll", 116) == 6110705
+
 .. c:function:: locale(locale_identifier)
 
     .. versionadded:: 3.2.0

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -2949,6 +2949,96 @@ define_function(imports_dll)
   return_integer(result);
 }
 
+define_function(import_rva)
+{
+  SIZED_STRING* in_dll_name = sized_string_argument(1);
+  SIZED_STRING* in_function_name = sized_string_argument(2);
+
+  SIZED_STRING* dll_name;
+  SIZED_STRING* function_name;
+  YR_OBJECT* module = yr_module();
+  PE* pe = (PE*) module->data;
+
+  if (!pe)
+    return_integer(YR_UNDEFINED);
+
+  int64_t num_imports = yr_get_integer(pe->object, "number_of_imports");
+  if (IS_UNDEFINED(num_imports))
+    return_integer(YR_UNDEFINED);
+
+  for (int i = 0; i < num_imports; i++)
+  {
+    dll_name = yr_get_string(module, "import_details[%i].library_name", i);
+    if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
+        ss_compare(in_dll_name, dll_name) != 0)
+      continue;
+
+    int64_t num_functions = yr_get_integer(
+        module, "import_details[%i].number_of_functions", i);
+    if (IS_UNDEFINED(num_functions))
+      return_integer(YR_UNDEFINED);
+
+    for (int j = 0; j < num_functions; j++)
+    {
+      function_name = yr_get_string(
+          module, "import_details[%i].functions[%i].name", i, j);
+      if (function_name == NULL || IS_UNDEFINED(function_name))
+        continue;
+
+      if (ss_compare(in_function_name, function_name) == 0)
+        return_integer(yr_get_integer(
+            module, "import_details[%i].functions[%i].rva", i, j));
+    }
+  }
+
+  return_integer(YR_UNDEFINED);
+}
+
+define_function(import_rva_ordinal)
+{
+  SIZED_STRING* in_dll_name = sized_string_argument(1);
+  int64_t in_ordinal = integer_argument(2);
+
+  SIZED_STRING* dll_name;
+  int64_t ordinal;
+  YR_OBJECT* module = yr_module();
+  PE* pe = (PE*) module->data;
+
+  if (!pe)
+    return_integer(YR_UNDEFINED);
+
+  int64_t num_imports = yr_get_integer(pe->object, "number_of_imports");
+  if (IS_UNDEFINED(num_imports))
+    return_integer(YR_UNDEFINED);
+
+  for (int i = 0; i < num_imports; i++)
+  {
+    dll_name = yr_get_string(module, "import_details[%i].library_name", i);
+    if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
+        ss_compare(in_dll_name, dll_name) != 0)
+      continue;
+
+    int64_t num_functions = yr_get_integer(
+        module, "import_details[%i].number_of_functions", i);
+    if (IS_UNDEFINED(num_functions))
+      return_integer(YR_UNDEFINED);
+
+    for (int j = 0; j < num_functions; j++)
+    {
+      ordinal = yr_get_integer(
+          module, "import_details[%i].functions[%i].ordinal", i, j);
+      if (IS_UNDEFINED(ordinal))
+        continue;
+
+      if (ordinal == in_ordinal)
+        return_integer(yr_get_integer(
+            module, "import_details[%i].functions[%i].rva", i, j));
+    }
+  }
+
+  return_integer(YR_UNDEFINED);
+}
+
 define_function(locale)
 {
   YR_OBJECT* module = yr_module();
@@ -3490,6 +3580,8 @@ begin_declarations
   declare_function("imports", "isi", "i", imports_ordinal);
   declare_function("imports", "is", "i", imports_dll);
   declare_function("imports", "irr", "i", imports_regex);
+  declare_function("import_rva", "ss", "i", import_rva);
+  declare_function("import_rva", "si", "i", import_rva_ordinal);
   declare_function("locale", "i", "i", locale);
   declare_function("language", "i", "i", language);
   declare_function("is_dll", "", "i", is_dll);

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -873,6 +873,16 @@ int main(int argc, char** argv)
       }",
       "tests/data/pe_mingw");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.import_rva(\"PtImageRW.dll\", \"ord4\") == 254924 and \
+          pe.import_rva(\"PtPDF417Decode.dll\", 4) == 254948 \
+      }",
+      "tests/data/"
+      "ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386");
+
   yr_finalize();
 
   YR_DEBUG_FPRINTF(

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -883,6 +883,16 @@ int main(int argc, char** argv)
       "tests/data/"
       "ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.delayed_import_rva(\"QDB.dll\", \"ord116\") == \
+          pe.delayed_import_rva(\"QDB.dll\", 116) \
+      }",
+      "tests/data/"
+      "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
   yr_finalize();
 
   YR_DEBUG_FPRINTF(


### PR DESCRIPTION
Add pe.import_rva("foo.dll", "func1") which returns the RVA of the imported function. Also add pe.import_rva("foo.dll", 1) which does the same but the import is done by ordinal.