### PR TITLE
fix: Allow other users to delete/rename the file we are currently checking

### DIFF
--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -270,7 +270,7 @@ YR_API int yr_filemap_map_ex(
   fd = CreateFileA(
       file_path,
       GENERIC_READ,
-      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
       NULL,
       OPEN_EXISTING,
       FILE_FLAG_SEQUENTIAL_SCAN,


### PR DESCRIPTION
According to Windows documentation, deletion/renaming of the file will only occur when
all the handles opened before the `DeleteFile(A|W)` call are closed, so yara won't have
any problems with reading the file and doing its work because of this.

On the other hand, it will make it much more intuitive for users that don't know nor care
that a software is using Yara on the file they're targetting, the deletion will just take
a second or two instead of being instant, but it's much better than being denied deletion
repeatedly.

This problem notably surfaces when antivirus software using Yara is installed on dev machines:
compiling creates/deletes lot of small executables sometimes, which are picked up and then
checked by Yara: currently this creates lots of error because the file cannot be deleted.
