### PR TITLE
fix error handling in string.to_int()

### DIFF
--- a/docs/modules/string.rst
+++ b/docs/modules/string.rst
@@ -28,7 +28,7 @@ strings section of your rule.
     .. versionadded:: 4.3.0
 
     Convert the given string, interpreted with the given base, to a signed
-    integer. Base must be 0 or between 2 and 32 inclusive. If it is zero then
+    integer. Base must be 0 or between 2 and 36 inclusive. If it is zero then
     the string will be intrepreted as base 16 if it starts with "0x" or as base
     8 if it starts with "0". Leading '+' or '-' is also supported.
 

--- a/libyara/modules/string/string.c
+++ b/libyara/modules/string/string.c
@@ -77,6 +77,9 @@ define_function(to_int_base)
   int64_t base = integer_argument(2);
   int64_t result = 0;
 
+  if (!(base == 0 || (base >= 2 && base <= 36))) {
+      return_integer(YR_UNDEFINED);
+  }
   if (string_to_int(s, base, &result)) {
       return_integer(result);
   } else {

--- a/libyara/modules/string/string.c
+++ b/libyara/modules/string/string.c
@@ -36,21 +36,52 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define MODULE_NAME string
 
+bool string_to_int(char* s, int base, int64_t* result)
+{
+  char* endp = s;
+
+  errno = 0;
+  *result = strtoll(s, &endp, base);
+
+  if (errno != 0) {
+    // Error while parsing the string.
+    return false;
+  }
+  if (endp == s) {
+    // No digits were found.
+    return false;
+  }
+  if (*endp != '\0') {
+    // Parsing did not reach the end of the string.
+    return false;
+  }
+
+  return true;
+}
+
 define_function(to_int)
 {
   char* s = string_argument(1);
-  errno = 0;
-  int64_t result = strtoll(s, NULL, 0);
-  return_integer(errno ? YR_UNDEFINED : result);
+  int64_t result = 0;
+
+  if (string_to_int(s, 0, &result)) {
+      return_integer(result);
+  } else {
+      return_integer(YR_UNDEFINED);
+  }
 }
 
 define_function(to_int_base)
 {
   char* s = string_argument(1);
   int64_t base = integer_argument(2);
-  errno = 0;
-  int64_t result = strtoll(s, NULL, base);
-  return_integer(errno ? YR_UNDEFINED : result);
+  int64_t result = 0;
+
+  if (string_to_int(s, base, &result)) {
+      return_integer(result);
+  } else {
+      return_integer(YR_UNDEFINED);
+  }
 }
 
 define_function(string_length)

--- a/libyara/modules/string/string.c
+++ b/libyara/modules/string/string.c
@@ -39,16 +39,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 define_function(to_int)
 {
   char* s = string_argument(1);
+  errno = 0;
   int64_t result = strtoll(s, NULL, 0);
-  return_integer(result == 0 && errno ? YR_UNDEFINED : result);
+  return_integer(errno ? YR_UNDEFINED : result);
 }
 
 define_function(to_int_base)
 {
   char* s = string_argument(1);
   int64_t base = integer_argument(2);
+  errno = 0;
   int64_t result = strtoll(s, NULL, base);
-  return_integer(result == 0 && errno ? YR_UNDEFINED : result);
+  return_integer(errno ? YR_UNDEFINED : result);
 }
 
 define_function(string_length)

--- a/tests/test-string.c
+++ b/tests/test-string.c
@@ -55,15 +55,6 @@ int main(int argc, char** argv)
       }",
       NULL);
 
-  // Strings that are only partially converted are still fine.
-  assert_true_rule(
-      "import \"string\" \
-      rule test { \
-        condition: \
-          string.to_int(\"10A20\") == 10 \
-      }",
-      NULL);
-
   assert_true_rule(
       "import \"string\" \
       rule test { \
@@ -85,9 +76,9 @@ int main(int argc, char** argv)
       }",
       NULL);
 
-  // Test undefined cases:
-  // - on invalid base value
-  // - on underflow or underflow
+  // Test undefined cases
+
+  // on invalid base value
   assert_true_rule(
       "import \"string\" \
       rule test { \
@@ -97,6 +88,8 @@ int main(int argc, char** argv)
           not defined string.to_int(\"1\", 37) \
       }",
       NULL);
+
+  // on underflow or underflow
   assert_true_rule(
       "import \"string\" \
       rule test { \
@@ -109,6 +102,27 @@ int main(int argc, char** argv)
       rule test { \
         condition: \
           not defined string.to_int(\"-9223372036854775809\") \
+      }",
+      NULL);
+
+  // if parsing does not use all the string
+  assert_true_rule(
+      "import \"string\" \
+      rule test { \
+        condition: \
+          not defined string.to_int(\"FOO\") and \
+          not defined string.to_int(\"10A20\") \
+      }",
+      NULL);
+
+  // if parsing does not consume any digits
+  assert_true_rule(
+      "import \"string\" \
+      rule test { \
+        condition: \
+          not defined string.to_int(\"\") and \
+          not defined string.to_int(\"   -\") and \
+          not defined string.to_int(\" +0x\") \
       }",
       NULL);
 

--- a/tests/test-string.c
+++ b/tests/test-string.c
@@ -85,6 +85,33 @@ int main(int argc, char** argv)
       }",
       NULL);
 
+  // Test undefined cases:
+  // - on invalid base value
+  // - on underflow or underflow
+  assert_true_rule(
+      "import \"string\" \
+      rule test { \
+        condition: \
+          not defined string.to_int(\"1\", -1) and \
+          not defined string.to_int(\"1\", 1) and \
+          not defined string.to_int(\"1\", 37) \
+      }",
+      NULL);
+  assert_true_rule(
+      "import \"string\" \
+      rule test { \
+        condition: \
+          not defined string.to_int(\"9223372036854775808\") \
+      }",
+      NULL);
+  assert_true_rule(
+      "import \"string\" \
+      rule test { \
+        condition: \
+          not defined string.to_int(\"-9223372036854775809\") \
+      }",
+      NULL);
+
   assert_true_rule(
       "import \"string\" \
       rule test { \


### PR DESCRIPTION
Error handling in the to_int method of the new string module was not properly done.

- errno was not reset prior to the call to strtoll, so YR_UNDEFINED could be returned if a prior call failed, but not the current one.
- overflow/underflow was not properly checked, as it returns LLONG_MIN or LLONG_MAX and not 0.

Instead, do what is recommended in the man page for strtol:
- set errno to 0 prior to the call
- check errno after the call