### PR TITLE
test-magic: Update expected strings

### DIFF
--- a/tests/test-magic.c
+++ b/tests/test-magic.c
@@ -23,8 +23,10 @@ int main(int argc, char** argv)
 
   assert_true_rule_blob(
       "import \"magic\" rule test { condition: \
-      magic.type() contains \"MS-DOS executable\" and \
-      magic.mime_type() == \"application/x-dosexec\" }",
+      ( magic.type() contains \"MS-DOS executable\" or \
+        magic.type() contains \"PE32+ executable\" ) and                                                      \
+      ( magic.mime_type() == \"application/x-dosexec\" or \
+        magic.mime_type() == \"application/vnd.microsoft.portable-executable\" ) }",
       PE32_FILE);
 
   // Test case for https://github.com/VirusTotal/yara/issues/1663


### PR DESCRIPTION
As of file 5.44, some PE-related strings and MIME types have been updated, causing the test to fail.

See [Debian bug#1027031](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027031)