### PR TITLE
hash: Use OpenSSL's evp(7) series of functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,20 +259,19 @@ AC_ARG_WITH([crypto],
 
 AS_IF([test "x$with_crypto" != "xno"],
   [
-    AC_CHECK_HEADERS([openssl/md5.h],, [have_crypto=no])
-    AC_CHECK_HEADERS([openssl/sha.h],, [have_crypto=no])
+    AC_CHECK_HEADERS([openssl/evp.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/asn1.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/crypto.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/bio.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/pkcs7.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/x509.h],, [have_crypto=no])
     AC_CHECK_HEADERS([openssl/safestack.h],, [have_crypto=no])
-    AC_CHECK_LIB(crypto, MD5_Init,, [have_crypto=no])
-    AC_CHECK_LIB(crypto, MD5_Update,, [have_crypto=no])
-    AC_CHECK_LIB(crypto, MD5_Final,, [have_crypto=no])
-    AC_CHECK_LIB(crypto, SHA256_Init,, [have_crypto=no])
-    AC_CHECK_LIB(crypto, SHA256_Update,, [have_crypto=no])
-    AC_CHECK_LIB(crypto, SHA256_Final,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_DigestInit,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_DigestUpdate,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_DigestFinal,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_md5,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_sha1,, [have_crypto=no])
+    AC_CHECK_LIB(crypto, EVP_sha256,, [have_crypto=no])
   ],
   [
     have_crypto=no

--- a/libyara/crypto.h
+++ b/libyara/crypto.h
@@ -36,24 +36,50 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(HAVE_LIBCRYPTO)
 #include <openssl/crypto.h>
-#include <openssl/md5.h>
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
-typedef MD5_CTX yr_md5_ctx;
-typedef SHA_CTX yr_sha1_ctx;
-typedef SHA256_CTX yr_sha256_ctx;
+typedef EVP_MD_CTX *yr_md5_ctx;
+typedef EVP_MD_CTX *yr_sha1_ctx;
+typedef EVP_MD_CTX *yr_sha256_ctx;
 
-#define yr_md5_init(ctx)              MD5_Init(ctx)
-#define yr_md5_update(ctx, data, len) MD5_Update(ctx, data, len)
-#define yr_md5_final(digest, ctx)     MD5_Final(digest, ctx)
+#define yr_md5_init(ctx)             \
+  {                                  \
+    *ctx = EVP_MD_CTX_create();      \
+    EVP_DigestInit(*ctx, EVP_md5()); \
+  }
+#define yr_md5_update(ctx, data, len) EVP_DigestUpdate(*ctx, data, len)
+#define yr_md5_final(digest, ctx)        \
+  {                                      \
+    unsigned int len = YR_MD5_LEN;       \
+    EVP_DigestFinal(*ctx, digest, &len); \
+    EVP_MD_CTX_destroy(*ctx);            \
+  }
 
-#define yr_sha1_init(ctx)              SHA1_Init(ctx)
-#define yr_sha1_update(ctx, data, len) SHA1_Update(ctx, data, len)
-#define yr_sha1_final(digest, ctx)     SHA1_Final(digest, ctx)
+#define yr_sha1_init(ctx)             \
+  {                                   \
+    *ctx = EVP_MD_CTX_create();       \
+    EVP_DigestInit(*ctx, EVP_sha1()); \
+  }
+#define yr_sha1_update(ctx, data, len) EVP_DigestUpdate(*ctx, data, len)
+#define yr_sha1_final(digest, ctx)       \
+  {                                      \
+    unsigned int len = YR_SHA1_LEN;      \
+    EVP_DigestFinal(*ctx, digest, &len); \
+    EVP_MD_CTX_destroy(*ctx);            \
+  }
 
-#define yr_sha256_init(ctx)              SHA256_Init(ctx)
-#define yr_sha256_update(ctx, data, len) SHA256_Update(ctx, data, len)
-#define yr_sha256_final(digest, ctx)     SHA256_Final(digest, ctx)
+#define yr_sha256_init(ctx)             \
+  {                                     \
+    *ctx = EVP_MD_CTX_create();         \
+    EVP_DigestInit(*ctx, EVP_sha256()); \
+  }
+#define yr_sha256_update(ctx, data, len) EVP_DigestUpdate(*ctx, data, len)
+#define yr_sha256_final(digest, ctx)     \
+  {                                      \
+    unsigned int len = YR_SHA256_LEN;    \
+    EVP_DigestFinal(*ctx, digest, &len); \
+    EVP_MD_CTX_destroy(*ctx);            \
+  }
 
 #elif defined(HAVE_WINCRYPT_H)
 #include <windows.h>


### PR DESCRIPTION
As of OpenSSL 3.0, {MD5,SHA1,SHA256}_{Init,Update,Final} are deprecated. Stop using them.