### PR TITLE
Display plaintext when using the -X argument.

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -779,14 +779,15 @@ static int populate_scan_list(const char* filename, SCAN_OPTIONS* scan_opts)
 
 #endif
 
-static void print_string(const uint8_t* data, int length)
+static void print_string(const uint8_t* data, int length, uint8_t xor_key)
 {
   for (int i = 0; i < length; i++)
   {
-    if (data[i] >= 32 && data[i] <= 126)
-      _tprintf(_T("%c"), data[i]);
+    uint8_t c = data[i] ^ xor_key;
+    if (c >= 32 && c <= 126)
+      _tprintf(_T("%c"), c);
     else
-      _tprintf(_T("\\x%02X"), data[i]);
+      _tprintf(_T("\\x%02X"), c);
   }
 }
 
@@ -1118,7 +1119,11 @@ static int handle_message(
                 string->identifier);
 
           if (show_xor_key)
-            _tprintf(_T(":xor(0x%02x)"), match->xor_key);
+          {
+            _tprintf(_T(":xor(0x%02x,"), match->xor_key);
+            print_string(match->data, match->data_length, match->xor_key);
+            _tprintf(_T(")"));
+          }
 
           if (show_strings)
           {
@@ -1127,7 +1132,7 @@ static int handle_message(
             if (STRING_IS_HEX(string))
               print_hex_string(match->data, match->data_length);
             else
-              print_string(match->data, match->data_length);
+              print_string(match->data, match->data_length, 0);
           }
 
           _tprintf(_T("\n"));

--- a/cli/yara.c
+++ b/cli/yara.c
@@ -308,7 +308,7 @@ args_option_t options[] = {
         'X',
         _T("print-xor-key"),
         &show_xor_key,
-        _T("print xor key of matched strings")),
+        _T("print xor key and plaintext of matched strings")),
 
     OPT_BOOLEAN('g', _T("print-tags"), &show_tags, _T("print tags")),
 

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -700,7 +700,6 @@ int yr_parser_reduce_string_declaration(
     modifier.flags |= STRING_FLAGS_DOT_ALL;
 
   if (!(modifier.flags & STRING_FLAGS_WIDE) &&
-      !(modifier.flags & STRING_FLAGS_XOR) &&
       !(modifier.flags & STRING_FLAGS_BASE64 ||
         modifier.flags & STRING_FLAGS_BASE64_WIDE))
   {

--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -912,6 +912,28 @@ static int _yr_scan_verify_literal_match(
   if (STRING_FITS_IN_ATOM(string))
   {
     forward_matches = ac_match->backtrack;
+    if (STRING_IS_XOR(string))
+    {
+      if (STRING_IS_WIDE(string))
+      {
+        _yr_scan_xor_wcompare(
+            data + offset,
+            data_size - offset,
+            string->string,
+            string->length,
+            &xor_key);
+      }
+
+      if (STRING_IS_ASCII(string))
+      {
+        _yr_scan_xor_compare(
+            data + offset,
+            data_size - offset,
+            string->string,
+            string->length,
+            &xor_key);
+      }
+    }
   }
   else if (STRING_IS_NO_CASE(string))
   {


### PR DESCRIPTION
Output of -X now looks like this:

```
wxs@mbp yara % cat rules/xor.yara
rule a {
  strings:
    $a = "This program cannot"
    $b = "This program cannot" xor(1-255)
  condition:
    any of them
}
wxs@mbp yara % ./yara -s -X rules/xor.yara tests/data/xorwideandascii.out | head -5
a tests/data/xorwideandascii.out
0x4:$a:xor(0x00,This program cannot): This program cannot
0x1c:$b:xor(0x01,This program cannot): Uihr!qsnfs`l!b`oonu
0x34:$b:xor(0x02,This program cannot): Vjkq"rpmepco"acllmv
0x4c:$b:xor(0x03,This program cannot): Wkjp#sqldqbn#`bmmlw
wxs@mbp yara % ./yara -s -X rules/xor.yara tests/data/xorwideandascii.out | tail -5
0x1878:$b:xor(0xfb,This program cannot): \xAF\x93\x92\x88\xDB\x8B\x89\x94\x9C\x89\x9A\x96\xDB\x98\x9A\x95\x95\x94\x8F
0x1891:$b:xor(0xfc,This program cannot): \xA8\x94\x95\x8F\xDC\x8C\x8E\x93\x9B\x8E\x9D\x91\xDC\x9F\x9D\x92\x92\x93\x88
0x18aa:$b:xor(0xfd,This program cannot): \xA9\x95\x94\x8E\xDD\x8D\x8F\x92\x9A\x8F\x9C\x90\xDD\x9E\x9C\x93\x93\x92\x89
0x18c3:$b:xor(0xfe,This program cannot): \xAA\x96\x97\x8D\xDE\x8E\x8C\x91\x99\x8C\x9F\x93\xDE\x9D\x9F\x90\x90\x91\x8A
0x18dc:$b:xor(0xff,This program cannot): \xAB\x97\x96\x8C\xDF\x8F\x8D\x90\x98\x8D\x9E\x92\xDF\x9C\x9E\x91\x91\x90\x8B
wxs@mbp yara %
```