### PR TITLE
test-magic: Update expected strings (#1853)

### DIFF
--- a/tests/test-magic.c
+++ b/tests/test-magic.c
@@ -24,7 +24,8 @@ int main(int argc, char** argv)
   assert_true_rule_blob(
       "import \"magic\" rule test { condition: \
       ( magic.type() contains \"MS-DOS executable\" or \
-        magic.type() contains \"PE32+ executable\" ) and                                                      \
+        magic.type() contains \"PE32+ executable\" or \
+        magic.type() contains \"PE32 executable\") and \
       ( magic.mime_type() == \"application/x-dosexec\" or \
         magic.mime_type() == \"application/vnd.microsoft.portable-executable\" ) }",
       PE32_FILE);


### PR DESCRIPTION
As of file 5.44, some PE-related strings and MIME types have been updated, causing the test to fail. This commit extends the fix in 0939464c359b4718779b9f071029624df98bae39 to cover more cases.

closes #1853

See [Gentoo bug#889182](https://bugs.gentoo.org/889182)