### PR TITLE
fix: set number_of_signatures if no security data directory entry exists

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1847,14 +1847,14 @@ static void pe_parse_certificates(PE* pe)
 {
   int counter = 0;
 
+  // Default to 0 signatures until we know otherwise.
+  yr_set_integer(0, pe->object, "number_of_signatures");
+
   PIMAGE_DATA_DIRECTORY directory = pe_get_directory_entry(
       pe, IMAGE_DIRECTORY_ENTRY_SECURITY);
 
   if (directory == NULL)
     return;
-
-  // Default to 0 signatures until we know otherwise.
-  yr_set_integer(0, pe->object, "number_of_signatures");
 
   // directory->VirtualAddress is a file offset. Don't call pe_rva_to_offset().
   if (yr_le32toh(directory->VirtualAddress) == 0 ||


### PR DESCRIPTION
If no security data directory entry existed, `pe.number_of_signatures` was undefined, but should be 0. 
This is a regression compared to v4.2.3, where `pe.number_of_signatures` is set correctly.

This issue also occurs with the 4.3.0-rc1.