### PR TITLE
* Linux proc scan: Skip the memory region that doesn't have read perm…

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -372,6 +372,11 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
       // If the row was parsed correctly sscan must return 7.
       if (n == 7)
       {
+        // skip the memory region that doesn't have read permission.
+        if (perm[0] != 'r')
+        {
+          continue;
+        }
         // path_start contains the offset within buffer where the path starts,
         // the path should start with /.
         if (buffer[path_start] == '/')


### PR DESCRIPTION
…ission.

Memory regions in /proc/$PID/maps may have no read permission. e.g.
7f6d866bc000-7f6d868bb000 ---p 001c4000 fd:00 33679343 /usr/lib64/libc-2.17.so

The perms ---p (access flag: PROT_NONE) indicate the memory cannot be accessed at all. These areas are usually used as guard pages. Sometimes these regions with PROT_NONE access permission have some physical memory mapped pages. Reading these pages on some systems can cause process exceptions.
![image](https://user-images.githubusercontent.com/79446166/220599320-d13a3c29-9959-42b7-9cd5-4a0949e2e36f.png)


Skip those regions also improves some efficiency.

