### PR TITLE
Expose function RVA in pe.export_details[]

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1573,6 +1573,9 @@ static void pe_parse_exports(PE* pe)
     yr_set_integer(
         ordinal_base + i, pe->object, "export_details[%i].ordinal", exp_sz);
 
+    yr_set_integer(
+        yr_le32toh(function_addrs[i]), pe->object, "export_details[%i].rva", exp_sz);
+
     // Don't check for a failure here since some packers make this an invalid
     // value.
     offset = pe_rva_to_offset(pe, yr_le32toh(function_addrs[i]));
@@ -3720,6 +3723,7 @@ begin_declarations
     declare_string("name");
     declare_string("forward_name");
     declare_integer("ordinal");
+    declare_integer("rva");
   end_struct_array("export_details")
 
   begin_struct_array("import_details")

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -561,6 +561,10 @@ int main(int argc, char** argv)
           pe.export_details[0].offset == 1072 and \
           pe.export_details[0].name == \"DllGetClassObject\" and \
           pe.export_details[0].ordinal == 1 and \
+          pe.export_details[0].rva == 0x1030 and \
+          pe.export_details[1].rva == 0x267d and \
+          pe.export_details[2].rva == 0x26a8 and \
+          pe.export_details[3].rva == 0x26ca and \
           pe.export_details[1].forward_name == \"COMSVCS.GetObjectContext\" \
       }",
       "tests/data/mtxex.dll");
@@ -607,7 +611,8 @@ int main(int argc, char** argv)
       "import \"pe\" \
       rule test { \
         condition: \
-          pe.export_details[0].name == \"CP_PutItem\" \
+          pe.export_details[0].name == \"CP_PutItem\" and \
+          pe.export_details[0].rva == 0x106c \
       }",
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885.upx");


### PR DESCRIPTION
Analysts would welcome having a function RVA in its raw form available via `pe.export_details[]` before it is turned into offset via `RVA->offset` calculation. I have exposed it and added few test cases to test this feature out.