### PR TITLE
Rich version data

### DIFF
--- a/docs/modules/pe.rst
+++ b/docs/modules/pe.rst
@@ -1043,6 +1043,12 @@ Reference
 
         Data after being decrypted by XORing it with the key.
 
+    .. c:member:: version_data
+
+        .. versionadded:: 4.3.0
+
+        Version fields after being decrypted by XORing it with the key.
+
     .. c:function:: version(version, [toolid])
 
         .. versionadded:: 3.5.0

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -624,6 +624,15 @@ int main(int argc, char** argv)
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
 
+  assert_true_rule_file(
+      "import \"pe\" \
+      rule test { \
+        condition: \
+          pe.rich_signature.version_data == \"\\x1b\\x9d\\x9c\\x00\\x1b\\x9d\\x9e\\x00\\x1b\\x9d\\xaa\\x00ov\\xab\\x00\\x09x\\x93\\x00\\x00\\x00\\x01\\x00\\x1b\\x9d\\xab\\x00\\x1b\\x9d\\x9b\\x00\\x1b\\x9d\\x9a\\x00\\x1b\\x9d\\x9d\\x00\" \
+      }",
+      "tests/data/"
+      "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");
+
   // This is the first 840 bytes (just enough to make sure the rich header is
   // parsed) of
   // 3593d3d08761d8ddc269dde945c0cb07e5cef5dd46ad9eefc22d17901f542093.


### PR DESCRIPTION
Add support for pulling out the just tool id and version fields into their own string. This is a more generic capability than hashing the entire rich header clear data because it is agnostic of the count fields.