### PR TITLE
Some small fixes in macho module

### DIFF
--- a/libyara/include/yara/macho.h
+++ b/libyara/include/yara/macho.h
@@ -540,7 +540,7 @@ typedef struct
   uint64_t lr;
   uint64_t sp;
   uint64_t pc;
-  uint64_t cpsr;
+  uint32_t cpsr;
 } yr_arm_thread_state64_t;
 
 typedef struct

--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -1032,9 +1032,14 @@ define_function(ep_for_arch_subtype)
 
     if (type == type_arg && subtype == subtype_arg)
     {
-      uint64_t file_offset = yr_get_integer(module, "fat_arch[%i].offset", i);
       uint64_t entry_point = yr_get_integer(module, "file[%i].entry_point", i);
-      return_integer(file_offset + entry_point);
+      uint64_t file_offset = yr_get_integer(module, "fat_arch[%i].offset", i);
+
+      if (entry_point == YR_UNDEFINED) {
+        return_integer(YR_UNDEFINED);
+      } else {
+        return_integer(file_offset + entry_point);
+      }
     }
   }
 


### PR DESCRIPTION
First commit is a fix for the retrieval of the entry_point value for arm64 architecture:
the last element in the `yr_arm_thread_state64_t` struct is a 32 bit integer and not a 64 bit one.
This caused the struct to be slightly bigger than it should be, possibly causing the
entry point for this architecture to not be retrieved.

Second commit is a fix for the macho.entry_point_for_arch function, if the entry_point is undefined.
Calling `macho.entry_point_for_arch` on this arch adds this undefined value to the arch offset, returning a buggy value.