### PR TITLE
Added NetLock to Who's using Yara

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ awesome list of [YARA-related stuff](https://github.com/InQuest/awesome-yara).
 * [McAfee Advanced Threat Defense](https://mcafee.com/atd)
 * [Metaflows](https://www.metaflows.com)
 * [NBS System](https://www.nbs-system.com/)
+* [NetLock](https://netlockendpoint.com) 
 * [Nextron Systems](https://www.nextron-systems.com)
 * [Nozomi Networks](https://www.nozominetworks.com)
 * [osquery](https://www.osquery.io)


### PR DESCRIPTION
NetLock Endpoint uses Yara. I couldnt see any way to PR to the website, 

also the following links are dead, I didnt want to just remove them, or replace them but can if that helps :)
http://www.activecanopy.com/ 
https://claroty.com/continuous-threat-detection 
https://security.opentext.com/endpointsecurity 
http://www.raytheoncyber.com/capabilities/products/sureview-threatprotection/ 
https://www.emc.com/security/rsa-ecat.htm 
https://www.wewatchyourwebsite.com/