### PR TITLE
Fixed dotnet module failure on Windows

### DIFF
--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -274,7 +274,7 @@ static const char* get_typedef_type(uint32_t flags)
 static char* create_full_name(const char* name, const char* namespace)
 {
   if (!name || !strlen(name))
-    return namespace ? strdup(namespace) : NULL;
+    return namespace ? yr_strdup(namespace) : NULL;
 
   // No namespace -> return name only
   if (!namespace || !strlen(namespace))


### PR DESCRIPTION
create_full_name() used strdup() even on Windows where all str* functions are masked behind yr_str*() functions which internally used HeapAlloc()/HeapFree() which does not cooperate well with malloc()/free().

Thanks to @wxsBSD & @tlansec for finding the bug.