### PR TITLE
Fix case sensitive checks.

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -3019,7 +3019,7 @@ define_function(import_rva)
   {
     dll_name = yr_get_string(module, "import_details[%i].library_name", i);
     if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
-        ss_compare(in_dll_name, dll_name) != 0)
+        ss_icompare(in_dll_name, dll_name) != 0)
       continue;
 
     int64_t num_functions = yr_get_integer(
@@ -3034,7 +3034,7 @@ define_function(import_rva)
       if (function_name == NULL || IS_UNDEFINED(function_name))
         continue;
 
-      if (ss_compare(in_function_name, function_name) == 0)
+      if (ss_icompare(in_function_name, function_name) == 0)
         return_integer(yr_get_integer(
             module, "import_details[%i].functions[%i].rva", i, j));
     }
@@ -3064,7 +3064,7 @@ define_function(import_rva_ordinal)
   {
     dll_name = yr_get_string(module, "import_details[%i].library_name", i);
     if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
-        ss_compare(in_dll_name, dll_name) != 0)
+        ss_icompare(in_dll_name, dll_name) != 0)
       continue;
 
     int64_t num_functions = yr_get_integer(
@@ -3112,7 +3112,7 @@ define_function(delayed_import_rva)
         module, "delayed_import_details[%i].library_name", i);
 
     if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
-        ss_compare(in_dll_name, dll_name) != 0)
+        ss_icompare(in_dll_name, dll_name) != 0)
       continue;
 
     int64_t num_functions = yr_get_integer(
@@ -3129,7 +3129,7 @@ define_function(delayed_import_rva)
       if (function_name == NULL || IS_UNDEFINED(function_name))
         continue;
 
-      if (ss_compare(in_function_name, function_name) == 0)
+      if (ss_icompare(in_function_name, function_name) == 0)
         return_integer(yr_get_integer(
             module, "delayed_import_details[%i].functions[%i].rva", i, j));
     }
@@ -3161,7 +3161,7 @@ define_function(delayed_import_rva_ordinal)
         module, "delayed_import_details[%i].library_name", i);
 
     if (dll_name == NULL || IS_UNDEFINED(dll_name) ||
-        ss_compare(in_dll_name, dll_name) != 0)
+        ss_icompare(in_dll_name, dll_name) != 0)
       continue;
 
     int64_t num_functions = yr_get_integer(

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -882,22 +882,26 @@ int main(int argc, char** argv)
       }",
       "tests/data/pe_mingw");
 
+  // These are intentionally using DLL and function names with incorrect case
+  // sure the string compare is case insensitive.
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \
         condition: \
-          pe.import_rva(\"PtImageRW.dll\", \"ord4\") == 254924 and \
-          pe.import_rva(\"PtPDF417Decode.dll\", 4) == 254948 \
+          pe.import_rva(\"ptimagerw.dll\", \"ORD4\") == 254924 and \
+          pe.import_rva(\"ptPDF417decode.dll\", 4) == 254948 \
       }",
       "tests/data/"
       "ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386");
 
+  // These are intentionally using DLL and function names with incorrect case
+  // sure the string compare is case insensitive.
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \
         condition: \
-          pe.delayed_import_rva(\"QDB.dll\", \"ord116\") == \
-          pe.delayed_import_rva(\"QDB.dll\", 116) \
+          pe.delayed_import_rva(\"qdb.dll\", \"ORD116\") == \
+          pe.delayed_import_rva(\"qdb.dll\", 116) \
       }",
       "tests/data/"
       "079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885");

--- a/tests/test-pe.c
+++ b/tests/test-pe.c
@@ -883,7 +883,7 @@ int main(int argc, char** argv)
       "tests/data/pe_mingw");
 
   // These are intentionally using DLL and function names with incorrect case
-  // sure the string compare is case insensitive.
+  // to be sure the string compare is case insensitive.
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \
@@ -895,7 +895,7 @@ int main(int argc, char** argv)
       "ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386");
 
   // These are intentionally using DLL and function names with incorrect case
-  // sure the string compare is case insensitive.
+  // to be sure the string compare is case insensitive.
   assert_true_rule_file(
       "import \"pe\" \
       rule test { \


### PR DESCRIPTION
When using pe.import_rva() or pe.delayed_import_rva() they were using case sensitive checks while other import/export functions were case insensitive.

The import_rva() and delayed_import_rva() were added in 4.3.0 so I think they aren't heavily used yet and we can fix them to be consistent now.

Noticed by: Ronnie Salomonsen