### PR TITLE
Respect MSVC grammar for __declspec(deprecated) when using YR_DEPRECATED

### DIFF
--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -563,7 +563,7 @@ struct YR_RULES
     // deprecated, which will raise a warning if used.
     // TODO(vmalvarez): Remove this field when a reasonable a few versions
     // after 4.1 has been released.
-    YR_RULE* rules_list_head YR_DEPRECATED;
+    YR_DEPRECATED(YR_RULE* rules_list_head);
   };
 
   // Array of pointers with an entry for each of the defined strings. The idx
@@ -576,7 +576,7 @@ struct YR_RULES
     // deprecated, which will raise a warning if used.
     // TODO(vmalvarez): Remove this field when a reasonable a few versions
     // after 4.1 has been released.
-    YR_STRING* strings_list_head YR_DEPRECATED;
+    YR_DEPRECATED(YR_STRING* strings_list_head);
   };
 
   // Array of pointers with an entry for each external variable.
@@ -588,7 +588,7 @@ struct YR_RULES
     // as deprecated, which will raise a warning if used.
     // TODO(vmalvarez): Remove this field when a reasonable a few versions
     // after 4.1 has been released.
-    YR_EXTERNAL_VARIABLE* externals_list_head YR_DEPRECATED;
+    YR_DEPRECATED(YR_EXTERNAL_VARIABLE* externals_list_head);
   };
 
   // Pointer to the Aho-Corasick transition table.

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -55,38 +55,38 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if defined(_WIN32) || defined(__CYGWIN__)
 #ifdef YR_BUILDING_DLL
 #ifdef __GNUC__
-#define YR_API            EXTERNC __attribute__((dllexport))
-#define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
-#define YR_DEPRECATED     __attribute__((deprecated))
+#define YR_API                   EXTERNC __attribute__((dllexport))
+#define YR_DEPRECATED_API        EXTERNC __attribute__((deprecated))
+#define YR_DEPRECATED(statement) statement __attribute__((deprecated))
 #else
-#define YR_API            EXTERNC __declspec(dllexport)
-#define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
-#define YR_DEPRECATED     __declspec(deprecated)
+#define YR_API                   EXTERNC __declspec(dllexport)
+#define YR_DEPRECATED_API        EXTERNC __declspec(deprecated)
+#define YR_DEPRECATED(statement) __declspec(deprecated) statement
 #endif
 #elif defined(YR_IMPORTING_DLL)
 #ifdef __GNUC__
-#define YR_API            EXTERNC __attribute__((dllimport))
-#define YR_DEPRECATED_API EXTERNC __attribute__((deprecated))
-#define YR_DEPRECATED     __attribute__((deprecated))
+#define YR_API                   EXTERNC __attribute__((dllimport))
+#define YR_DEPRECATED_API        EXTERNC __attribute__((deprecated))
+#define YR_DEPRECATED(statement) statement __attribute__((deprecated))
 #else
-#define YR_API            EXTERNC __declspec(dllimport)
-#define YR_DEPRECATED_API EXTERNC __declspec(deprecated)
-#define YR_DEPRECATED     __declspec(deprecated)
+#define YR_API                   EXTERNC __declspec(dllimport)
+#define YR_DEPRECATED_API        EXTERNC __declspec(deprecated)
+#define YR_DEPRECATED(statement) __declspec(deprecated) statement
 #endif
 #else
-#define YR_API            EXTERNC
-#define YR_DEPRECATED_API EXTERNC
-#define YR_DEPRECATED
+#define YR_API                   EXTERNC
+#define YR_DEPRECATED_API        EXTERNC
+#define YR_DEPRECATED(statement) statement
 #endif
 #else
 #if __GNUC__ >= 4
-#define YR_API            EXTERNC __attribute__((visibility("default")))
-#define YR_DEPRECATED_API YR_API __attribute__((deprecated))
-#define YR_DEPRECATED     __attribute__((deprecated))
+#define YR_API                   EXTERNC __attribute__((visibility("default")))
+#define YR_DEPRECATED_API        YR_API __attribute__((deprecated))
+#define YR_DEPRECATED(statement) statement __attribute__((deprecated))
 #else
-#define YR_API            EXTERNC
-#define YR_DEPRECATED_API EXTERNC
-#define YR_DEPRECATED
+#define YR_API                   EXTERNC
+#define YR_DEPRECATED_API        EXTERNC
+#define YR_DEPRECATED(statement) statement
 #endif
 #endif
 


### PR DESCRIPTION
This PR fixes compiler errors for usages of YR_DEPRECATED when compiling with MSVC

Step 7 in #1592 would be obsolete.