### PR TITLE
Add CLI flag for disabling console log printing.

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -159,6 +159,7 @@ static bool negate = false;
 static bool print_count_only = false;
 static bool fail_on_warnings = false;
 static bool rules_are_compiled = false;
+static bool disable_console_logs = false;
 static long total_count = 0;
 static long limit = 0;
 static long timeout = 1000000;
@@ -198,6 +199,12 @@ args_option_t options[] = {
         MAX_ARGS_EXT_VAR,
         _T("define external variable"),
         _T("VAR=VALUE")),
+
+    OPT_BOOLEAN(
+        'q',
+        _T("disable-console-logs"),
+        &disable_console_logs,
+        _T("disable printing console log messages")),
 
     OPT_BOOLEAN(
         0,
@@ -1245,7 +1252,8 @@ static int callback(
     return CALLBACK_CONTINUE;
 
   case CALLBACK_MSG_CONSOLE_LOG:
-    _tprintf(_T("%" PF_S "\n"), (char*) message_data);
+    if (!disable_console_logs)
+      _tprintf(_T("%" PF_S "\n"), (char*) message_data);
     return CALLBACK_CONTINUE;
   }
 

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -61,6 +61,10 @@ Available options are:
 
   Define external variable. This option can be used multiple times.
 
+.. option:: -q --disable-console-logs
+
+  Disable printing console log messages.
+
 .. option:: --fail-on-warnings
 
   Treat warnings as errors. Has no effect if used with --no-warnings.


### PR DESCRIPTION
- Add CLI flag that will disable the console module from printing: 
    - Short: -q
    - Long:  --disable-console-logs
- Update documentation with new CLI flag

Closes #1912