### PR TITLE
Add an init guard to prevent authenticode parser reinitialize

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -3886,8 +3886,15 @@ int module_initialize(YR_MODULE* module)
 {
 #if defined(HAVE_LIBCRYPTO)
   // Initialize OpenSSL global objects for the auth library before any
-  // multithreaded environment as it is not thread-safe
-  initialize_authenticode_parser();
+  // multithreaded environment as it is not thread-safe. This can
+  // only be called once per process.
+  static bool s_initialized = false;
+
+  if (!s_initialized)
+  {
+    s_initialized = true;
+    initialize_authenticode_parser();
+  }
 #endif
   return ERROR_SUCCESS;
 }


### PR DESCRIPTION
We use libyara in a process that can initialize/finialize and then re-initialize yara.
After #1623 was merged, calling initialize the second time caused failures.

This change adds a static guard around the `initialize_authenticode_parser` call in pe module's initialize so that it won't be initialized more than once per process.