### PR TITLE
Do not init authenticode-parser when using BoringSSL

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -3884,7 +3884,7 @@ end_declarations
 
 int module_initialize(YR_MODULE* module)
 {
-#if defined(HAVE_LIBCRYPTO)
+#if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
   // Initialize OpenSSL global objects for the auth library before any
   // multithreaded environment as it is not thread-safe. This can
   // only be called once per process.


### PR DESCRIPTION
`authenticode-parser` is compatible with OpenSSL only. Most of the preprocessor directives already handle this, except for the call to `initialize_authenticode_parser`. This was causing a link failure when trying to use YARA with BoringSSL.