### PR TITLE
fix: ensure all notebook allocations are 8-byte aligned

### DIFF
--- a/libyara/notebook.c
+++ b/libyara/notebook.c
@@ -64,7 +64,10 @@ struct YR_NOTEBOOK_PAGE
   // Pointer to next page.
   YR_NOTEBOOK_PAGE* next;
   // Page's data.
-  uint8_t data[0];
+  //
+  // This field must be 8-byte aligned to guarantee that all notebooks
+  // allocations are 8-byte aligned.
+  YR_ALIGN(8) uint8_t data[0];
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add a custom align directive on the data field in YR_NOTEBOOK_PAGE. This ensures the field is 8-byte aligned, and thus all allocations are 8-byte aligned.

Technically YR_ALIGN only works if the provided alignment is not bigger than the max alignment, so i'm not sure whether this fixes the bug everywhere.