### PR TITLE
Fix bug in `yr_rules_from_arena` causing allocation of bitmask of wrong size

### DIFF
--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -337,7 +337,7 @@ int yr_rules_from_arena(YR_ARENA* arena, YR_RULES** rules)
     return ERROR_INSUFFICIENT_MEMORY;
 
   new_rules->rule_evaluate_condition_flags = (YR_BITMASK*) yr_calloc(
-      sizeof(YR_BITMASK), YR_BITMASK_SIZE(new_rules->num_rules));
+      sizeof(YR_BITMASK), YR_BITMASK_SIZE(summary->num_rules));
   if (new_rules->rule_evaluate_condition_flags == NULL)
   {
     yr_free(new_rules);


### PR DESCRIPTION
There is a bug introduced in 1c309a82499fc64fc490fcefb5da18abbfde7f6d: the size of bitmask to allocate is calculated with undefined `new_rules->num_rules` value instead of passed  `summary->num_rules`, so the `YR_BITMASK_SIZE()` is evaluated as random value, sometimes less then needed.

In my case `new_rules->num_rules == 0` so `YR_BITMASK_SIZE(new_rules->num_rules) == 1` and I get 4 (`1 * sizeof(YR_BITMASK)` ) bytes allocated for bitmask. After that I get heap corruption because of writing of first bit of non-allocated 5th byte for 128 rule (`i == 128`) here:
https://github.com/VirusTotal/yara/blob/1c309a82499fc64fc490fcefb5da18abbfde7f6d/libyara/rules.c#L378-L384