### PR TITLE
fix: If any signature is valid, the file is properly signed

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1703,7 +1703,7 @@ void _process_authenticode(
   {
     const Authenticode* authenticode = auth_array->signatures[i];
 
-    signature_valid = authenticode->verify_flags == AUTHENTICODE_VFY_VALID
+    signature_valid |= authenticode->verify_flags == AUTHENTICODE_VFY_VALID
                           ? true
                           : false;
 


### PR DESCRIPTION
If any signature will be valid, pe file is correctly signed