### PR TITLE
Added symbols from dotnet module to reference in docs

### DIFF
--- a/docs/modules/dotnet.rst
+++ b/docs/modules/dotnet.rst
@@ -250,6 +250,19 @@ Reference
 
     The typelib of the file.
 
+.. c:type:: number_of_constants
+
+    The number of constants in the .NET file.
+
+.. c:type:: constants
+
+    A zero-based array of strings, one for each constant the .NET file has. 
+    Individual constants can be accessed by using the [] operator.
+
+.. c:type:: number_of_assembly_refs
+
+    The number of objects for .NET assembly reference information.
+
 .. c:type:: assembly_refs
 
     Object for .NET assembly reference information.


### PR DESCRIPTION
There were some symbols missing in [docs](https://yara.readthedocs.io/en/stable/modules/dotnet.html#reference), although they are implemented in [dotnet module](https://github.com/VirusTotal/yara/blob/master/libyara/modules/dotnet/dotnet.c):

`number_of_assembly_refs`
`constants`
`number_of_constants`

Dotnet module reference in docs was checked and these missing symbols have been added, so now it should fully correspond to the real state of dotnet module.