### PR TITLE
Expose reading object arrays.

### DIFF
--- a/libyara/include/yara/object.h
+++ b/libyara/include/yara/object.h
@@ -123,9 +123,10 @@ int yr_object_set_string(
     const char* field,
     ...) YR_PRINTF_LIKE(4, 5);
 
-int yr_object_array_length(YR_OBJECT* object);
+YR_API int yr_object_array_length(YR_OBJECT* object);
 
-YR_OBJECT* yr_object_array_get_item(YR_OBJECT* object, int flags, int index);
+YR_API YR_OBJECT* yr_object_array_get_item(YR_OBJECT* object, int flags,
+                                           int index);
 
 int yr_object_array_set_item(YR_OBJECT* object, YR_OBJECT* item, int index);
 

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -655,7 +655,7 @@ int yr_object_structure_set_member(YR_OBJECT* object, YR_OBJECT* member)
   return ERROR_SUCCESS;
 }
 
-int yr_object_array_length(YR_OBJECT* object)
+YR_API int yr_object_array_length(YR_OBJECT* object)
 {
   YR_OBJECT_ARRAY* array;
 
@@ -668,7 +668,8 @@ int yr_object_array_length(YR_OBJECT* object)
   return array->items->length;
 }
 
-YR_OBJECT* yr_object_array_get_item(YR_OBJECT* object, int flags, int index)
+YR_API YR_OBJECT* yr_object_array_get_item(YR_OBJECT* object, int flags,
+                                           int index)
 {
   YR_OBJECT* result = NULL;
   YR_OBJECT_ARRAY* array;


### PR DESCRIPTION
Expose yr_object_array_get_item() and yr_object_array_length() - we use these to access array items in a custom callback. We can maintain this patch internally if necessary, but I suspect it will be useful outside of our use case.