### PR TITLE
Allow unreferenced strings if they start with '_'

### DIFF
--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -512,6 +512,16 @@ static void test_syntax()
       "rule test { strings: $a = \"a\" condition: for 3.14159 of them: ($) }",
       ERROR_INVALID_VALUE);
 
+  assert_error(
+      "rule test { strings: $a = \"a\" condition: true }",
+      ERROR_UNREFERENCED_STRING);
+
+  // String identifiers prefixed with '_' are allowed to be unreferenced.
+  // Any unreferenced string must be searched for anywhere.
+  assert_string_capture(
+      "rule test { strings: $a = \"AXS\" $_b = \"ERS\" condition: $a }",
+      "AXSERS", "ERS");
+
   YR_DEBUG_FPRINTF(1, stderr, "} // %s()\n", __FUNCTION__);
 }
 
@@ -522,6 +532,11 @@ static void test_anonymous_strings()
   assert_true_rule(
       "rule test { strings: $ = \"a\" $ = \"b\" condition: all of them }",
       "ab");
+
+  // Anonymous strings must be referenced.
+  assert_error(
+      "rule test { strings: $ = \"a\" condition: true }",
+      ERROR_UNREFERENCED_STRING);
 
   YR_DEBUG_FPRINTF(1, stderr, "} // %s()\n", __FUNCTION__);
 }

--- a/tests/util.h
+++ b/tests/util.h
@@ -183,6 +183,16 @@ void assert_hex_atoms(
     }                                                                   \
   } while (0);
 
+// Ensure that a particular string is found when scanning. This is useful for
+// making sure that unreferenced strings are searched for properly.
+// Specifically, making sure they have STRING_FLAGS_FIXED_OFFSET unset.
+#define assert_string_capture(rule, string, expected) do {              \
+    if (!capture_string(rule, string, expected)) {                      \
+      fprintf(stderr, "%s:%d: rule does not match\n",                   \
+              __FILE__, __LINE__);                                      \
+      exit(EXIT_FAILURE);                                               \
+    }                                                                   \
+  } while (0);
 
 #define assert_match_count(rule, string, count)                         \
   do {                                                                  \


### PR DESCRIPTION
As briefly discussed in #1937, this change will make it so that any string identifier that starts with '_' can be unreferenced. Any anonymous strings must still be referenced.

While testing this out I realized that an unreferenced string still had the STRING_FLAG_FIXED_OFFSET set, which meant any unreferenced string would have a fixed_offset of YR_UNDEFINED. To deal with this when we are reducing the rule we unset STRING_FLAG_FIXED_OFFSET if the string is unreferenced.