### PR TITLE
fix verified field in pe module with multiple signatures

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1750,19 +1750,18 @@ void _process_authenticode(
   if (!auth_array || !auth_array->count)
     return;
 
-  /* If any signature will be valid -> file is correctly signed */
   bool signature_valid = false;
 
   for (size_t i = 0; i < auth_array->count; ++i)
   {
     const Authenticode* authenticode = auth_array->signatures[i];
+    bool verified = authenticode->verify_flags == AUTHENTICODE_VFY_VALID;
 
-    signature_valid |= authenticode->verify_flags == AUTHENTICODE_VFY_VALID
-                           ? true
-                           : false;
+    /* If any signature is valid -> file is correctly signed */
+    signature_valid |= verified;
 
     yr_set_integer(
-        signature_valid, pe->object, "signatures[%i].verified", *sig_count);
+        verified, pe->object, "signatures[%i].verified", *sig_count);
 
     yr_set_string(
         authenticode->digest_alg,


### PR DESCRIPTION
Commit 1a85738 fixed one bug but introduced a new one. The `pe.is_signed` field is now properly set (true if any signature is valid), but the `signatures[i].verified` is now incorrectly set: instead of being set to whether this signature is verified, it is set to true if any previous signature is verified.

Unfortunately, there is no test file that is triggering this behavior. This would require having a signature that is invalid appearing after a signature that is valid.

I targetted master, but we probably want this fix in 4.4.0. I'm not sure how you handle this, do you want me to target 4.4.x?