### PR TITLE
feat: memory module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -80,6 +80,7 @@ yara_library(
         "time",
         "console",
         "string",
+        "memory",
     ],
     modules_srcs = [
         "libyara/modules/cuckoo/cuckoo.c",
@@ -96,6 +97,7 @@ yara_library(
         "libyara/modules/time/time.c",
         "libyara/modules/console/console.c",
         "libyara/modules/string/string.c",
+        "libyara/modules/modules/modules.c",
     ],
     deps = [
         "@jansson",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -97,7 +97,7 @@ yara_library(
         "libyara/modules/time/time.c",
         "libyara/modules/console/console.c",
         "libyara/modules/string/string.c",
-        "libyara/modules/modules/modules.c",
+        "libyara/modules/memory/memory.c",
     ],
     deps = [
         "@jansson",

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,6 +140,7 @@ endif
 #
 # MODULES += libyara/modules/yourmodule.c
 #
+MODULES += libyara/modules/memory/memory.c
 
 include_HEADERS = libyara/include/yara.h
 

--- a/libyara/include/yara/proc.h
+++ b/libyara/include/yara/proc.h
@@ -55,4 +55,68 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 YR_API const uint8_t* yr_process_fetch_memory_block_data(
     YR_MEMORY_BLOCK* block);
 
+
+#if defined(USE_WINDOWS_PROC)
+
+#include <windows.h>
+
+typedef struct _YR_PROC_INFO
+{
+  HANDLE hProcess;
+  SYSTEM_INFO si;
+} YR_PROC_INFO;
+#elif defined(USE_LINUX_PROC)
+
+#include <unistd.h>
+
+typedef struct _YR_PROC_INFO
+{
+  int pid;
+  int mem_fd;
+  int pagemap_fd;
+  FILE* maps;
+  uint64_t map_offset;
+  uint64_t next_block_end;
+  int page_size;
+  char map_path[PATH_MAX];
+  uint64_t map_dmaj;
+  uint64_t map_dmin;
+  uint64_t map_ino;
+} YR_PROC_INFO;
+
+#elif defined(USE_MACH_PROC)
+
+#include <mach/mach.h>
+
+typedef struct _YR_PROC_INFO
+{
+  task_t task;
+} YR_PROC_INFO;
+
+#elif defined(USE_OPENBSD_PROC)
+
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/sysctl.h>
+#include <sys/wait.h>
+
+typedef struct _YR_PROC_INFO
+{
+  int pid;
+  uint64_t old_end;
+  struct kinfo_vmentry vm_entry;
+} YR_PROC_INFO;
+
+#elif defined(USE_FREEBSD_PROC)
+
+#include <sys/ptrace.h>
+
+typedef struct _YR_PROC_INFO
+{
+  int pid;
+  struct ptrace_vm_entry vm_entry;
+} YR_PROC_INFO;
+
+#endif
+
 #endif

--- a/libyara/modules/memory/memory.c
+++ b/libyara/modules/memory/memory.c
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#define MODULE_NAME memory
+
+#include "memory.h"
+
+#if defined(USE_LINUX_PROC)
+#include "memory_linux.c"
+#elif defined(USE_WINDOWS_PROC)
+#include "memory_windows.c"
+#elif defined(USE_MACH_PROC)
+#include "memory_mach.c"
+#elif defined(USE_OPENBSD_PROC)
+#include "memory_openbsd.c"
+#elif defined(USE_FREEBSD_PROC)
+#include "memory_freebsd.c"
+#else
+#include "memory_others.c"
+#endif
+
+begin_declarations
+  declare_integer("PAGE_SIZE");
+  declare_integer("EXECUTE");
+  declare_integer("WRITE");
+  declare_integer("READ");
+  declare_function("protection", "i", "i", protection);
+end_declarations
+
+int module_initialize(YR_MODULE* module)
+{
+  page_size = get_page_size();
+  return ERROR_SUCCESS;
+}
+
+int module_finalize(YR_MODULE* module)
+{
+  return ERROR_SUCCESS;
+}
+
+int module_load(
+    YR_SCAN_CONTEXT* context,
+    YR_OBJECT* module_object,
+    void* module_data,
+    size_t module_data_size)
+{
+  if (context->flags & SCAN_FLAGS_PROCESS_MEMORY)
+  {
+    YR_PROC_ITERATOR_CTX* proc_context = (YR_PROC_ITERATOR_CTX*) context->iterator->context;
+    module_object->data = proc_context->proc_info;
+  }
+
+  yr_set_integer(page_size, module_object, "PAGE_SIZE");
+  yr_set_integer(EXECUTE, module_object, "EXECUTE");
+  yr_set_integer(WRITE, module_object, "WRITE");
+  yr_set_integer(READ, module_object, "READ");
+
+  return ERROR_SUCCESS;
+}
+
+int module_unload(YR_OBJECT* module_object)
+{
+  return ERROR_SUCCESS;
+}

--- a/libyara/modules/memory/memory.h
+++ b/libyara/modules/memory/memory.h
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef YR_MEMORY_H
+#define YR_MEMORY_H
+
+static int page_size = -1;
+
+#define EXECUTE 1
+#define WRITE 2
+#define READ 4
+
+#endif

--- a/libyara/modules/memory/memory_freebsd.c
+++ b/libyara/modules/memory/memory_freebsd.c
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/sysctl.h>
+#include <sys/wait.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  YR_OBJECT* module = yr_module();
+  if (module->data == NULL)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  int64_t address = integer_argument(1);
+
+  if (address == YR_UNDEFINED)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+
+  YR_PROC_INFO* proc_info = (YR_PROC_INFO*) module->data;  
+  
+  struct ptrace_vm_entry vm_entry;
+  memset(&vm_entry, 0, sizeof(struct ptrace_vm_entry));
+
+  while (vm_entry.pve_end <= address)
+  {
+    if (ptrace(
+            PT_VM_ENTRY, proc_info->pid, (char*) (&vm_entry), 0) ==
+        -1)
+    {
+      return_integer(YR_UNDEFINED);
+    }
+  }
+
+  if (vm_entry.pve_start > address || vm_entry.pve_end <= address)
+  {
+      return_integer(YR_UNDEFINED);
+  }
+
+  int protection = 0;
+  if (vm_entry.pve_prot & 1)
+  {
+    protection |= READ;
+  }
+  if (vm_entry.pve_prot & 2)
+  {
+    protection |= WRITE;
+  }
+  if (vm_entry.pve_prot & 4)
+  {
+    protection |= EXECUTE;
+  }
+  return_integer(protection);
+}
+
+int get_page_size()
+{
+  return PAGE_SIZE;
+}

--- a/libyara/modules/memory/memory_linux.c
+++ b/libyara/modules/memory/memory_linux.c
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <linux/limits.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  YR_OBJECT* module = yr_module();
+  if (module->data == NULL)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  int64_t address = integer_argument(1);
+
+  if (address == YR_UNDEFINED)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  
+  YR_PROC_INFO* proc_info = (YR_PROC_INFO*) module->data;
+
+  char buffer[PATH_MAX];
+  char perm[5];
+
+  fseek(proc_info->maps, 0, 0);
+
+  while (fgets(buffer, sizeof(buffer), proc_info->maps) != NULL)
+  {
+    char* p;
+    // locate the '\n' character
+    p = strrchr(buffer, '\n');
+    // If we haven't read the whole line, skip over the rest.
+    if (p == NULL)
+    {
+      int c;
+      do
+      {
+        c = fgetc(proc_info->maps);
+      } while (c >= 0 && c != '\n');
+    }
+    // otherwise remove '\n' at the end of the line
+    else
+    {
+      *p = '\0';
+    }
+
+
+    // Each row in /proc/$PID/maps describes a region of contiguous virtual
+    // memory in a process or thread. Each row has the following fields:
+    //
+    // address           perms offset  dev   inode   pathname
+    // 08048000-08056000 r-xp 00000000 03:0c 64593   /usr/sbin/gpm
+    //
+    // For this use case, we only need the first 2 columns (range and perms)
+    uint64_t begin, end;
+    int n = 0;
+    n = sscanf(
+        buffer,
+        "%" SCNx64 "-%" SCNx64 " %4s ",
+        &begin,
+        &end,
+        perm);
+
+    // If the row was parsed correctly sscan must return 3.
+    if (n == 3)
+    {
+      if (begin <= address && end > address)
+      {
+        // Found correct block in maps
+        int protection = 0;
+        if (perm[0] == 'r')
+        {
+          protection |= READ;
+        }
+        if (perm[1] == 'w')
+        {
+          protection |= WRITE;
+        }
+        if (perm[2] == 'x')
+        {
+          protection |= EXECUTE;
+        }
+        return_integer(protection);
+      }
+      continue;
+    }
+  }
+  return_integer(YR_UNDEFINED);
+}
+
+int get_page_size()
+{
+  int page_size = sysconf(_SC_PAGE_SIZE);
+  if (page_size < 0)
+    page_size = 4096;
+  return page_size;
+}

--- a/libyara/modules/memory/memory_mach.c
+++ b/libyara/modules/memory/memory_mach.c
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach/vm_region.h>
+#include <mach/vm_statistics.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  YR_OBJECT* module = yr_module();
+  if (module->data == NULL)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  vm_address_t address = integer_argument(1);
+
+  if (address == YR_UNDEFINED)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+
+  YR_PROC_INFO* proc_info = (YR_PROC_INFO*) module->data;  
+
+  kern_return_t kr;
+  mach_msg_type_number_t info_count = VM_REGION_BASIC_INFO_COUNT_64;
+  mach_port_t object;
+  vm_region_basic_info_data_64_t info;
+  vm_size_t size = 0;
+
+  kr = vm_region_64(
+      proc_info->task,
+      &address,
+      &size,
+      VM_REGION_BASIC_INFO,
+      (vm_region_info_t) &info,
+      &info_count,
+      &object);
+
+  if (kr != KERN_SUCCESS)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+
+  int protection = 0;
+  if (info.protection & VM_PROT_READ)
+  {
+    protection |= READ;
+  }
+  if (info.protection & VM_PROT_WRITE)
+  {
+    protection |= WRITE;
+  }
+  if (info.protection & VM_PROT_EXECUTE)
+  {
+    protection |= EXECUTE;
+  }
+
+  return_integer(protection);
+}
+
+int get_page_size()
+{
+  return PAGE_SIZE;
+}

--- a/libyara/modules/memory/memory_openbsd.c
+++ b/libyara/modules/memory/memory_openbsd.c
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/sysctl.h>
+#include <sys/wait.h>
+
+#include <unistd.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  YR_OBJECT* module = yr_module();
+  if (module->data == NULL)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  int64_t address = integer_argument(1);
+
+  if (address == YR_UNDEFINED)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+
+  YR_PROC_INFO* proc_info = (YR_PROC_INFO*) module->data;  
+
+  int mib[] = {CTL_KERN, KERN_PROC_VMMAP, proc_info->pid};
+  size_t len = sizeof(struct kinfo_vmentry);
+  
+  struct kinfo_vmentry entry;
+  memset(&entry, 0, len);
+  
+  entry.kve_start = address;
+
+  if (sysctl(mib, 3, &entry, &len, NULL, 0) < 0)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+
+  int protection = 0;
+  if (entry.kve_protection & KVE_PROT_READ)
+  {
+    protection |= READ;
+  }
+  if (entry.kve_protection & KVE_PROT_WRITE)
+  {
+    protection |= WRITE;
+  }
+  if (entry.kve_protection & KVE_PROT_EXEC)
+  {
+    protection |= EXECUTE;
+  }
+  return_integer(protection);
+}
+
+int get_page_size()
+{
+  int page_size = sysconf(_SC_PAGE_SIZE);
+  if (page_size < 0)
+    page_size = 4096;
+  return page_size;
+}

--- a/libyara/modules/memory/memory_others.c
+++ b/libyara/modules/memory/memory_others.c
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <inttypes.h>
+
+#include <yara/modules.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  return_integer(YR_UNDEFINED);
+}
+
+int get_page_size()
+{
+  return -1;
+}

--- a/libyara/modules/memory/memory_windows.c
+++ b/libyara/modules/memory/memory_windows.c
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2023. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <inttypes.h>
+
+#include <memoryapi.h>
+#include <sysinfoapi.h>
+#include <winnt.h>
+
+#include <yara/modules.h>
+#include <yara/proc.h>
+#include <yara/utils.h>
+
+#include "memory.h"
+
+define_function(protection)
+{
+  YR_OBJECT* module = yr_module();
+  if (module->data == NULL)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  int64_t address = integer_argument(1);
+
+  if (address == YR_UNDEFINED)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+    
+  YR_PROC_INFO* proc_info = (YR_PROC_INFO*) module->data;
+  
+  MEMORY_BASIC_INFORMATION memory_info;
+  if (VirtualQueryEx(proc_info->hProcess, (void*) address, &memory_info, sizeof(MEMORY_BASIC_INFORMATION)) == 0)
+  {
+    return_integer(YR_UNDEFINED);
+  }
+  
+  int protection = 0;
+
+  if (memory_info.AllocationProtect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+  {
+    protection |= EXECUTE;
+  }
+  if (memory_info.AllocationProtect & (PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY | PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY))
+  {
+    protection |= READ;
+  }
+  if (memory_info.AllocationProtect & (PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY | PAGE_READWRITE | PAGE_WRITECOPY))
+  {
+    protection |= WRITE;
+  }
+  return_integer(protection);
+}
+
+int get_page_size()
+{
+  SYSTEM_INFO system_info;
+  GetNativeSystemInfo(&system_info);
+  return system_info.dwPageSize;
+}

--- a/libyara/modules/module_list
+++ b/libyara/modules/module_list
@@ -5,6 +5,7 @@ MODULE(math)
 MODULE(time)
 MODULE(console)
 MODULE(string)
+MODULE(memory)
 
 #ifdef DOTNET_MODULE
 MODULE(dotnet)

--- a/libyara/proc/freebsd.c
+++ b/libyara/proc/freebsd.c
@@ -41,12 +41,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/proc.h>
 
-typedef struct _YR_PROC_INFO
-{
-  int pid;
-  struct ptrace_vm_entry vm_entry;
-} YR_PROC_INFO;
-
 int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)
 {
   int status;

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -46,21 +46,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/proc.h>
 #include <yara/strutils.h>
 
-typedef struct _YR_PROC_INFO
-{
-  int pid;
-  int mem_fd;
-  int pagemap_fd;
-  FILE* maps;
-  uint64_t map_offset;
-  uint64_t next_block_end;
-  int page_size;
-  char map_path[PATH_MAX];
-  uint64_t map_dmaj;
-  uint64_t map_dmin;
-  uint64_t map_ino;
-} YR_PROC_INFO;
-
 static int page_size = -1;
 
 int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)

--- a/libyara/proc/mach.c
+++ b/libyara/proc/mach.c
@@ -38,11 +38,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/proc.h>
 
-typedef struct _YR_PROC_INFO
-{
-  task_t task;
-} YR_PROC_INFO;
-
 int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)
 {
   YR_PROC_INFO* proc_info = (YR_PROC_INFO*) yr_malloc(sizeof(YR_PROC_INFO));

--- a/libyara/proc/openbsd.c
+++ b/libyara/proc/openbsd.c
@@ -47,13 +47,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/proc.h>
 
-typedef struct _YR_PROC_INFO
-{
-  int pid;
-  uint64_t old_end;
-  struct kinfo_vmentry vm_entry;
-} YR_PROC_INFO;
-
 int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)
 {
   int status;

--- a/libyara/proc/openbsd.c
+++ b/libyara/proc/openbsd.c
@@ -154,7 +154,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
 
   iterator->last_error = ERROR_SUCCESS;
 
-  if (proc_info->old_end <= current_begin)
+  while (proc_info->old_end <= current_begin)
   {
     if (sysctl(mib, 3, &proc_info->vm_entry, &len, NULL, 0) < 0)
       return NULL;

--- a/libyara/proc/windows.c
+++ b/libyara/proc/windows.c
@@ -36,12 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/mem.h>
 #include <yara/proc.h>
 
-typedef struct _YR_PROC_INFO
-{
-  HANDLE hProcess;
-  SYSTEM_INFO si;
-} YR_PROC_INFO;
-
 int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)
 {
   TOKEN_PRIVILEGES tokenPriv;

--- a/windows/vs2015/libyara/libyara.vcxproj
+++ b/windows/vs2015/libyara/libyara.vcxproj
@@ -246,6 +246,7 @@
     <ClCompile Include="..\..\..\libyara\modules\hash\hash.c" />
     <ClCompile Include="..\..\..\libyara\modules\math\math.c" />
     <ClCompile Include="..\..\..\libyara\modules\macho\macho.c" />
+    <ClCompile Include="..\..\..\libyara\modules\memory\memory.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\authenticode.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\helper.c" />

--- a/windows/vs2017/libyara/libyara.vcxproj
+++ b/windows/vs2017/libyara/libyara.vcxproj
@@ -245,6 +245,7 @@
     <ClCompile Include="..\..\..\libyara\modules\hash\hash.c" />
     <ClCompile Include="..\..\..\libyara\modules\math\math.c" />
     <ClCompile Include="..\..\..\libyara\modules\macho\macho.c" />
+    <ClCompile Include="..\..\..\libyara\modules\memory\memory.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\authenticode.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\helper.c" />

--- a/windows/vs2019/libyara/libyara.vcxproj
+++ b/windows/vs2019/libyara/libyara.vcxproj
@@ -245,6 +245,7 @@
     <ClCompile Include="..\..\..\libyara\modules\hash\hash.c" />
     <ClCompile Include="..\..\..\libyara\modules\math\math.c" />
     <ClCompile Include="..\..\..\libyara\modules\macho\macho.c" />
+    <ClCompile Include="..\..\..\libyara\modules\memory\memory.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\authenticode.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\helper.c" />


### PR DESCRIPTION
A small YARA module (inspired by https://twitter.com/NinjaParanoid/status/1712743509961380325) that allows rules to query memory protection for live process memory. This allows writing conditions like `for any i in (1..#a) : ( memory.Protection(@a[i]) & memory.EXECUTE == memory.EXECUTE)` for strings that should only match on executable memory.