### PR TITLE
fix: don't scan mapped devices on linux

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -161,7 +161,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
 
   // Only try mapping the file if it has a path and belongs to a device
   if (strlen(proc_info->map_path) > 0 &&
-      !(proc_info->map_dmaj == 0 && proc_info->map_dmin == 0))
+      !(proc_info->map_dmaj == 0 && (proc_info->map_dmin == 0 || proc_info->map_dmin == 5)))
   {
     struct stat st;
     fd = open(proc_info->map_path, O_RDONLY);


### PR DESCRIPTION
On Linux, process scans with YARA hang if the process has mapped devices into its virtual memory (see issue #1929). Blacklist device ID 0,5 which is used by the kernel for files like devices that do not originate from any device themselves. Unfortunately, this behavior seems to be undocumented; the only documentation for device IDs I could find is
https://www.kernel.org/doc/Documentation/admin-guide/devices.txt.