### PR TITLE
fix: check mmap result

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -230,11 +230,17 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
         0);
   }
 
-  if (context->buffer != NULL)
+  if (context->buffer == MAP_FAILED)
+  {
+    context->buffer = NULL;
+    context->buffer_size = 0;
+    goto _exit;
+  }
+  else if (context->buffer != NULL)
   {
     context->buffer_size = block->size;
   }
-  else
+  else // Should according to man page never happen
   {
     context->buffer_size = 0;
     goto _exit;

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -218,8 +218,16 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
         fd,
         proc_info->map_offset);
     close(fd);
+    if (context->buffer == MAP_FAILED)
+    {
+      // Notify the code below that we couldn't read from the file
+      // fallback to pread() from the process
+      fd = -1;
+    }
+    context->buffer_size = block->size;
   }
-  else
+
+  if (fd == -1)
   {
     context->buffer = mmap(
         NULL,
@@ -228,22 +236,13 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
         MAP_PRIVATE | MAP_ANONYMOUS,
         -1,
         0);
-  }
-
-  if (context->buffer == MAP_FAILED)
-  {
-    context->buffer = NULL;
-    context->buffer_size = 0;
-    goto _exit;
-  }
-  else if (context->buffer != NULL)
-  {
+    if (context->buffer == MAP_FAILED)
+    {
+      context->buffer = NULL;
+      context->buffer_size = 0;
+      goto _exit;
+    }
     context->buffer_size = block->size;
-  }
-  else // Should according to man page never happen
-  {
-    context->buffer_size = 0;
-    goto _exit;
   }
 
   // If mapping can't be accessed through the filesystem, read everything from

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -227,7 +227,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
     context->buffer_size = block->size;
   }
 
-  if (fd == -1)
+  if (fd < 0)
   {
     context->buffer = mmap(
         NULL,


### PR DESCRIPTION
Check if mmap failed (return value MAP_FAILED) and, if yes, exit.