### PR TITLE
fix process scanning on linux 32bits without LFS

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -249,7 +249,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
   // target process VM.
   if (fd == -1)
   {
-    if (pread(
+    if (pread64(
             proc_info->mem_fd,
             (void*) context->buffer,
             block->size,
@@ -265,7 +265,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
     {
       goto _exit;
     }
-    if (pread(
+    if (pread64(
             proc_info->pagemap_fd,
             pagemap,
             sizeof(uint64_t) * block->size / page_size,
@@ -284,7 +284,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
       // swap-backed and if it differs from our mapping.
       uint8_t buffer[page_size];
 
-      if (pread(
+      if (pread64(
               proc_info->mem_fd,
               buffer,
               page_size,


### PR DESCRIPTION
The commit dfd6f7b5f brought large file detection in the autoconf file to fix process scanning on linux in x86 architecture. This is however a bit flaky, because:
- process scanning won't work on systems that do not have LFS, which does not make sense (although I don't really know how autoconf detects it or not).
- the fix does not work if the compilation is done without the use of autoconf, and `_FILE_OFFSET_BITS` is not defined. This is for example the case for yara-rust, where the process scanning does not work on linux 32bits for this reason.

This breaks process scanning because without it, the pread function on the mem file will fail if provided with an offset bigger than INT32_MAX, which will always happen for processes.

A better fix is to use the pread64 syscall, which always takes a 64-bits value for the offset. This is the actual linux syscall, so it is completely safe.

See for example the exact same fix on chromium:

https://groups.google.com/a/chromium.org/g/crashpad-dev/c/IJLo8M2AQs0/m/Edyyau2LAwAJ