### PR TITLE
fix: properly check success of pagemap open

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -97,7 +97,7 @@ int _yr_process_attach(int pid, YR_PROC_ITERATOR_CTX* context)
   snprintf(buffer, sizeof(buffer), "/proc/%u/pagemap", pid);
   proc_info->pagemap_fd = open(buffer, O_RDONLY);
 
-  if (proc_info->mem_fd == -1)
+  if (proc_info->pagemap_fd == -1)
     goto err;
 
   context->proc_info = proc_info;


### PR DESCRIPTION
The pagemap_fd value was not checked, probably a bad copy-paste from the mem_fd open just above it.