### PR TITLE
semaphore_destroy: use sem_destroy on POSIX

### DIFF
--- a/cli/threading.c
+++ b/cli/threading.c
@@ -111,7 +111,7 @@ void cli_semaphore_destroy(SEMAPHORE* semaphore)
 #elif defined(__APPLE__)
   semaphore_destroy(mach_task_self(), *semaphore);
 #else
-  sem_close(*semaphore);
+  sem_destroy(*semaphore);
   free(*semaphore);
 #endif
 }


### PR DESCRIPTION
per POSIX semaphore, sem_init should be paired with sem_destroy (unnamed semaphore), sem_close should be paired with sem_open (named one).

While glibc seems forgiving about this, this will cause hangs or segfaults with musl (for example, #1887).