### PR TITLE
Fix segfault in math module when scanning a process that dies during scan

### DIFF
--- a/docs/writingmodules.rst
+++ b/docs/writingmodules.rst
@@ -657,11 +657,14 @@ checks in your code nevertheless). In those cases you can use the
         const uint8_t* block_data;
 
         block = first_memory_block(context);
-        block_data = block->fetch_data(block)
-
-        if (block_data != NULL)
+        if (block != NULL)
         {
-          ..do something with the memory block
+          block_data = block->fetch_data(block)
+
+          if (block_data != NULL)
+          {
+            ..do something with the memory block
+          }
         }
     }
 

--- a/libyara/modules/magic/magic.c
+++ b/libyara/modules/magic/magic.c
@@ -101,6 +101,10 @@ define_function(magic_mime_type)
   if (cache->cached_mime_type == NULL)
   {
     block = first_memory_block(context);
+
+    if (block == NULL)
+      return_string(YR_UNDEFINED);
+
     block_data = block->fetch_data(block);
 
     if (block_data != NULL)
@@ -134,6 +138,10 @@ define_function(magic_type)
   if (cache->cached_type == NULL)
   {
     block = first_memory_block(context);
+
+    if (block == NULL)
+      return_string(YR_UNDEFINED);
+
     block_data = block->fetch_data(block);
 
     if (block_data != NULL)

--- a/libyara/modules/math/math.c
+++ b/libyara/modules/math/math.c
@@ -64,7 +64,7 @@ uint32_t* get_distribution(int64_t offset, int64_t length, YR_SCAN_CONTEXT* cont
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
-  if (offset < 0 || length < 0 || offset < block->base)
+  if (block == NULL || offset < 0 || length < 0 || offset < block->base)
   {
     yr_free(data);
     return NULL;
@@ -132,9 +132,8 @@ uint32_t* get_distribution_global(YR_SCAN_CONTEXT* context) {
   if (data == NULL)
     return NULL;
 
-  YR_MEMORY_BLOCK* block = first_memory_block(context);
+  YR_MEMORY_BLOCK* block;
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
-
   foreach_memory_block(iterator, block)
   {
     if (expected_next_offset != block->base)
@@ -323,6 +322,9 @@ define_function(data_serial_correlation)
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
 
+  if (block == NULL)
+    return_float(YR_UNDEFINED);
+
   double sccun = 0;
   double sccfirst = 0;
   double scclast = 0;
@@ -449,6 +451,9 @@ define_function(data_monte_carlo_pi)
   YR_SCAN_CONTEXT* context = yr_scan_context();
   YR_MEMORY_BLOCK* block = first_memory_block(context);
   YR_MEMORY_BLOCK_ITERATOR* iterator = context->iterator;
+
+  if (block == NULL)
+    return_float(YR_UNDEFINED);
 
   if (offset < 0 || length < 0 || offset < block->base)
     return_float(YR_UNDEFINED);


### PR DESCRIPTION
The math module retrieves the first block of memory to do some validation on parameters. However, contrary to for example the hash module, the block value is not checked. This can lead, if for example scanning a process and having the process die during the scan, to a SIGSEGV/Null access violation, as the first block call will return NULL.

This bug manifests in surprising ways. Since yara runs by default evaluation of condition in a try catch block, this bug is actually caught by the try catch block, and a surprising "ERROR_COULD_NOT_MAP_FILE" error is then returned.

In addition, since the try catch bypasses the whole stack, this leads to a memory leak that can add up as more instances of this bug is triggered.

In addition, the magic module is also fixed (although it should not really trigger since the process memory flag is checked beforehand), and the doc is updated.