### PR TITLE
Fix Validation error for rule_modifier in grammar.y

### DIFF
--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -468,14 +468,21 @@ condition
 
 rule_modifiers
     : /* empty */                      { $$ = 0;  }
-    | rule_modifiers rule_modifier     { $$ = $1 | $2; }
+    | rule_modifier_global rule_modifier_private     { $$ = $1 | $2; }
+    | rule_modifier_private rule_modifier_global     { $$ = $1 | $2; }
     ;
 
 
-rule_modifier
-    : _PRIVATE_      { $$ = RULE_FLAGS_PRIVATE; }
+rule_modifier_global
+    : /*empty */      
     | _GLOBAL_       { $$ = RULE_FLAGS_GLOBAL; }
     ;
+
+
+rule_modifier_private
+    : /*empty */      
+    | _PRIVATE_       { $$ = RULE_FLAGS_PRIVATE; }
+    ;     
 
 
 tags

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -474,13 +474,13 @@ rule_modifiers
 
 
 rule_modifier_global
-    : /*empty */      
+    : /*empty */                       { $$ = 0;  }
     | _GLOBAL_       { $$ = RULE_FLAGS_GLOBAL; }
     ;
 
 
 rule_modifier_private
-    : /*empty */      
+    : /*empty */                       { $$ = 0;  }
     | _PRIVATE_       { $$ = RULE_FLAGS_PRIVATE; }
     ;     
 


### PR DESCRIPTION
Prevent user from using the rule modifiers 'global' and 'private' more than once while also allowing to use them together in any order.