### PR TITLE
feat: handle SIGBUS / SIGSEGV only when originating from YARA's memory blocks

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -131,7 +131,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           offset <= block->base + block->size - sizeof(type))     \
       {                                                           \
         type result;                                              \
-        const uint8_t* data = block->fetch_data(block);           \
+        const uint8_t* data = yr_fetch_block_data(block);         \
         if (data == NULL)                                         \
           return YR_UNDEFINED;                                    \
         result = *(type*) (data + offset - block->base);          \

--- a/libyara/include/yara/globals.h
+++ b/libyara/include/yara/globals.h
@@ -48,6 +48,13 @@ extern YR_THREAD_STORAGE_KEY yr_yyfatal_trampoline_tls;
 // Thread-local storage (TLS) key used by YR_TRYCATCH.
 extern YR_THREAD_STORAGE_KEY yr_trycatch_trampoline_tls;
 
+#if !(_WIN32 || __CYGWIN__)
+extern struct sigaction old_sigsegv_exception_handler;
+extern struct sigaction old_sigbus_exception_handler;
+extern int exception_handler_usecount;
+extern pthread_mutex_t exception_handler_mutex;
+#endif
+
 // When YARA is built with YR_DEBUG_VERBOSITY defined as larger than 0 it can
 // print debug information to stdout.
 #if 0 == YR_DEBUG_VERBOSITY

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -706,6 +706,8 @@ struct YR_MEMORY_BLOCK
   YR_MEMORY_BLOCK_FETCH_DATA_FUNC fetch_data;
 };
 
+YR_API const uint8_t* yr_fetch_block_data(YR_MEMORY_BLOCK* self);
+
 ///////////////////////////////////////////////////////////////////////////////
 // YR_MEMORY_BLOCK_ITERATOR represents an iterator that returns a series of
 // memory blocks to be scanned by yr_scanner_scan_mem_blocks. The iterator have

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -52,6 +52,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 YR_THREAD_STORAGE_KEY yr_yyfatal_trampoline_tls;
 YR_THREAD_STORAGE_KEY yr_trycatch_trampoline_tls;
 
+#if !(_WIN32 || __CYGWIN__)
+
+#include <pthread.h>
+#include <signal.h>
+
+struct sigaction old_sigsegv_exception_handler;
+struct sigaction old_sigbus_exception_handler;
+int exception_handler_usecount = 0;
+pthread_mutex_t exception_handler_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
 static int init_count = 0;
 
 static struct yr_config_var

--- a/libyara/modules/dex/dex.c
+++ b/libyara/modules/dex/dex.c
@@ -1514,7 +1514,7 @@ int module_load(
 
   foreach_memory_block(iterator, block)
   {
-    const uint8_t* block_data = block->fetch_data(block);
+    const uint8_t* block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL)
       continue;

--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -3515,7 +3515,7 @@ int module_load(
   {
     PIMAGE_NT_HEADERS32 pe_header;
 
-    block_data = block->fetch_data(block);
+    block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL)
       continue;

--- a/libyara/modules/elf/elf.c
+++ b/libyara/modules/elf/elf.c
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/simple_str.h>
 #include <yara/utils.h>
 #include "../crypto.h"
+#include "../exception.h"
 
 #define MODULE_NAME elf
 
@@ -1113,7 +1114,7 @@ int module_load(
 
   foreach_memory_block(iterator, block)
   {
-    const uint8_t* block_data = block->fetch_data(block);
+    const uint8_t* block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL)
       continue;

--- a/libyara/modules/hash/hash.c
+++ b/libyara/modules/hash/hash.c
@@ -326,7 +326,7 @@ define_function(data_md5)
 
     if (offset >= block->base && offset < block->base + block->size)
     {
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {
@@ -456,7 +456,7 @@ define_function(data_sha1)
     // if desired block within current block
     if (offset >= block->base && offset < block->base + block->size)
     {
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {
@@ -585,7 +585,7 @@ define_function(data_sha256)
     // if desired block within current block
     if (offset >= block->base && offset < block->base + block->size)
     {
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {
@@ -674,7 +674,7 @@ define_function(data_checksum32)
   {
     if (offset >= block->base && offset < block->base + block->size)
     {
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {
@@ -765,7 +765,7 @@ define_function(data_crc32)
   {
     if (offset >= block->base && offset < block->base + block->size)
     {
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {

--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -1363,7 +1363,7 @@ int module_load(
 
   foreach_memory_block(iterator, block)
   {
-    const uint8_t* block_data = block->fetch_data(block);
+    const uint8_t* block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL || block->size < 4)
       continue;

--- a/libyara/modules/magic/magic.c
+++ b/libyara/modules/magic/magic.c
@@ -105,7 +105,7 @@ define_function(magic_mime_type)
     if (block == NULL)
       return_string(YR_UNDEFINED);
 
-    block_data = block->fetch_data(block);
+    block_data = yr_fetch_block_data(block);
 
     if (block_data != NULL)
     {
@@ -142,7 +142,7 @@ define_function(magic_type)
     if (block == NULL)
       return_string(YR_UNDEFINED);
 
-    block_data = block->fetch_data(block);
+    block_data = yr_fetch_block_data(block);
 
     if (block_data != NULL)
     {

--- a/libyara/modules/math/math.c
+++ b/libyara/modules/math/math.c
@@ -78,7 +78,7 @@ uint32_t* get_distribution(int64_t offset, int64_t length, YR_SCAN_CONTEXT* cont
       size_t data_len = (size_t) yr_min(
           length, (size_t)(block->size - data_offset));
 
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data == NULL)
       {
@@ -145,7 +145,7 @@ uint32_t* get_distribution_global(YR_SCAN_CONTEXT* context) {
       yr_free(data);
       return NULL;
     }
-    const uint8_t* block_data = block->fetch_data(block);
+    const uint8_t* block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL)
     {
@@ -344,7 +344,7 @@ define_function(data_serial_correlation)
       size_t data_len = (size_t) yr_min(
           length, (size_t)(block->size - data_offset));
 
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data == NULL)
         return_float(YR_UNDEFINED);
@@ -468,7 +468,7 @@ define_function(data_monte_carlo_pi)
       size_t data_len = (size_t) yr_min(
           length, (size_t)(block->size - data_offset));
 
-      const uint8_t* block_data = block->fetch_data(block);
+      const uint8_t* block_data = yr_fetch_block_data(block);
 
       if (block_data == NULL)
         return_float(YR_UNDEFINED);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -4317,7 +4317,7 @@ int module_load(
 
   foreach_memory_block(iterator, block)
   {
-    block_data = block->fetch_data(block);
+    block_data = yr_fetch_block_data(block);
 
     if (block_data == NULL)
       continue;

--- a/tests/test-exception.c
+++ b/tests/test-exception.c
@@ -87,7 +87,7 @@ void setup_rules()
   yr_initialize();
 
   compile_rule(
-      "rule test { strings: $a = \"aaaa\" condition: all of them }", &rules_a);
+      "import \"console\"\nrule test { strings: $a = \"aaaa\" condition: console.log(0) and all of them }", &rules_a);
 
   compile_rule(
       "rule test { strings: $a = { 00 00 00 00 } condition: all of them }",
@@ -113,7 +113,7 @@ void setup_crasher()
   pthread_create(&t, &attr, &crasher_func, NULL);
 }
 
-/* Simple yr_scan_* callback function that delays execution by 2 seconds */
+/* Simple yr_scan_* callback function that delays execution in CONSOLE_LOG by 2 seconds */
 int delay_callback(
     YR_SCAN_CONTEXT* context,
     int message,
@@ -124,8 +124,12 @@ int delay_callback(
   {
     (*(int*) user_data)++;
   }
-  fputs("callback: delaying execution...\n", stderr);
-  sleep(2);
+  if (message == CALLBACK_MSG_CONSOLE_LOG)
+  {
+    fputs("callback: delaying execution...\n", stderr);
+    sleep(2);
+    fputs("callback: finished delaying execution.\n", stderr);
+  }
   return CALLBACK_CONTINUE;
 }
 


### PR DESCRIPTION
YARA currently registers its own signal handler unless instructed otherwise with `SCAN_FLAGS_NO_TRYCATCH`. This is dangerous for several reasons:
- The current implementation is racy; when multiple threads scan simultaneously, the original signal handler may never be restored.
- If the calling application is multithreaded, and one thread scans with YARA while a signal occurs in another thread, then that signal is ignored by the current signal handler.
- If a callback from YARA causes a segmentation fault, YARA assumes this to be due to the data, potentially causing havoc if the caller (which may be unaware of YARA's signal handler) expects its own signal handler to be called.

This PR tries to improve this situation by adding several safety mechanisms when handling signals:
 - Creating a signal handler in the (racy) POSIX way is now secured with a mutex
 - Signals are only handled if the fault address lies within the currently inspected memory block
 - Unhandled signals are forwarded to the signal handler that was installed before YARA (analogous to the Windows implementation, which uses EXCEPTION_CONTINUE_SEARCH)