### PR TITLE
fix issues with modules fetch of memory blocks in some situations

### DIFF
--- a/libyara/modules/hash/hash.c
+++ b/libyara/modules/hash/hash.c
@@ -361,7 +361,7 @@ define_function(data_md5)
       return_string(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -490,7 +490,7 @@ define_function(data_sha1)
       return_string(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -618,7 +618,7 @@ define_function(data_sha256)
       return_string(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -703,7 +703,7 @@ define_function(data_checksum32)
       return_integer(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -796,7 +796,7 @@ define_function(data_crc32)
       return_integer(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 

--- a/libyara/modules/math/math.c
+++ b/libyara/modules/math/math.c
@@ -112,7 +112,7 @@ uint32_t* get_distribution(
       return NULL;
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -384,7 +384,7 @@ define_function(data_serial_correlation)
       return_float(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 
@@ -519,7 +519,7 @@ define_function(data_monte_carlo_pi)
       return_float(YR_UNDEFINED);
     }
 
-    if (block->base + block->size > offset + length)
+    if (block->base + block->size >= offset + length)
       break;
   }
 


### PR DESCRIPTION
Some modules functions (from hash and math) can access multiple memory blocks, as long as those are contiguous. For example, when hashing between offsets 0..1000, blocks that cover this range will be fetched.

This logic however is a bit buggy on the boundary: if the fetched range ends exactly at the end of a block, the iteration keeps going instead of ending. This can result in two situations:

- The next block is contiguous: it is then fetched.
  - if the fetch fails, the function fails (and return undefined)
  - if the fetch succeeds, we read 0 bytes from it and end the iteration, so a useless fetch was done.
- The next block is not contiguous: the function fails (and return undefined).

This is fixed by modifying the condition to detect if there are still more bytes to fetch.