### PR TITLE
modules/pe: make resources sanity check stricter

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -450,15 +450,18 @@ static int _pe_iterate_resources(
 
   // A few sanity checks to avoid corrupt files
 
+  WORD NumberOfNamedEntries = yr_le16toh(resource_dir->NumberOfNamedEntries);
+  WORD NumberOfIdEntries = yr_le16toh(resource_dir->NumberOfIdEntries);
+
   if (yr_le32toh(resource_dir->Characteristics) != 0 ||
-      yr_le16toh(resource_dir->NumberOfNamedEntries) > 32768 ||
-      yr_le16toh(resource_dir->NumberOfIdEntries) > 32768)
+      NumberOfNamedEntries >= 0x8000 ||
+      NumberOfIdEntries >= 0x8000 ||
+      (NumberOfNamedEntries + NumberOfIdEntries) >= 0x8000)
   {
     return result;
   }
 
-  total_entries = yr_le16toh(resource_dir->NumberOfNamedEntries) +
-                  yr_le16toh(resource_dir->NumberOfIdEntries);
+  total_entries = NumberOfNamedEntries + NumberOfIdEntries;
 
   // The first directory entry is just after the resource directory,
   // by incrementing resource_dir we skip sizeof(resource_dir) bytes


### PR DESCRIPTION
Make number-based PE resources sanity checks a bit stricter to avoid more potentially corrupt files.

We came across [this](https://www.virustotal.com/gui/file/ef866e5eeacd096c4dab73c6d2b098253ba46f1ecf45467e6d65a8e1a75b4ca9) sample, whose `NumberOfNamedEntries` and `NumberOfIdEntries` resource entries would pass the resource-numbers-based PE parsing sanity checks, but its resources are corrupt. Resource parsing for the sample in question is still skipped thanks to `yr_le32toh(resource_dir->Characteristics) != 0` part of the condition, but if it were not there, it would pass and run into trouble.

The "solution" is not ideal, it only makes the existing conditions a bit stricter, but it should not really have any downside.

cc @metthal @ladislav-zezula 