### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -487,7 +487,7 @@ Reference
 
 .. py:class:: StringMatch
 
-  .. versionadded:: 3.4.0
+  .. versionadded:: 4.3.0
 
   Objects which represent string matches.
 


### PR DESCRIPTION
Fixes a typo in the docs regarding when stringmatch objects were introduced