### PR TITLE
countersignature: remove TS_VERIFY_CTX_init() call

### DIFF
--- a/libyara/modules/pe/authenticode-parser/countersignature.c
+++ b/libyara/modules/pe/authenticode-parser/countersignature.c
@@ -357,7 +357,6 @@ int IMPL_FUNC_NAME(verify_digest, pkcs7)(
 
     X509_STORE* store = X509_STORE_new();
     TS_VERIFY_CTX* ctx = TS_VERIFY_CTX_new();
-    TS_VERIFY_CTX_init(ctx);
 
     TS_VERIFY_CTX_set_flags(ctx, TS_VFY_VERSION | TS_VFY_IMPRINT);
     TS_VERIFY_CTX_set_store(ctx, store);


### PR DESCRIPTION
This is redundant and already handled by `TS_VERIFY_CTX_new()`. Additionally it causes build failures with LibreSSL `>= 3.8.0` which removed this function since it serves no purpose with opaque `TS_VERIFY_CTX` where it will zero out an already zero'd out `ctx` or cause a leak.

See: https://github.com/libressl/portable/issues/1006