### PR TITLE
linux.c: don't use pread64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,7 +145,7 @@ AC_ARG_ENABLE([profiling],
 AC_ARG_WITH([debug-verbose],
   [AS_HELP_STRING([--with-debug-verbose=[[NUM]]], [Turn on runtime debugging information])],
   [if test $withval -gt 0; then
-    AC_DEFINE_UNQUOTED([YR_DEBUG_VERBOSITY], [$withval])
+    AC_DEFINE_UNQUOTED([YR_DEBUG_VERBOSITY], [$withval], [Define for verbose debugging output])
    else
     AC_MSG_ERROR([debug verbosity must be greater than 0])
   fi])
@@ -379,8 +379,8 @@ AM_CONDITIONAL([USE_OPENBSD_PROC], [test x$proc_interface = xopenbsd ])
 AM_CONDITIONAL([USE_MACH_PROC], [test x$proc_interface = xmach ])
 AM_CONDITIONAL([USE_NO_PROC], [test x$proc_interface = xnone ])
 AS_IF(
-  [test x$proc_interface != xnone],[AC_DEFINE([HAVE_SCAN_PROC_IMPL],[1])],
-  [test x$proc_interface = xnone],[AC_DEFINE([HAVE_SCAN_PROC_IMPL],[0])])
+  [test x$proc_interface != xnone],[AC_DEFINE([HAVE_SCAN_PROC_IMPL],[1],[Define for proc-scan])],
+  [test x$proc_interface = xnone],[AC_DEFINE([HAVE_SCAN_PROC_IMPL],[0],[Define for proc-scan])])
 
 # Configure TLSH function
 CFLAGS="$CFLAGS -DBUCKETS_128=1 -DCHECKSUM_1B=1"

--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -46,6 +46,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara/proc.h>
 #include <yara/strutils.h>
 
+#define _FILE_OFFSET_BITS 64
+
 typedef struct _YR_PROC_INFO
 {
   int pid;
@@ -249,7 +251,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
   // target process VM.
   if (fd == -1)
   {
-    if (pread64(
+    if (pread(
             proc_info->mem_fd,
             (void*) context->buffer,
             block->size,
@@ -265,7 +267,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
     {
       goto _exit;
     }
-    if (pread64(
+    if (pread(
             proc_info->pagemap_fd,
             pagemap,
             sizeof(uint64_t) * block->size / page_size,
@@ -284,7 +286,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
       // swap-backed and if it differs from our mapping.
       uint8_t buffer[page_size];
 
-      if (pread64(
+      if (pread(
               proc_info->mem_fd,
               buffer,
               page_size,


### PR DESCRIPTION
Starting with `musl-1.2.4` all LFS64 APIs have been removed since musl is always 64-bit and yara now fails with implicit function declarations for `pread64`.

However `configure.ac` already sets `AC_SYS_LARGEFILE` so changing them all to `pread` will work with both glibc and musl.