### PR TITLE
Updated authenticode parser to latest version (2024-03-02)

### DIFF
--- a/libyara/include/authenticode-parser/authenticode.h
+++ b/libyara/include/authenticode-parser/authenticode.h
@@ -124,6 +124,8 @@ typedef struct {
     char* digest_alg;        /* Name of the digest algorithm used */
     ByteArray digest;        /* Stored message digest */
     CertificateArray* chain; /* Certificate chain of the signer */
+    CertificateArray* certs; /* All certs stored inside Countersignature, this can be superset
+                                of chain in case of non PKCS9 countersignature*/
 } Countersignature;
 
 typedef struct {

--- a/libyara/modules/pe/authenticode-parser/authenticode.c
+++ b/libyara/modules/pe/authenticode-parser/authenticode.c
@@ -114,23 +114,6 @@ static char* parse_program_name(ASN1_TYPE* spcAttr)
     return result;
 }
 
-/* Parses X509* certs into internal representation and inserts into CertificateArray
- * Array is assumed to have enough space to hold all certificates storted in the STACK */
-static void parse_certificates(const STACK_OF(X509) * certs, CertificateArray* result)
-{
-    int certCount = sk_X509_num(certs);
-    int i = 0;
-    for (; i < certCount; ++i) {
-        Certificate* cert = certificate_new(sk_X509_value(certs, i));
-        if (!cert)
-            break;
-
-        /* Write to the result */
-        result->certs[i] = cert;
-    }
-    result->count = i;
-}
-
 static void parse_nested_authenticode(PKCS7_SIGNER_INFO* si, AuthenticodeArray* result)
 {
     STACK_OF(X509_ATTRIBUTE)* attrs = PKCS7_get_attributes(si);
@@ -190,32 +173,6 @@ static void parse_pkcs9_countersig(PKCS7* p7, Authenticode* auth)
     }
 }
 
-/* Extracts X509 certificates from MS countersignature and stores them into result */
-static void extract_ms_counter_certs(const uint8_t* data, int len, CertificateArray* result)
-{
-    PKCS7* p7 = d2i_PKCS7(NULL, &data, len);
-    if (!p7)
-        return;
-
-    /* We expect SignedData type of PKCS7 */
-    if (!PKCS7_type_is_signed(p7) || !p7->d.sign) {
-        PKCS7_free(p7);
-        return;
-    }
-
-    STACK_OF(X509)* certs = p7->d.sign->cert;
-    CertificateArray* certArr = certificate_array_new(sk_X509_num(certs));
-    if (!certArr) {
-        PKCS7_free(p7);
-        return;
-    }
-    parse_certificates(certs, certArr);
-    certificate_array_move(result, certArr);
-    certificate_array_free(certArr);
-
-    PKCS7_free(p7);
-}
-
 static void parse_ms_countersig(PKCS7* p7, Authenticode* auth)
 {
     PKCS7_SIGNER_INFO* si = sk_PKCS7_SIGNER_INFO_value(PKCS7_get_signer_info(p7), 0);
@@ -239,14 +196,14 @@ static void parse_ms_countersig(PKCS7* p7, Authenticode* auth)
         int len = nested->value.sequence->length;
         const uint8_t* data = nested->value.sequence->data;
 
-        Countersignature* sig = ms_countersig_new(data, len, si->enc_digest);
-        if (!sig)
+        Countersignature* csig = ms_countersig_new(data, len, si->enc_digest);
+        if (!csig)
             return;
 
+        countersignature_array_insert(auth->countersigs, csig);
         /* Because MS TimeStamp countersignature has it's own SET of certificates
          * extract it back into parent signature for consistency with PKCS9 */
-        countersignature_array_insert(auth->countersigs, sig);
-        extract_ms_counter_certs(data, len, auth->certs);
+        certificate_array_append(auth->certs, csig->certs);
     }
 }
 
@@ -344,7 +301,7 @@ AuthenticodeArray* authenticode_new(const uint8_t* data, int32_t len)
         auth->verify_flags = AUTHENTICODE_VFY_INTERNAL_ERROR;
         goto end;
     }
-    parse_certificates(certs, auth->certs);
+    parse_x509_certificates(certs, auth->certs);
 
     /* Get Signature content that contains the message digest and it's algorithm */
     SpcIndirectDataContent* dataContent = get_content(p7data->contents);

--- a/libyara/modules/pe/authenticode-parser/certificate.h
+++ b/libyara/modules/pe/authenticode-parser/certificate.h
@@ -31,10 +31,14 @@ extern "C" {
 #endif
 
 Certificate* certificate_new(X509* x509);
+Certificate* certificate_copy(Certificate* cert);
 void certificate_free(Certificate* cert);
+
+void parse_x509_certificates(const STACK_OF(X509) * certs, CertificateArray* result);
 
 CertificateArray* parse_signer_chain(X509* signer_cert, STACK_OF(X509) * certs);
 int certificate_array_move(CertificateArray* dst, CertificateArray* src);
+int certificate_array_append(CertificateArray* dst, CertificateArray* src);
 CertificateArray* certificate_array_new(int certCount);
 void certificate_array_free(CertificateArray* arr);
 

--- a/libyara/modules/pe/authenticode-parser/countersignature.c
+++ b/libyara/modules/pe/authenticode-parser/countersignature.c
@@ -456,6 +456,9 @@ CountersignatureImpl* ms_countersig_impl_new(const uint8_t* data, long size)
         result->funcs = &FUNC_ARRAY_NAME_FOR_IMPL(pkcs7);
         result->pkcs7 = p7;
         return result;
+    } else if (p7) {
+        PKCS7_free(p7);
+        return NULL;
     }
 
     d = data;
@@ -526,6 +529,16 @@ Countersignature* ms_countersig_new(const uint8_t* data, long size, ASN1_STRING*
     }
 
     STACK_OF(X509)* certs = impl->funcs->get_certs(impl);
+
+    /* MS Counter signatures (PKCS7/CMS) can have extra certificates that are not part of a chain */
+    result->certs = certificate_array_new(sk_X509_num(certs));
+    if (!result->certs) {
+        result->verify_flags = AUTHENTICODE_VFY_INTERNAL_ERROR;
+        goto end;
+    }
+
+    parse_x509_certificates(certs, result->certs);
+
     result->chain = parse_signer_chain(signCert, certs);
 
     /* Imprint == digest */
@@ -641,6 +654,7 @@ void countersignature_free(Countersignature* sig)
         free(sig->digest_alg);
         free(sig->digest.data);
         certificate_array_free(sig->chain);
+        certificate_array_free(sig->certs);
         free(sig);
     }
 }


### PR DESCRIPTION
Upon fixing the latest issue regarding parsing CMS, we figured out we are not properly extracting all certificates from Microsoft countersignatures. This should now properly expose them.

Also fixes one memory leak for countersignature parsing.