### PR TITLE
modules/pe/authenticode: Add Wincrypt API support for authenticode on Windows

### DIFF
--- a/libyara/crypto.h
+++ b/libyara/crypto.h
@@ -86,6 +86,8 @@ typedef EVP_MD_CTX *yr_sha256_ctx;
 
 #include <wincrypt.h>
 
+#define HAVE_CRYPTO_WINCRYPT
+
 extern HCRYPTPROV yr_cryptprov;
 
 typedef HCRYPTHASH yr_md5_ctx;
@@ -143,5 +145,9 @@ typedef CC_SHA256_CTX yr_sha256_ctx;
 #define yr_sha256_final(digest, ctx)     CC_SHA256_Final(digest, ctx)
 
 #endif
+
+#if defined(USE_WINCRYPT_AUTHENTICODE) && !defined(HAVE_CRYPTO_WINCRYPT)
+#error Cannot use wincrypt for authenticode if wincrypt library is not available
+#endif // USE_WINCRYPT_AUTHENTICODE && !HAVE_WINCRYPT_H
 
 #endif

--- a/libyara/include/authenticode-parser/authenticode.h
+++ b/libyara/include/authenticode-parser/authenticode.h
@@ -201,6 +201,10 @@ AuthenticodeArray* authenticode_new(const uint8_t* data, int32_t len);
  */
 void authenticode_array_free(AuthenticodeArray* auth);
 
+/* Moves signatures from src to dst, returns 0 on success,
+ * else 1. If error occurs, arguments are unchanged */
+int authenticode_array_move(AuthenticodeArray* dst, AuthenticodeArray* src);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libyara/include/authenticode-parser/windows/authenticode.h
+++ b/libyara/include/authenticode-parser/windows/authenticode.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_H
+#define YR_AUTHENTICODE_WINDOWS_H
+
+#include <authenticode-parser/authenticode.h>
+
+#include <authenticode-parser/windows/tools.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+
+/// @brief Parses PE certificate directory data to extract signatures from it
+/// @param[in]      data                Certificate directory raw data PKCS7 blob to read signatures from
+/// @param[in]      length              Length of the data in bytes
+/// @param[in, out] authenticode_array  Signatures array read from data. To be freed using authenticode_array_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT parse_authenticode_wincrypt(
+  _In_      CONST   PBYTE               data,
+  _In_      CONST   DWORD               length,
+  _Inout_           AuthenticodeArray*  authenticode_array
+);
+
+/// @brief Computes file digest from the given pe data blob, using the digest algorithm specified in the given signature
+/// @param[in, out] authenticode        Authenticode signature to read digest algorithm from, and to write the computed file digest to
+/// @param[in]      pe_data             PE data blob
+/// @param[in]      pe_length           PE data blob length in bytes
+/// @param[in]      pe_header_offset    Offset to the pe header
+/// @param[in]      is_64bit            Is the PE 64 bits ?
+/// @param[in]      cert_addr           Certificates directory address
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT authenticode_wincrypt_compute_file_digest(
+  _Inout_           Authenticode    *CONST  authenticode,
+  _In_      CONST   PBYTE                   pe_data,
+  _In_      CONST   ULONGLONG               pe_length,
+  _In_      CONST   uint32_t                pe_header_offset,
+  _In_      CONST   BOOL                    is_64bit,
+  _In_      CONST   uint64_t                cert_addr
+);
+
+#endif  // USE_WINCRYPT_AUTHENTICODE
+
+#endif  // !YR_AUTHENTICODE_WINDOWS_H

--- a/libyara/include/authenticode-parser/windows/certificate.h
+++ b/libyara/include/authenticode-parser/windows/certificate.h
@@ -1,0 +1,87 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_CERTIFICATE_H
+#define YR_AUTHENTICODE_WINDOWS_CERTIFICATE_H
+
+#include <authenticode-parser/authenticode.h>
+
+#include <authenticode-parser/windows/tools.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+
+/// @brief Builds a Yara certificates array from the given Microsoft certificates store
+/// @param[in]  cert_store          Certificate from which to extract all certificates
+/// @param[out] certificate_array   Yara certificates array data structure built from the given Microsoft certificates store. To be freed using certificate_array_free
+INT get_all_certificates_authenticode(
+    _In_        CONST   HCERTSTORE                  cert_store,
+    _Outptr_            CertificateArray*   *CONST  certificate_array
+);
+
+/// @brief Take a certificate name blob, which can be an issuer or a subject, and format
+/// it using known OID to match the output given by OpenSSL
+/// @param[in]  cert_name_blob  Certificate name blob which ie. an issuer or a subject
+/// @param[out] Formatted name as PSTR string
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note The straightforward way to obtain the issuer/subject dn would have been to call
+/// @note CertNameToStrA. But some minors differences would appear relatively to the use
+/// @note of OpenSSL. However the objective of this module is always have the  same output
+/// @note regardless of the API used. That is why, despite the heaviness, it is prefered to
+/// @note build our proper string by enumerating all RDN and using a matching strings table.
+INT format_cert_name_blob_using_known_oid(
+    _In_        CONST   CERT_NAME_BLOB*         cert_name_blob,
+    _Outptr_            PSTR            *CONST  formatted_name
+);
+
+/// @brief Parses the cert name blob to extract attributes it finds in it
+/// @param[in]  cert_name_blob  Data blob to parse to extract attributes
+/// @param[out] attributes      Parsed attributes that could be found
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT fill_attributes_using_cert_name_blob(
+    _In_    CONST PCERT_NAME_BLOB           cert_name_blob,
+    _Out_         Attributes        *CONST  attributes
+);
+
+/// @brief Builds certificates chain from a given signer info
+/// @param[in]  cert_store              Certificates store to use to build signer certificates chain
+/// @param[in]  signer_info             Signer info to build certificates chain for
+/// @param[out] certificate_chain_array Resulting built certificates chain
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT build_certificate_chain_from_signer_info(
+    _In_    CONST   HCERTSTORE                  cert_store,
+    _In_    CONST   PCMSG_SIGNER_INFO           signer_info,
+    _Out_           CertificateArray*   *CONST  certificate_chain_array
+);
+
+/// @brief Find the signer certificate from certificates store using signer info issuer and serial number
+/// @param[in]  cert_store      Certificates store from where to look for the signer certificate
+/// @param[in]  signer_info     Signer info to use to look for certificate
+/// @param[out] cert_context    Found certificate, to be freed using CertFreeCertificateContext
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT find_signer_certificate_from_signer_info(
+    _In_      CONST   HCERTSTORE                  cert_store,
+    _In_      CONST   PCMSG_SIGNER_INFO           signer_info,
+    _Outptr_          PCERT_CONTEXT       *CONST  cert_context
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif // !YR_AUTHENTICODE_WINDOWS_CERTIFICATE_H

--- a/libyara/include/authenticode-parser/windows/cleanup.h
+++ b/libyara/include/authenticode-parser/windows/cleanup.h
@@ -1,0 +1,85 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_CLEANUP_H
+#define YR_AUTHENTICODE_WINDOWS_CLEANUP_H
+
+#include <authenticode-parser/windows/tools.h>
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+/// @brief Cleanups a given byte array by freeing its inner data, but not the container itself
+/// @param[in]  byte_array  Byte array to be cleaned up
+VOID cleanup_byte_array(
+    _Inout_ ByteArray   *CONST  byte_array
+);
+
+/// @brief Cleanups a given attributes container by freeing its inner ByteArray data, but not the container itself
+/// @param[in]  attributes  Attributes to be cleaned up
+VOID cleanup_attributes(
+    _Inout_ Attributes  *CONST  attributes
+);
+
+/// @brief Destroys certificate and free container
+/// @parma[in]  certificate Certificate to be destroyed
+VOID destroy_certificate(
+    _In_ _Post_ptr_invalid_ Certificate *CONST  certificate
+);
+
+/// @brief Destroys certificate array and free container
+/// @param[in]  certificate_array   Certificates array to be destroyed
+VOID destroy_certificate_array(
+    _In_ _Post_ptr_invalid_ CertificateArray    *CONST  certificate_array
+);
+
+/// @brief Destroys signer and free container
+/// @param[in]  signer  Signer to be destroyed
+VOID destroy_signer(
+    _In_ _Post_ptr_invalid_ Signer  *CONST signer
+);
+
+/// @brief Destroy countersignature and free container
+/// @param[in]  countersignature    Countersignature to be destroyed
+VOID destroy_countersignature(
+    _In_ _Post_ptr_invalid_ Countersignature    *CONST  countersignature
+);
+
+/// @brief Destroy countersignature array and free container
+/// @param[in]  array   Countersignatures array to be destroyed
+VOID destroy_countersignature_array(
+    _In_ _Post_ptr_invalid_ CountersignatureArray   *CONST  array
+);
+
+/// @brief Destroy authenticode signature and free container
+/// @param[in]  authenticode    Authenticode signature to be destroyed
+VOID destroy_authenticode(
+    _In_ _Post_ptr_invalid_ Authenticode    *CONST  authenticode
+);
+
+/// @brief Destroy authenticode signatures array and free container
+/// @param[in]  array   Array of authenticode signatures to be destroyed
+VOID destroy_authenticode_array(
+    _In_ _Post_ptr_invalid_ AuthenticodeArray   *CONST  array
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif // !YR_AUTHENTICODE_WINDOWS_CLEANUP_H

--- a/libyara/include/authenticode-parser/windows/countersignature.h
+++ b/libyara/include/authenticode-parser/windows/countersignature.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_COUNTERSIGNATURE_H
+#define YR_AUTHENTICODE_WINDOWS_COUNTERSIGNATURE_H
+
+#include <authenticode-parser/windows/tools.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+
+/// @brief Looks into crypt message for countersignature in unauthenticated attributes. Can either be RFC3161 or RSA countersignature
+/// @param[in]      crypt_msg               Crypt message from which to look for countersignatures
+/// @param[in]      cert_store              Signature certificates store
+/// @param[in]      signature_index         Signature identified by its index to use to retrieve unauthenticated attributes
+/// @param[out]     countersignature_array  Countersignatures array into which to insert found countersignatures
+/// @param[in, out] certificate_array       Array of certificates into which to insert newly found certificates in the case of a MS RFC3161 countersignature
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT look_for_counter_signature_authenticode(
+    _In_        CONST   HCRYPTMSG                       crypt_msg,
+    _In_        CONST   HCERTSTORE                      cert_store,
+    _In_        CONST   DWORD                           signature_index,
+    _Outptr_            CountersignatureArray*  *CONST  countersignature_array,
+    _Inout_             CertificateArray        *CONST  certificate_array
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif // !YR_AUTHENTICODE_WINDOWS_COUNTERSIGNATURE_H

--- a/libyara/include/authenticode-parser/windows/extractors.h
+++ b/libyara/include/authenticode-parser/windows/extractors.h
@@ -1,0 +1,123 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_EXTRACTORS_H
+#define YR_AUTHENTICODE_WINDOWS_EXTRACTORS_H
+
+#include <authenticode-parser/authenticode.h>
+
+#include <authenticode-parser/windows/tools.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+/// @brief A function pointer prototype for the extraction and formatting of specific elements
+/// from a CERT_CONTEXT to a yara Certificate data structure
+/// @param[in] certificate_context  A pointer to the CERT_CONTEXT containing the property to extract
+/// @param[in] certificate          The certificate to fill with extracted data
+typedef VOID (*CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC)(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves SHA256 digest from certificate context
+/// @param[in]      certificate_context Certificate context to extract SHA256 digest from
+/// @param[in,out]  certificate         Yara certificate data structure to store computed SHA256 digest into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_sha256_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves SHA1 digest from certificate context
+/// @param[in]      certificate_context Certificate context to extract SHA1 digest from
+/// @param[in,out]  certificate         Yara certificate data structure to store computed SHA1 digest into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_sha1_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves issuer from certificate context, and format it according to OpenSSL format
+/// @param[in]      certificate_context Certificate context to extract issuer from
+/// @param[in,out]  certificate         Yara certificate data structure to store issuer into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_issuer_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves subject from certificate context, and format it according to OpenSSL format
+/// @param[in]      certificate_context Certificate context to extract subject from
+/// @param[in,out]  certificate         Yara certificate data structure to store subject into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_subject_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves version from certificate context
+/// @param[in]      certificate_context Certificate context to extract version from
+/// @param[in,out]  certificate         Yara certificate data structure to store version into
+/// @note Versions are 0 based, but we do not do the one increment in this extractor as it is done later on by Yara write_certificate maccro
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_version_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves signature algorithm from certificate context
+/// @param[in]      certificate_context Certificate context to extract signature algorithm from
+/// @param[in,out]  certificate         Yara certificate data structure to store signature algorithm into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_signature_algorithm_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves serial from certificate context
+/// @param[in]      certificate_context Certificate context to extract serial from
+/// @param[in,out]  certificate         Yara certificate data structure to store serial into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_serial_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves "not before" time from certificate context
+/// @param[in]      certificate_context Certificate context to extract "not before" time from
+/// @param[in,out]  certificate         Yara certificate data structure to store "not before" time into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_not_before_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+/// @brief Retrieves "not after" time from certificate context
+/// @param[in]      certificate_context Certificate context to extract "not after" time from
+/// @param[in,out]  certificate         Yara certificate data structure to store "not after" time into
+/// @see CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC
+VOID retrieve_not_after_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif  // !YR_AUTHENTICODE_WINDOWS_EXTRACTORS_H

--- a/libyara/include/authenticode-parser/windows/oid.h
+++ b/libyara/include/authenticode-parser/windows/oid.h
@@ -1,0 +1,149 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_OID_H
+#define YR_AUTHENTICODE_WINDOWS_OID_H
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+/// @brief Attributes types to be used when looking for a particular attribute
+typedef enum ATTRIBUTE_TYPE
+{
+    ATTRIBUTE_COMMON_NAME,
+    ATTRIBUTE_SURNAME,
+    ATTRIBUTE_SERIAL_NUMBER,
+    ATTRIBUTE_COUNTRY_NAME,
+    ATTRIBUTE_LOCALITY_NAME,
+    ATTRIBUTE_STATE_OR_PROVINCE_NAME,
+    ATTRIBUTE_STREET,
+    ATTRIBUTE_ORGANIZATION_NAME,
+    ATTRIBUTE_ORGANIZATION_UNIT_NAME,
+    ATTRIBUTE_TITLE,
+    ATTRIBUTE_DESCRIPTION,
+    ATTRIBUTE_SEARCH_GUIDE,
+    ATTRIBUTE_BUSINESS_CATEGORY,
+    ATTRIBUTE_POSTAL_ADDRESS,
+    ATTRIBUTE_POSTAL_CODE,
+    ATTRIBUTE_POSTAL_OFFICE_BOX,
+    ATTRIBUTE_PHYSICAL_DELIVERY_OFFICE_NAME,
+    ATTRIBUTE_TELEPHONE_NUMBER,
+    ATTRIBUTE_TELEX_NUMBER,
+    ATTRIBUTE_TELETEX_TERMINAL_IDENTIFIER,
+    ATTRIBUTE_FACSIMILE_TELEPHONE_NUMBER,
+    ATTRIBUTE_X121_ADDRESS,
+    ATTRIBUTE_INTERNATIONAL_ISDN_NUMBER,
+    ATTRIBUTE_REGISTERED_ADDRESS,
+    ATTRIBUTE_DESTINATION_INDICATOR,
+    ATTRIBUTE_PREFERRED_DELIVERY_METHOD,
+    ATTRIBUTE_PRESENTATION_ADDRESS,
+    ATTRIBUTE_SUPPORTED_APPLICATION_CONTEXT,
+    ATTRIBUTE_MEMBER,
+    ATTRIBUTE_OWNER,
+    ATTRIBUTE_ROLE_OCCUPANT,
+    ATTRIBUTE_SEE_ALSO,
+    ATTRIBUTE_USER_PASSWORD,
+    ATTRIBUTE_USER_CERTIFICATE,
+    ATTRIBUTE_CA_CERTIFICATE,
+    ATTRIBUTE_AUTHORITY_REVOCATION_LIST,
+    ATTRIBUTE_CERTIFICATE_REVOCATION_LIST,
+    ATTRIBUTE_CROSS_CERTIFICATE_PAIR,
+    ATTRIBUTE_NAME,
+    ATTRIBUTE_GIVEN_NAME,
+    ATTRIBUTE_INITIALS,
+    ATTRIBUTE_GENERATION_QUALIFIER,
+    ATTRIBUTE_X500_UNIQUE_IDENTIFIER,
+    ATTRIBUTE_DN_QUALIFIER,
+    ATTRIBUTE_ENHANCED_SEARCH_GUIDE,
+    ATTRIBUTE_PROTOCOL_INFORMATION,
+    ATTRIBUTE_DISTINGUISHED_NAME,
+    ATTRIBUTE_UNIQUE_MEMBER,
+    ATTRIBUTE_HOUSE_IDENTIFIER,
+    ATTRIBUTE_SUPPORTED_ALGORITHMS,
+    ATTRIBUTE_DELTA_REVOCATION_LIST,
+    ATTRIBUTE_DMD_NAME,
+    ATTRIBUTE_PSEUDONYM,
+    ATTRIBUTE_ROLE,
+    ATTRIBUTE_ORGANIZATION_IDENTIFIER,
+    ATTRIBUTE_C3,
+    ATTRIBUTE_N3,
+    ATTRIBUTE_DNS_NAME,
+    ATTRIBUTE_JURISDICTION_OF_INCORPORATION_LOCALITY_NAME,
+    ATTRIBUTE_JURISDICTION_OF_INCORPORATION_STATE_OR_PROVINCE_NAME,
+    ATTRIBUTE_JURISDICTION_OF_INCORPORATION_COUNTRY_NAME,
+    ATTRIBUTE_EMAIL_ADDRESS
+} ATTRIBUTE_TYPE;
+
+/// @brief A structure that matches an object ID (numerical reference) to a
+/// human readable name or description, plus some info.
+typedef struct _OID_DATA
+{
+  /// A string representing the OID
+  PCSTR oid;
+
+  /// A string containing the display name
+  PCSTR display_name;
+
+  // Attribute type associated to this OID
+  ATTRIBUTE_TYPE attribute_type;
+} OID_DATA, *POID_DATA;
+typedef CONST OID_DATA* PCOID_DATA;
+
+/// @brief Gets the display name for an algorithm designated by its OID, according to the ISO classification.
+/// @param[in] algo_oid A pointer to a ANSI string representing the algorithm OID
+/// @return A pointer to a string containing the display name on success. It must be freed using yr_free
+/// @return NULL otherwise.
+PCSTR get_algorithmname_from_oid(
+  _In_  PCSTR algo_oid
+);
+
+/// @brief Gets data for an oid designated by its OID, according to the ISO
+/// classification.
+/// @param[in] attr_name_oid A pointer to a ANSI string representing the
+/// attribute OID
+/// @return A pointer to an OID_DATA element
+/// @return NULL otherwise.
+/// @note The caller MUST NOT release the returned data as it is a pointer to
+/// a static element.
+PCOID_DATA find_oid_attribute_data(
+  _In_  PCSTR attr_name_oid
+);
+
+/// @brief Finds the wincrypt digest algorithm constant for a given OpenSSL digest algorithm name
+/// @param[in]  algorithm_name  Name of the algorithm to look constant for
+/// @param[out] algorithm_id    Set to the constant of the algorithm if is_found is set to TRUE by this function
+/// @param[out] is_found        TRUE if the digest algorithm is found, FALSE otherwise
+/// @return Algorithm name if found, NULL otherwise
+PCWSTR find_algorithm_from_algorithm_name(
+    _In_    CONST   PCSTR   algorithm_name
+);
+
+/// @brief Finds the bcrypt algorithm constant from the given algorithm oid
+/// @param[in]  algorithm_oid       Algorithm oid to look algorithm bcrypt constant for
+/// @param[out] bcrypt_algorithm    BCrypt algorithm matching the algorithm oid
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT find_bcrypt_algorithm_from_oid(
+    _In_    PCSTR           algorithm_oid,
+    _Out_   PCWSTR  *CONST  bcrypt_algorithm
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif // !YR_AUTHENTICODE_WINDOWS_OID_H

--- a/libyara/include/authenticode-parser/windows/signer.h
+++ b/libyara/include/authenticode-parser/windows/signer.h
@@ -1,0 +1,82 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_SIGNER_H
+#define YR_AUTHENTICODE_WINDOWS_SIGNER_H
+
+#include <authenticode-parser/windows/tools.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/authenticode.h>
+
+/// @brief Parses a signer info into a Yara Signer data structure
+/// @param[in]  signer_info     Signature signer info
+/// @param[in]  cert_store      Cert store for the given signature
+/// @param[out] signer          Resulting allocated signer data structure, to be freed using Yara's signer_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT parse_signer_authenticode(
+    _In_        CONST   PCMSG_SIGNER_INFO           signer_info,
+    _In_        CONST   HCERTSTORE                  cert_store,
+    _Outptr_            Signer*             *CONST  signer
+);
+
+/// @brief Retrieves signer info from the given crypt message
+/// @param[in]  crypt_msg       Crypt message from which to retrieve the signer info
+/// @param[in]  signature_index Signature for which to retrieve the signer info
+/// @param[out] signer_info     Signer info obtained from crypt message. To be freed using yr_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_signer_info_from_crypt_message(
+    _In_        CONST   HCRYPTMSG           crypt_msg,
+    _In_        CONST   DWORD               signature_index,
+    _Outptr_            PCMSG_SIGNER_INFO*  signer_info
+);
+
+/// @brief Retrieves unauthenticated attributes of signer from the given crypt message
+/// @param[in]  crypt_msg           Crypt message from which to retrieve the signer unauthenticated attributes
+/// @param[in]  signature_index     Signature for which to retrieve the signer unauthenticated attributes
+/// @param[out] crypt_attributes    Unauthenticated attributes obtained from crypt message for signer. To be freed using yr_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_unauthenticated_attributes_from_crypt_message(
+    _In_        CONST   HCRYPTMSG           crypt_msg,
+    _In_        CONST   DWORD               signature_index,
+    _Outptr_            PCRYPT_ATTRIBUTES*  crypt_attributes
+);
+
+/// @brief Verifies signature's signer info using WinVerifyTrust
+/// @param[in]  cert_store      Certificate store to use to verify signer info
+/// @param[in]  signer_info     Signer info to verify
+/// @param[in]  digest          Digest of the data being signed
+/// @param[in]  digest_length   Length of the digest of the data being signed
+/// @param[out] is_verified     Stores the verification result
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note Digest is digest of the signed attributes DER representation or encapContentInfo eContent as specified at https://datatracker.ietf.org/doc/html/rfc5652#section-5.4
+INT verify_signature_from_signer_info(
+  _In_  CONST   HCERTSTORE          cert_store,
+  _In_  CONST   PCMSG_SIGNER_INFO   signer_info,
+  _In_  CONST   PBYTE               digest,
+  _In_  CONST   DWORD               digest_length,
+  _Out_         PBOOL               is_verified
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif // !YR_AUTHENTICODE_WINDOWS_SIGNER_H

--- a/libyara/include/authenticode-parser/windows/tools.h
+++ b/libyara/include/authenticode-parser/windows/tools.h
@@ -1,0 +1,194 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef YR_AUTHENTICODE_WINDOWS_TOOLS_H
+#define YR_AUTHENTICODE_WINDOWS_TOOLS_H
+
+#include <authenticode-parser/authenticode.h>
+
+#if USE_WINCRYPT_AUTHENTICODE
+
+#include <windows.h>
+// Needed for LPWIN_CERTIFICATE/WIN_CERT_TYPE_PKCS_SIGNED_DATA/WIN_CERT_REVISION_2_0
+#include <WinTrust.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <winnt.h>
+
+#define PE_WINCRYPT_TOOLS_NO_SEPARATOR_CHAR             0
+
+/// @brief Evaluates the Unix timestamp value for the given Windows FILETIME.
+/// @param[in] filetime A pointer to the FILETIME to convert.
+/// @return The timestamp in UNIX representation
+/// @return 0 if an invalid filetime is provided
+uint64_t filetime_to_epoch(
+    _In_ CONST PFILETIME filetime
+);
+
+/// @brief Formats a human-readable string of the binary content of a buffer.
+/// @brief Each byte will be formatted with its hexadecimal representation on 2 characters, 0-padded.
+/// @brief It is possible to select the order of the bytes as well as the separators
+/// @brief between the bytes.
+/// @param[in] in_buffer_size The size in bytes for in_buffer.
+/// @param[in] in_buffer A pointer to the buffer to convert.
+/// @param[out] out_buffer_size Optional, a pointer that receives the size of the
+///                        returned out_buffer
+/// @param[out] out_buffer A pointer that receives a newly allocated buffer fo the formatted string.
+/// @param[in] separator The separator character to insert between bytes.
+///                      PE_WINCRYPT_TOOLS_NO_SEPARATOR_CHAR if no separator is required.
+/// @param[in] reverse in_buffer will be enumerated backwards if true, forward if false.
+/// @return ERROR_SUCCESS on success
+/// @return A Yara error code otherwise
+/// @note the caller is responsible for the clean up of out_buffer using yr_free
+INT buffer_to_hex(
+    _In_    CONST   size_t          in_buffer_size,
+    _In_    CONST   PBYTE           in_buffer,
+    _Out_           size_t  *const  out_buffer_size,
+    _Outptr_        PCSTR   *const  out_buffer,
+    _In_    CONST   CHAR            separator,
+    _In_    CONST   BOOL            reverse
+);
+
+/// @brief Duplicates the given string
+/// @param[in]  source  Source string to be duplicated
+/// @return Duplicated string address. To be freed using yr_free
+PSTR duplicate_string(
+    _In_ PCSTR source
+);
+
+/// @brief Converts an UTF-8 widechar string into a multibytes string
+/// @param[in]  data                Input data blob to be converted
+/// @param[in]  data_length         Length of the data blob to be converted
+/// @param[out] multibyte_string    Resulting converted string. To be freed using yr_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT widechar_utf8_to_multibytes(
+    _In_        CONST   PVOID           data,
+    _In_        CONST   DWORD           data_length,
+    _Outptr_            PSTR    *CONST  multibyte_string
+);
+
+/// @brief Duplicates a given cert rdn attribute into a multibytes string. Converts it if necessary
+/// @param[in]  cert_rdn_attr   Attribute to get
+/// @param[out] value           Extracted value. To be freed using yr_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_string_value_from_cert_rdn_value_blob(
+    _In_        CONST   PCERT_RDN_ATTR          cert_rdn_attr,
+    _Outptr_            PSTR            *CONST  value
+);
+
+/// @brief Looks for digest attribute identified by the specified attribute oid, and check if this is an octet string before copying it to byte array
+/// @param[in]  crypt_attributes    Crypt attributes from where to look for digest attribute
+/// @param[in]  attribute_oid       OID of the digest attribute we're looking for
+/// @param[out] byte_array          Byte array to which copy digest if found
+/// @param[out] is_found            Set to TRUE if the attribute has been found
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_digest_attribute_from_crypt_attributes(
+    _In_    CONST   PCRYPT_ATTRIBUTES           crypt_attributes,
+    _In_            PCSTR                       attribute_oid,
+    _Out_           ByteArray           *CONST  byte_array,
+    _Out_opt_       PBOOL                       is_found
+);
+
+/// @brief Looks for the signing time attribute into an RSA countersignature
+/// @param[in]  crypt_attributes    Crypt attributes from where to look for signing time attribute
+/// @param[out] epoch               Signing time, expressed as unix timestamp
+/// @param[out] is_found            Set to TRUE if signing time attrubute has been found
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_rsa_signing_time_attribute_from_crypt_attributes(
+    _In_    CONST   PCRYPT_ATTRIBUTES   crypt_attributes,
+    _Out_           PULONGLONG          epoch,
+    _Out_opt_       PBOOL               is_found
+);
+
+/// @brief Look for any kind a attribute identified by its OID to be retrieved raw into a byte array
+/// @param[in]  crypt_attributes    Crypt attributes from where to look for attribute
+/// @param[in]  attribute_oid       OID of the attribute to get raw data for
+/// @param[out] byte_array          Byte array into which copy attribute raw data if found
+/// @param[out] is_found            Set to TRUE if the attribute we were looking for has been found
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT get_attribute_from_crypt_attributes(
+    _In_    CONST   PCRYPT_ATTRIBUTES           crypt_attributes,
+    _In_            PCSTR                       attribute_oid,
+    _Out_           ByteArray           *CONST  byte_array,
+    _Out_opt_       PBOOL                       is_found
+);
+
+/// @brief Copies data to byte array, by allocating byte array internal buffer
+/// @param[in]  data        Data to be copied
+/// @param[in]  length      Length of the data to be copied
+/// @param[out] byte_array  Byte array into which copy the data
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT copy_data_to_byte_array(
+    _In_    CONST   PBYTE               data,
+    _In_    CONST   DWORD               length,
+    _Out_           ByteArray   *CONST  byte_array
+);
+
+/// @brief Compute digest for the given blob using the given algorithm oid
+/// @param[in]  bcrypt_digest_algorithm BCrypt constant for the digest algorithm to use
+/// @param[in]  data_to_digest          Data to digest
+/// @param[in]  data_to_digest_length   Length of data to digest
+/// @param[out] digest                  Computed digest
+/// @param[out] digest_length           Length of the computed digest
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+INT compute_blob_digest(
+  _In_      CONST   PCWSTR          bcrypt_digest_algorithm,
+  _In_      CONST   PBYTE           data_to_digest,
+  _In_      CONST   DWORD           data_to_digest_length,
+  _Outptr_          PBYTE   *CONST  digest,
+  _Out_             PDWORD          digest_length
+);
+
+/// @brief A structure representing a string with buffer reallocation capabilities
+typedef struct _DYNAMIC_STRING
+{
+  /// @brief The buffer containing an ANSI-string
+  LPSTR buffer;
+
+  /// @brief The size in bytes of buffer
+  DWORD buffer_size;
+} DYNAMIC_STRING, *PDYNAMIC_STRING;
+
+/// @brief Concatenates a regular string to a DYNAMIC_STRING.
+/// @param[in,out] dynamic_string A pointer to a valid DYNAMIC_STRING (i.e. already initiated).
+/// @param[in] str_append A pointer to the string to concatenate
+/// @return ERROR_SUCCESS on success, a Yara error code otherwise
+INT dynamic_string_append(
+  _Inout_   CONST   PDYNAMIC_STRING dynamic_string,
+  _In_              PCSTR           str_append
+);
+
+/// @brief Allocates a DYNAMIC_STRING buffer for the first time. Default size is 50 bytes large.
+/// @param[out] dynamic_string  A pointer to the DYNAMIC_STRING to initialize.
+/// @return ERROR_SUCCESS on success, a Yara error code otherwise
+INT dynamic_string_init(
+  _Out_ CONST   PDYNAMIC_STRING dynamic_string
+);
+
+/// @brief Cleans up resources allocated for a DYNAMIC_STRING.
+/// @param[in, out] dynamic_string  A pointer to the DYNAMIC_STRING to clean up.
+VOID dynamic_string_free(
+  _Inout_   PDYNAMIC_STRING dynamic_string
+);
+
+#endif // USE_WINCRYPT_AUTHENTICODE
+
+#endif  // !YR_AUTHENTICODE_WINDOWS_TOOLS_H

--- a/libyara/include/yara/error.h
+++ b/libyara/include/yara/error.h
@@ -155,6 +155,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }                                         \
   }
 
+#define GOTO_EXIT_ON_NULL(x, error) \
+  {                                 \
+    if ((x) == NULL)                \
+    {                               \
+      result = error;               \
+      goto _exit;                   \
+    }                               \
+  }
+
+#define GOTO_EXIT_ON_FAIL(x) \
+  {                          \
+    if ((x) == FALSE)        \
+    {                        \
+      result = -1;           \
+      goto _exit;            \
+    }                        \
+  }
+
 #ifdef NDEBUG
 #define assertf(expr, msg, ...) ((void) 0)
 #else

--- a/libyara/modules/pe/authenticode-parser/certificate.h
+++ b/libyara/modules/pe/authenticode-parser/certificate.h
@@ -24,19 +24,23 @@ SOFTWARE.
 
 #include <authenticode-parser/authenticode.h>
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #include <openssl/x509.h>
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 Certificate* certificate_new(X509* x509);
+CertificateArray* parse_signer_chain(X509* signer_cert, STACK_OF(X509) * certs);
+void parse_x509_certificates(const STACK_OF(X509) * certs, CertificateArray* result);
+#endif // !USE_WINCRYPT_AUTHENTICODE
+
 Certificate* certificate_copy(Certificate* cert);
 void certificate_free(Certificate* cert);
 
-void parse_x509_certificates(const STACK_OF(X509) * certs, CertificateArray* result);
-
-CertificateArray* parse_signer_chain(X509* signer_cert, STACK_OF(X509) * certs);
 int certificate_array_move(CertificateArray* dst, CertificateArray* src);
 int certificate_array_append(CertificateArray* dst, CertificateArray* src);
 CertificateArray* certificate_array_new(int certCount);

--- a/libyara/modules/pe/authenticode-parser/countersignature.c
+++ b/libyara/modules/pe/authenticode-parser/countersignature.c
@@ -25,6 +25,7 @@ SOFTWARE.
 
 #include <yara/mem.h>
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #include <openssl/cms.h>
 #include <openssl/evp.h>
 #include <openssl/objects.h>
@@ -34,6 +35,8 @@ SOFTWARE.
 #include <openssl/safestack.h>
 #include <openssl/ts.h>
 #include <openssl/x509.h>
+#endif // !USE_WINCRYPT_AUTHENTICODE
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,6 +44,8 @@ SOFTWARE.
 #include "certificate.h"
 #include "helper.h"
 #include "structs.h"
+
+#ifndef USE_WINCRYPT_AUTHENTICODE
 
 struct CountersignatureImplStruct;
 
@@ -613,6 +618,8 @@ end:
     ms_countersig_impl_free(impl);
     return result;
 }
+
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 int countersignature_array_insert(CountersignatureArray* arr, Countersignature* sig)
 {

--- a/libyara/modules/pe/authenticode-parser/countersignature.h
+++ b/libyara/modules/pe/authenticode-parser/countersignature.h
@@ -28,16 +28,20 @@ SOFTWARE.
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #include <openssl/safestack.h>
 #include <openssl/x509.h>
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 Countersignature* pkcs9_countersig_new(
     const uint8_t* data, long size, STACK_OF(X509) * certs, ASN1_STRING* enc_digest);
 Countersignature* ms_countersig_new(const uint8_t* data, long size, ASN1_STRING* enc_digest);
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 int countersignature_array_insert(CountersignatureArray* arr, Countersignature* sig);
 /* Moves all countersignatures of src and inserts them into dst */

--- a/libyara/modules/pe/authenticode-parser/helper.c
+++ b/libyara/modules/pe/authenticode-parser/helper.c
@@ -21,6 +21,8 @@ SOFTWARE.
 
 #include "helper.h"
 
+#include <yara/mem.h>
+
 #include <openssl/bio.h>
 #include <openssl/x509_vfy.h>
 #include <stdint.h>
@@ -64,7 +66,7 @@ int byte_array_init(ByteArray* arr, const uint8_t* data, int len)
         return 0;
     }
 
-    arr->data = (uint8_t*)malloc(len);
+    arr->data = (uint8_t*)yr_malloc(len);
     if (!arr->data)
         return -1;
 

--- a/libyara/modules/pe/authenticode-parser/helper.h
+++ b/libyara/modules/pe/authenticode-parser/helper.h
@@ -27,7 +27,9 @@ SOFTWARE.
 #include <stddef.h>
 #include <stdint.h>
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #include <openssl/x509.h>
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef _WIN32
 #define timegm _mkgmtime
@@ -53,13 +55,15 @@ uint32_t bswap32(uint32_t d);
 #define betoh32(x) bswap32(x)
 #endif
 
+/* Copies data of length len into already existing arr */
+int byte_array_init(ByteArray* arr, const uint8_t* data, int len);
+#ifndef USE_WINCRYPT_AUTHENTICODE
 /* Calculates digest md of data, return bytes written to digest or 0 on error
  * Maximum of EVP_MAX_MD_SIZE will be written to digest */
 int calculate_digest(const EVP_MD* md, const uint8_t* data, size_t len, uint8_t* digest);
-/* Copies data of length len into already existing arr */
-int byte_array_init(ByteArray* arr, const uint8_t* data, int len);
 /* Converts ASN1_TIME string time into a unix timestamp */
 int64_t ASN1_TIME_to_int64_t(const ASN1_TIME* time);
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef __cplusplus
 }

--- a/libyara/modules/pe/authenticode-parser/structs.c
+++ b/libyara/modules/pe/authenticode-parser/structs.c
@@ -21,6 +21,7 @@ SOFTWARE.
 
 #include "structs.h"
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 ASN1_CHOICE(SpcString) = {
 	ASN1_IMP_OPT(SpcString, value.unicode, ASN1_BMPSTRING, 0),
 	ASN1_IMP_OPT(SpcString, value.ascii, ASN1_IA5STRING, 1)
@@ -76,3 +77,4 @@ IMPLEMENT_ASN1_FUNCTIONS(AlgorithmIdentifier)
 IMPLEMENT_ASN1_FUNCTIONS(DigestInfo)
 IMPLEMENT_ASN1_FUNCTIONS(SpcIndirectDataContent)
 IMPLEMENT_ASN1_FUNCTIONS(SpcSpOpusInfo)
+#endif // !USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/structs.h
+++ b/libyara/modules/pe/authenticode-parser/structs.h
@@ -22,15 +22,18 @@ SOFTWARE.
 #ifndef AUTHENTICODE_PARSER_STRUCTS_H
 #define AUTHENTICODE_PARSER_STRUCTS_H
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/ossl_typ.h>
 #include <openssl/x509v3.h>
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef USE_WINCRYPT_AUTHENTICODE
 #define NID_spc_info                "1.3.6.1.4.1.311.2.1.12"
 #define NID_spc_ms_countersignature "1.3.6.1.4.1.311.3.3.1"
 #define NID_spc_nested_signature    "1.3.6.1.4.1.311.2.4.1"
@@ -103,6 +106,7 @@ DECLARE_ASN1_FUNCTIONS(DigestInfo)
 DECLARE_ASN1_FUNCTIONS(SpcIndirectDataContent)
 DECLARE_ASN1_FUNCTIONS(SpcSpOpusInfo)
 DECLARE_ASN1_FUNCTIONS(SpcContentInfo)
+#endif // !USE_WINCRYPT_AUTHENTICODE
 
 #ifdef __cplusplus
 }

--- a/libyara/modules/pe/authenticode-parser/windows/authenticode.c
+++ b/libyara/modules/pe/authenticode-parser/windows/authenticode.c
@@ -1,0 +1,603 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <crypto.h>
+
+#include <yara/mem.h>
+#include <yara/modules.h>
+#include <yara/pe.h>
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+#include <authenticode-parser/windows/tools.h>
+#include <authenticode-parser/windows/authenticode.h>
+#include <authenticode-parser/windows/certificate.h>
+#include <authenticode-parser/windows/cleanup.h>
+#include <authenticode-parser/windows/countersignature.h>
+#include <authenticode-parser/windows/extractors.h>
+#include <authenticode-parser/windows/oid.h>
+#include <authenticode-parser/windows/signer.h>
+
+#include <authenticode-parser/authenticode.h>
+
+/// @brief Check for nested signature attribute and parse it
+/// @param[in]      crypt_msg           Crypt message from which to look for nested signature
+/// @param[in, out] authenticode_array  Parsed authenticode array
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT check_for_nested_signature_authenticode(
+    _In_  CONST   HCRYPTMSG                   crypt_msg,
+    _Inout_       AuthenticodeArray   *CONST  authenticode_array
+)
+{
+    INT result = -1;
+
+    PCRYPT_ATTRIBUTES crypt_attributes = NULL;
+
+    if (authenticode_array == NULL || crypt_msg == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_ERROR(get_unauthenticated_attributes_from_crypt_message(crypt_msg, 0, &crypt_attributes));
+    // If there is no unauthenticated attributes, the previous function doesn't end up in error. We therefore need to check crypt_attributes
+    if (crypt_attributes != NULL)
+    {
+        for (DWORD attribute_index = 0; attribute_index < crypt_attributes->cAttr;
+            attribute_index++)
+        {
+            if (strcmp(crypt_attributes->rgAttr[attribute_index].pszObjId, szOID_NESTED_SIGNATURE) == 0)
+            {
+                GOTO_EXIT_ON_ERROR(parse_authenticode_wincrypt(crypt_attributes->rgAttr[attribute_index].rgValue[0].pbData,
+                    crypt_attributes->rgAttr[attribute_index].rgValue[0].cbData,
+                    authenticode_array));
+
+                break;
+            }
+        }
+    }
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (crypt_attributes != NULL)
+    {
+        yr_free(crypt_attributes);
+        crypt_attributes = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Extract signature digest/digest algorithm from crypt message content
+/// @param[in]      crypt_msg       Crypt message from which to retrieve digest/digest algorithm
+/// @param[in, out] authenticode    Authenticode signature to write digest/digest algorithm to
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT extract_signature_data_from_crypt_message_content(
+    _In_      CONST   HCRYPTMSG               crypt_msg,
+    _Inout_           Authenticode    *CONST  authenticode
+)
+{
+    INT result = -1;
+
+    DWORD content_blob_size = 0;
+    PBYTE content_blob_data = NULL;
+
+    DWORD spc_indirect_data_size = 0;
+    PSPC_INDIRECT_DATA_CONTENT spc_indirect_data_content = NULL;
+
+    if (crypt_msg == NULL || authenticode == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Read content of the signed message
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_CONTENT_PARAM, 0, NULL, &content_blob_size));
+
+    content_blob_data = yr_calloc(content_blob_size, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(content_blob_data, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_CONTENT_PARAM, 0, content_blob_data, &content_blob_size));
+
+    // Decode content of the signed message which is CRYPT_TIMESTAMP_INFO
+    GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        SPC_INDIRECT_DATA_OBJID,
+        content_blob_data, content_blob_size,
+        0,
+        NULL,
+        NULL,
+        &spc_indirect_data_size));
+
+    spc_indirect_data_content = yr_calloc(1, spc_indirect_data_size);
+    GOTO_EXIT_ON_NULL(spc_indirect_data_content, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        SPC_INDIRECT_DATA_OBJID,
+        content_blob_data, content_blob_size,
+        0,
+        NULL,
+        spc_indirect_data_content,
+        &spc_indirect_data_size));
+
+    GOTO_EXIT_ON_ERROR(copy_data_to_byte_array(spc_indirect_data_content->Digest.pbData, spc_indirect_data_content->Digest.cbData, &authenticode->digest));
+
+    authenticode->digest_alg = get_algorithmname_from_oid(spc_indirect_data_content->DigestAlgorithm.pszObjId);
+    GOTO_EXIT_ON_NULL(authenticode->digest_alg, ERROR_INSUFFICIENT_MEMORY);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (spc_indirect_data_content != NULL)
+    {
+        yr_free(spc_indirect_data_content);
+        spc_indirect_data_content = NULL;
+    }
+
+    if (content_blob_data != NULL)
+    {
+        yr_free(content_blob_data);
+        content_blob_data = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Verifies if signature message digest attribute values matches with computed one
+/// @param[in]  crypt_msg   Cryptographic message handle
+/// @param[in]  signer      Parsed signer information, to get digest/digest algorithm to be checked from
+/// @param[in]  is_verified Set to TRUE if digest matches
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note See https://datatracker.ietf.org/doc/html/rfc5652#section-11.2
+/// @note See https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/#length
+static INT verify_signature_message_digest(
+    _In_  CONST   HCRYPTMSG           crypt_msg,
+    _In_  CONST   Signer      *CONST  signer,
+    _Out_         PBOOL               is_verified
+)
+{
+    INT result = -1;
+
+    PCWSTR digest_algorithm = NULL;
+
+    DWORD econtent_size = 0;
+    PBYTE econtent_data = NULL;
+
+    DWORD payload_to_digest_length = 0;
+    DWORD total_length_occupied_bytes = 0;
+
+    PBYTE digest = NULL;
+    DWORD digest_length = 0;
+
+    if (crypt_msg == NULL || signer == NULL || is_verified == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // To compute signer info message digest attribute value, and as not clearly specified at
+    // https://datatracker.ietf.org/doc/html/rfc5652#section-11.2, we have to get content, and
+    // compute its digest without the DER type and length tags bytes. To know how many bytes there
+    // is to exclude, check latter comments
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_CONTENT_PARAM, 0, NULL, &econtent_size));
+    // Content has to have at least one byte for type, one byte for length
+    GOTO_EXIT_ON_FAIL(econtent_size > 2);
+    econtent_data = yr_calloc(econtent_size, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(econtent_data, ERROR_INSUFFICIENT_MEMORY);
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_CONTENT_PARAM, 0, econtent_data, &econtent_size));
+
+    // We have to know of much bytes the length occupies. To do this, as specified at
+    // https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/#length
+    // We check if the 8th bit of 2nd byte (length) is set to 1.
+    // If this is the case, the other 7 bits specify the number of bytes being used afterward to store the size
+    if ((econtent_data[1] & 0x80) != 0)
+    {
+        // 0XXX XXXX. bytes marked with X are used to store the bytes count to be used for the size (see previous comment)
+        CONST DWORD bytes_count_used_for_length = (econtent_data[1] & 0x7F);
+
+        // Make sure what we have to read afterward makes sense, as we would underflow later on if this value is 0
+        GOTO_EXIT_ON_FAIL(bytes_count_used_for_length > 0);
+
+        // Length occupied bytes is the first byte which tells how many bytes are used + the used bytes
+        total_length_occupied_bytes = 1 + bytes_count_used_for_length;
+
+        // We do not handle payload larger than the size of DWORD
+        GOTO_EXIT_ON_FAIL(total_length_occupied_bytes <= sizeof(DWORD));
+
+        // Make sure the size to read doesn't make us overflow buffer, tag + (size + its extension) should fit in buffer
+        GOTO_EXIT_ON_FAIL(econtent_size > 1 + total_length_occupied_bytes);
+
+        // Length to compute digest for is specified inside bytes_count_used_for_length bytes
+        // As we do not know how many bytes are used to store the length in advance, and the one with the lower index is in fact the one with most weight
+        // (big endian), we need to manually reverse bytes order
+        for (DWORD index = 0; index < bytes_count_used_for_length; index++)
+        {
+          // We start here at 2 as the first two bytes store the type tag and the size that we do skip
+          payload_to_digest_length += econtent_data[2 + index]
+              // The lowest byte in buffer is in fact the byte with the most weight (big endian), we reverse the order
+              << (bytes_count_used_for_length - index - 1) * 8;
+        }
+    }
+    // Otherwise, the length is only occupying one byte
+    else
+    {
+        total_length_occupied_bytes = 1;
+        payload_to_digest_length = (DWORD)econtent_data[1];
+    }
+
+    // Make sure the computed data doesn't make us overflow the buffer
+    // Payload should contain enough bytes for tag + length + payload we want to digest
+    GOTO_EXIT_ON_FAIL(econtent_size >= 1 + total_length_occupied_bytes + payload_to_digest_length);
+
+    // To compute digest, we use signer's digest algorithm
+    digest_algorithm = find_algorithm_from_algorithm_name(signer->digest_alg);
+    GOTO_EXIT_ON_NULL(digest_algorithm, ERROR_INVALID_VALUE);
+
+    // Compute digest, excluding tag and length
+    GOTO_EXIT_ON_ERROR(compute_blob_digest(digest_algorithm,
+        econtent_data + 1 + total_length_occupied_bytes,
+        payload_to_digest_length,
+        &digest, &digest_length));
+
+    // Check if the digest matches
+    GOTO_EXIT_ON_FAIL(signer->digest.len == digest_length);
+    *is_verified = memcmp(digest, signer->digest.data, digest_length) == 0;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (digest != NULL)
+    {
+        yr_free(digest);
+        digest = NULL;
+    }
+
+    if (econtent_data != NULL)
+    {
+        yr_free(econtent_data);
+        econtent_data = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Parse signatures from the given crypt message
+/// @param[in]  cert_store          Certificates store associated to these signatures
+/// @param[in]  crypt_msg           Crypt message from which to parse signatures
+/// @param[out] authenticode_array  Yara authenticodes array
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT parse_signature_authenticode(
+    _In_  CONST   HCERTSTORE                  cert_store,
+    _In_  CONST   HCRYPTMSG                   crypt_msg,
+    _Out_         AuthenticodeArray   *CONST  authenticode_array
+)
+{
+    INT result = -1;
+
+    DWORD signature_count = 0;
+
+    DWORD local_signature_counter = 0;
+    AuthenticodeArray *local_authenticode_array = NULL;
+
+    PBYTE computed_hash = NULL;
+    DWORD computed_hash_length = 0;
+
+    Authenticode* local_signature = NULL;
+
+    PCMSG_SIGNER_INFO signer_info = NULL;
+
+    DWORD signature_count_param_size = sizeof(DWORD);
+
+    if (cert_store == NULL || crypt_msg == NULL || authenticode_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    local_authenticode_array = yr_calloc(1, sizeof(AuthenticodeArray));
+    GOTO_EXIT_ON_NULL(local_authenticode_array, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(
+        crypt_msg,
+        CMSG_SIGNER_COUNT_PARAM,
+        0,
+        &signature_count,
+        &signature_count_param_size));
+
+    local_authenticode_array->count = signature_count;
+    local_authenticode_array->signatures = yr_calloc(signature_count, sizeof(Authenticode*));
+    GOTO_EXIT_ON_NULL(local_authenticode_array->signatures, ERROR_INSUFFICIENT_MEMORY);
+
+    // Compute message digest (hash)
+    // CMSG_COMPUTED_HASH_PARAM is doing what's specified at https://datatracker.ietf.org/doc/html/rfc5652#section-5.4
+    // If signed attributes exist, get its DER representation and change it from CONTEXT SPECIFIC (A0) to EXPLICIT SET (31), compute its digest
+    // based on message digest algorithm
+    // Else compute digest for encapContentInfo eContent OCTET STRING
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_COMPUTED_HASH_PARAM, 0, NULL, &computed_hash_length));
+    computed_hash = yr_calloc(computed_hash_length, sizeof(BYTE));
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_COMPUTED_HASH_PARAM, 0, computed_hash, &computed_hash_length));
+ 
+    for (DWORD signature_index = 0; signature_index < signature_count; signature_index++)
+    {
+        BOOL is_verified = FALSE;
+
+        DWORD version = 0;
+        DWORD version_size = sizeof(DWORD);
+
+        local_signature = yr_calloc(1, sizeof(Authenticode));
+        GOTO_EXIT_ON_NULL(local_signature, ERROR_INSUFFICIENT_MEMORY);
+
+        GOTO_EXIT_ON_FAIL(CryptMsgGetParam(
+            crypt_msg,
+            CMSG_VERSION_PARAM,
+            0,
+            &version,
+            &version_size));
+
+        local_signature->version = version;
+
+        GOTO_EXIT_ON_ERROR(get_signer_info_from_crypt_message(crypt_msg, signature_index, &signer_info));
+        GOTO_EXIT_ON_ERROR(parse_signer_authenticode(signer_info, cert_store, &local_signature->signer));
+        GOTO_EXIT_ON_ERROR(get_all_certificates_authenticode(cert_store, &local_signature->certs));
+        GOTO_EXIT_ON_ERROR(look_for_counter_signature_authenticode(crypt_msg, cert_store, signature_index, &local_signature->countersigs, local_signature->certs));
+        GOTO_EXIT_ON_ERROR(extract_signature_data_from_crypt_message_content(crypt_msg, local_signature));
+        GOTO_EXIT_ON_ERROR(verify_signature_message_digest(crypt_msg, local_signature->signer, &is_verified));
+        if (is_verified == FALSE)
+        {
+            // Do not loose the initial error, if any
+            if (local_signature->verify_flags == AUTHENTICODE_VFY_VALID)
+              local_signature->verify_flags = AUTHENTICODE_VFY_INVALID;
+        }
+        GOTO_EXIT_ON_ERROR(verify_signature_from_signer_info(cert_store, signer_info, computed_hash, computed_hash_length, &is_verified));
+        if (is_verified == FALSE)
+        {
+            // Do not loose the initial error, if any
+            if (local_signature->verify_flags == AUTHENTICODE_VFY_VALID)
+              local_signature->verify_flags = AUTHENTICODE_VFY_INVALID;
+        }
+
+        local_authenticode_array->signatures[signature_index] = local_signature;
+        local_signature = NULL;
+
+        yr_free(signer_info);
+        signer_info = NULL;
+    }
+
+    GOTO_EXIT_ON_ERROR(authenticode_array_move(authenticode_array, local_authenticode_array));
+
+    yr_free(local_authenticode_array);
+    local_authenticode_array = NULL;
+
+    GOTO_EXIT_ON_ERROR(check_for_nested_signature_authenticode(crypt_msg, authenticode_array));
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (signer_info != NULL)
+    {
+        yr_free(signer_info);
+        signer_info = NULL;
+    }
+
+    if (computed_hash != NULL)
+    {
+        yr_free(computed_hash);
+        computed_hash = NULL;
+    }
+
+    if (local_authenticode_array != NULL)
+    {
+        destroy_authenticode_array(local_authenticode_array);
+        local_authenticode_array = NULL;
+    }
+
+    return result;
+}
+
+INT authenticode_wincrypt_compute_file_digest(
+    _Inout_         Authenticode    *CONST  authenticode,
+    _In_    CONST   PBYTE                   pe_data,
+    _In_    CONST   ULONGLONG               pe_length,
+    _In_    CONST   uint32_t                pe_header_offset,
+    _In_    CONST   BOOL                    is_64bit,
+    _In_    CONST   uint64_t                cert_addr
+)
+{
+    INT result = -1;
+
+    DWORD bytes_copied = 0;
+
+    PCWSTR algorithm_id = 0;
+    BCRYPT_ALG_HANDLE  algorithm_handle = NULL;
+
+    DWORD digest_object_size = 0;
+    PUCHAR digest_object = NULL;
+
+    PBYTE digest = NULL;
+    DWORD local_digest_length = 0;
+
+    BCRYPT_HASH_HANDLE hash_handle = NULL;
+
+    PBYTE cursor = pe_data;
+
+#define CHECK_CURSOR(cursor, length_to_read)            \
+    if (cursor + length_to_read >= pe_data + pe_length) \
+    {                                                   \
+        result = ERROR_INTEGER_OVERFLOW;                  \
+        goto _exit;                                       \
+    }
+
+    // If PE is 64bit, header is 16 bytes larger
+    CONST DWORD pe64_extra = is_64bit ? 16 : 0;
+
+    // Offset to pointer in DOS header, that points to PE header, at 0x3c th byte
+    CONST DWORD cert_table_offset = 0x3c + pe64_extra;
+
+    // Checksum starts at 0x58th byte of the header
+    CONST DWORD pe_checksum_offset = pe_header_offset + 0x58;
+
+    if (authenticode == NULL || cursor == NULL)
+      return ERROR_INVALID_ARGUMENT;
+
+    algorithm_id = find_algorithm_from_algorithm_name(authenticode->digest_alg);
+    GOTO_EXIT_ON_NULL(algorithm_id, ERROR_INVALID_VALUE);
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&algorithm_handle, algorithm_id, NULL, 0))
+    );
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptGetProperty(algorithm_handle, BCRYPT_OBJECT_LENGTH, (PBYTE)&digest_object_size, sizeof(DWORD), &bytes_copied, 0))
+    );
+    GOTO_EXIT_ON_FAIL(bytes_copied == sizeof(DWORD));
+
+    digest_object = yr_calloc(digest_object_size, sizeof(UCHAR));
+    GOTO_EXIT_ON_NULL(digest_object, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptCreateHash(algorithm_handle, &hash_handle, digest_object, digest_object_size, NULL, 0, 0))
+    );
+
+    /* Calculate size of the space between file start and PE header */
+    CHECK_CURSOR(cursor, pe_checksum_offset);
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptHashData(hash_handle, cursor, pe_checksum_offset, 0))
+    );
+    // Checksum starts at 0x58th byte of the header
+    cursor += pe_header_offset + 0x58;
+
+    /* Skip the checksum which is 4 bytes
+       see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only */
+    cursor += 4;
+
+    /* Read up to certificate table*/
+    CHECK_CURSOR(cursor, cert_table_offset);
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptHashData(hash_handle, cursor, cert_table_offset, 0))
+    );
+    cursor += cert_table_offset;
+
+    /* Skip the certificate table, which is 8 bytes
+       see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-attribute-certificate-table-image-only */
+    cursor += 8;
+
+    /* PE header with check sum + checksum + cert table offset + cert table len */
+    /* Hash everything up to the signature (assuming signature is stored in the
+     * end of the file) */
+    ULONGLONG cursor_offset = cursor - pe_data;
+    CHECK_CURSOR(cursor, (cert_addr - (cursor_offset)));
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptHashData(hash_handle, cursor, (ULONG)(cert_addr - (cursor_offset)), 0))
+    );
+
+    // Finalize digest
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptGetProperty(algorithm_handle, BCRYPT_HASH_LENGTH, (PBYTE)&local_digest_length, sizeof(DWORD), &bytes_copied, 0))
+    );
+    GOTO_EXIT_ON_FAIL(bytes_copied == sizeof(DWORD));
+
+    digest = (PUCHAR)yr_calloc(local_digest_length, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(digest, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptFinishHash(hash_handle, digest, local_digest_length, 0))
+    );
+
+    authenticode->file_digest.data = digest;
+    digest = NULL;
+    authenticode->file_digest.len = local_digest_length;
+
+    result = ERROR_SUCCESS;
+
+#undef CHECK_CURSOR
+
+_exit:
+
+    if (digest != NULL)
+    {
+        yr_free(digest);
+        digest = NULL;
+    }
+
+    if (hash_handle != NULL)
+    {
+        BCryptDestroyHash(hash_handle);
+        hash_handle = NULL;
+    }
+
+    if (digest_object != NULL)
+    {
+        yr_free(digest_object);
+        digest_object = NULL;
+    }
+
+    if (algorithm_handle != NULL)
+    {
+        BCryptCloseAlgorithmProvider(algorithm_handle, 0);
+        algorithm_handle = NULL;
+    }
+
+    return result;
+}
+
+INT parse_authenticode_wincrypt(
+    _In_    CONST   PBYTE                       data,
+    _In_    CONST   DWORD                       length,
+    _Inout_         AuthenticodeArray   *CONST  authenticode_array
+)
+{
+    HCERTSTORE cert_store = NULL;
+    HCRYPTMSG crypt_msg = NULL; 
+    INT result = -1;
+
+    CERT_BLOB cert_blob = {
+        .pbData = data,
+        .cbData = length
+    };
+
+    if (data == NULL || length == 0 || authenticode_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(CryptQueryObject(
+        CERT_QUERY_OBJECT_BLOB,
+        &cert_blob,
+        CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED | CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
+        CERT_QUERY_FORMAT_FLAG_BINARY,
+        0,
+        NULL,
+        NULL,
+        NULL,
+        &cert_store,
+        &crypt_msg,
+        NULL));
+    GOTO_EXIT_ON_ERROR(parse_signature_authenticode(cert_store, crypt_msg, authenticode_array));
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (cert_store != NULL)
+    {
+        CertCloseStore(cert_store, CERT_CLOSE_STORE_FORCE_FLAG);
+        cert_store = NULL;
+    }
+
+    if (crypt_msg != NULL)
+    {
+        CryptMsgClose(crypt_msg);
+        crypt_msg = NULL;
+    }
+
+    return result;
+}
+
+#endif  // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/certificate.c
+++ b/libyara/modules/pe/authenticode-parser/windows/certificate.c
@@ -1,0 +1,577 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <Windows.h>
+
+#include <yara/error.h>
+#include <yara/mem.h>
+
+#include <authenticode-parser/authenticode.h>
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/windows/certificate.h>
+#include <authenticode-parser/windows/cleanup.h>
+#include <authenticode-parser/windows/extractors.h>
+#include <authenticode-parser/windows/oid.h>
+
+/// @brief Counts the certificates count in the given cert store
+/// @param[in]  cert_store  Certificates store to count from
+/// @param[out] count       Resulting count
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT count_certificates_in_cert_store(
+    _In_    CONST   HCERTSTORE  cert_store,
+    _Out_           PDWORD      count
+)
+{
+    DWORD local_count = 0;
+
+    PCERT_CONTEXT cert_context = NULL;
+
+    if (cert_store == NULL || count == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    do
+    {
+        cert_context = CertEnumCertificatesInStore(cert_store, cert_context);
+        if (cert_context == NULL)
+            break;
+        else
+            local_count++;
+    } while (cert_context != NULL);
+
+    *count = local_count;
+
+    return ERROR_SUCCESS;
+}
+
+/// Build Yara certificate data structure from a given microsoft certificate context
+/// @param[in]  certificate_context Certificate context to use to build the Yara certificate data structure
+/// @param[out] parsed_certificate  Allocated and filled Yara data structure certificate. To be freed with Yara's certificate_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note As key and key_alg is used nowhere in Yara codebase, it is not recovered as it would add complexity for no reason
+static INT parse_certificate_authenticode(
+    _In_        PCCERT_CONTEXT          certificate_context,
+    _Outptr_    Certificate*    *CONST  parsed_certificate
+)
+{
+    INT result = -1;
+
+    Certificate* local_certificate = NULL;
+
+    if (certificate_context == NULL || parsed_certificate == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    local_certificate = yr_calloc(1, sizeof(Certificate));
+    GOTO_EXIT_ON_NULL(local_certificate, ERROR_INSUFFICIENT_MEMORY);
+
+    // Certificate::key is not used
+    // Certificate::key_alg is not used
+
+    static CONST CERTIFICATE_PROPERTY_EXTRACTOR_CALLBACK_FUNC property_extractor_callbacks[] =
+    {
+        retrieve_sha1_from_cert_authenticode,
+        retrieve_sha256_from_cert_authenticode,
+        retrieve_subject_from_cert_authenticode,
+        retrieve_issuer_from_cert_authenticode,
+        retrieve_version_from_cert_authenticode,
+        retrieve_signature_algorithm_from_cert_authenticode,
+        retrieve_serial_from_cert_authenticode,
+        retrieve_not_before_from_cert_authenticode,
+        retrieve_not_after_from_cert_authenticode,
+    };
+
+    for (DWORD property_extractor_callback_ind = 0;
+        property_extractor_callback_ind < _countof(property_extractor_callbacks);
+        property_extractor_callback_ind++)
+    {
+        GOTO_EXIT_ON_NULL(property_extractor_callbacks[property_extractor_callback_ind], ERROR_CALLBACK_ERROR);
+        property_extractor_callbacks[property_extractor_callback_ind](certificate_context, local_certificate);
+    }
+
+    *parsed_certificate = local_certificate;
+    local_certificate = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_certificate != NULL)
+    {
+        destroy_certificate(local_certificate);
+        local_certificate = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Reverse the given certificates array order
+/// @param[in,out]  certificate_array   Certificates array to be reversed
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT reverse_certificates_array(
+    _Inout_ CertificateArray    *CONST  certificate_array
+)
+{
+    if (certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    for (DWORD index = 0; index < certificate_array->count / 2; index++)
+    {
+        CONST Certificate *temporary_certificate = certificate_array->certs[index];
+        certificate_array->certs[index] = certificate_array->certs[certificate_array->count - index - 1];
+        certificate_array->certs[certificate_array->count - index - 1] = temporary_certificate;
+    }
+
+    return ERROR_SUCCESS;
+}
+
+INT get_all_certificates_authenticode(
+    _In_        CONST   HCERTSTORE                  cert_store,
+    _Outptr_            CertificateArray*   *CONST  certificate_array
+)
+{
+    INT result = -1;
+
+    PCERT_CONTEXT cert_context = NULL;
+
+    CertificateArray* local_certificate_array = NULL;
+
+    DWORD certificate_count = 0;
+
+    if (cert_store == NULL || certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_ERROR(count_certificates_in_cert_store(cert_store, &certificate_count));
+
+    local_certificate_array = yr_calloc(1, sizeof(CertificateArray));
+    GOTO_EXIT_ON_NULL(local_certificate_array, ERROR_INSUFFICIENT_MEMORY);
+
+    local_certificate_array->certs = yr_calloc(certificate_count, sizeof(Certificate*));
+    GOTO_EXIT_ON_NULL(local_certificate_array->certs, ERROR_INSUFFICIENT_MEMORY);
+    local_certificate_array->count = certificate_count;
+
+    DWORD index = 0;
+    do
+    {
+        // Previous cert_context is freed by CertEnumCertificatesInStore on each call (see https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcertificatesinstore)
+        cert_context = CertEnumCertificatesInStore(cert_store, cert_context);
+        if (cert_context != NULL)
+        {
+          GOTO_EXIT_ON_ERROR(parse_certificate_authenticode(cert_context, &local_certificate_array->certs[index++]));
+        }
+    } while (cert_context != NULL);
+
+    // To match OpenSSL Yara version, we have to reverse the certificates array order
+    GOTO_EXIT_ON_ERROR(reverse_certificates_array(local_certificate_array));
+
+    *certificate_array = local_certificate_array;
+    local_certificate_array = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    // In case of an error in the loop, we need to free the cert context
+    if (cert_context != NULL)
+    {
+        CertFreeCertificateContext(cert_context);
+        cert_context = NULL;
+    }
+
+    if (local_certificate_array != NULL)
+    {
+        destroy_certificate_array(local_certificate_array);
+        local_certificate_array = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Builds a Yara certificates array which represent the certificate chain for the given Microsoft certificate context
+/// @param[in]  cert_store                  Certificates store from where to build chain
+/// @param[in]  cert_context                Certificate from which to build the chain
+/// @param[in]  certificate_chain_engine    Certificates chain engine to use (HCCE_CURRENT_USER or HCCE_LOCAL_MACHINE)
+/// @param[out] certificate_array           Yara certificates array data structure holding the build chain. To be freed using certificate_array_free
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note Certificate at index 0 is the certificate itself. Next ones are the one composing the chain, to root CA
+static INT build_certificate_chain_authenticode(
+    _In_        CONST   HCERTSTORE                  cert_store,
+    _In_                PCCERT_CONTEXT              cert_context,
+    _In_opt_    CONST   HCERTCHAINENGINE            certificate_chain_engine,
+    _Outptr_            CertificateArray*   *CONST  certificate_array
+)
+{
+    INT result = -1;
+
+    PCERT_CHAIN_CONTEXT cert_chain_context = NULL;
+    PCCERT_SIMPLE_CHAIN cert_simple_chain = NULL;
+
+    CertificateArray* local_certificate_array = NULL;
+    Certificate* local_certificate = NULL;
+
+    if (cert_store == NULL || cert_context == NULL || certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    {
+        CERT_CHAIN_PARA cert_chain_para = {0};
+
+        cert_chain_para.cbSize = sizeof(CERT_CHAIN_PARA);
+
+        GOTO_EXIT_ON_FAIL(CertGetCertificateChain(certificate_chain_engine,
+            cert_context,
+            NULL,
+            cert_store,
+            &cert_chain_para,
+            // When using flag CERT_CHAIN_CACHE_END_CERT, multiple calls using the same certificate can crash here, as cert_context is freed between calls
+            CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY | CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
+            NULL,
+            &cert_chain_context));
+
+        // We should have at least one element in chain
+        if (cert_chain_context->cChain < 1 || cert_chain_context->rgpChain == NULL || cert_chain_context->rgpChain[0] == NULL)
+        {
+            result = ERROR_INVALID_DATA;
+            goto _exit;
+        }
+    }
+
+    for (DWORD ChainIndex = 0; ChainIndex < cert_chain_context->cChain; ChainIndex++)
+    {
+        cert_simple_chain = cert_chain_context->rgpChain[ChainIndex];
+        // Looking for non-empty certificate chain
+        if (cert_simple_chain->cElement > 0)
+          break;
+    }
+
+    // We did not manage to find a non-empty chain
+    GOTO_EXIT_ON_NULL(cert_simple_chain, ERROR_INVALID_VALUE);
+
+    local_certificate_array = yr_calloc(1, sizeof(CertificateArray));
+    GOTO_EXIT_ON_NULL(local_certificate_array, ERROR_INSUFFICIENT_MEMORY);
+
+    local_certificate_array->count = cert_simple_chain->cElement;
+
+    local_certificate_array->certs = yr_calloc(local_certificate_array->count, sizeof(Certificate*));
+
+    for (DWORD element_index = 0; element_index < cert_simple_chain->cElement; element_index++)
+    {
+        GOTO_EXIT_ON_ERROR(parse_certificate_authenticode(cert_simple_chain->rgpElement[element_index]->pCertContext, &local_certificate));
+        local_certificate_array->certs[element_index] = local_certificate;
+        local_certificate = NULL;
+    }
+
+    *certificate_array = local_certificate_array;
+    local_certificate_array = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_certificate != NULL)
+    {
+        destroy_certificate(local_certificate);
+        local_certificate = NULL;
+    }
+
+    if (local_certificate_array != NULL)
+    {
+        destroy_certificate_array(local_certificate_array);
+        local_certificate_array = NULL;
+    }
+
+    if (cert_chain_context != NULL)
+    {
+        CertFreeCertificateChain(cert_chain_context);
+        cert_chain_context = NULL;
+    }
+
+    return result;
+}
+
+INT format_cert_name_blob_using_known_oid(
+    _In_        CONST   CERT_NAME_BLOB*         cert_name_blob,
+    _Outptr_            PSTR            *CONST  formatted_name
+)
+{
+    DYNAMIC_STRING dynstring_name = {0};
+    PCERT_NAME_INFO cert_name_info = NULL;
+    DWORD cert_name_info_size = 0;
+
+    INT result = -1;
+
+    PSTR local_result = NULL;
+
+    PSTR local_attribute_value = NULL;
+    PSTR buffer = NULL;
+
+    if (cert_name_blob == NULL || formatted_name == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObject(X509_ASN_ENCODING, X509_NAME, cert_name_blob->pbData, cert_name_blob->cbData, 0, NULL, &cert_name_info_size));
+
+    cert_name_info = (PCERT_NAME_INFO)yr_calloc(1, cert_name_info_size);
+    GOTO_EXIT_ON_NULL(cert_name_info, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObject(X509_ASN_ENCODING, X509_NAME, cert_name_blob->pbData, cert_name_blob->cbData, 0, cert_name_info, &cert_name_info_size));
+
+    GOTO_EXIT_ON_ERROR(dynamic_string_init(&dynstring_name));
+
+    for (DWORD rdn_index = 0; rdn_index < cert_name_info->cRDN; rdn_index++)
+    {
+        for (DWORD rdn_attr_index = 0;
+             rdn_attr_index < cert_name_info->rgRDN[rdn_index].cRDNAttr;
+             rdn_attr_index++)
+        {
+            PCOID_DATA oid_data = NULL;
+            PCERT_RDN_ATTR rdnAttribute = &cert_name_info->rgRDN[rdn_index].rgRDNAttr[rdn_attr_index];
+
+            oid_data = find_oid_attribute_data(rdnAttribute->pszObjId);
+
+            // if oid is not found, build the name string without it
+            if (oid_data == NULL)
+                continue;
+
+            GOTO_EXIT_ON_ERROR(get_string_value_from_cert_rdn_value_blob(rdnAttribute, &local_attribute_value));
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring_name, "/"));
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring_name, oid_data->display_name));
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring_name, "="));
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring_name, local_attribute_value));
+
+            yr_free(local_attribute_value);
+            local_attribute_value = NULL;
+        }
+    }
+
+    *formatted_name = duplicate_string(dynstring_name.buffer);
+    GOTO_EXIT_ON_NULL(*formatted_name, ERROR_INSUFFICIENT_MEMORY);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_attribute_value != NULL)
+    {
+        yr_free(local_attribute_value);
+        local_attribute_value = NULL;
+    }
+
+    if (buffer != NULL)
+    {
+        yr_free(buffer);
+        buffer = NULL;
+    }
+
+    dynamic_string_free(&dynstring_name);
+
+    if (cert_name_info != NULL)
+    {
+        yr_free(cert_name_info);
+        cert_name_info = NULL;
+    }
+
+    return result;
+}
+
+INT fill_attributes_using_cert_name_blob(
+    _In_    CONST PCERT_NAME_BLOB           cert_name_blob,
+    _Out_         Attributes        *CONST  attributes
+)
+{
+    PCERT_NAME_INFO cert_name_info = NULL;
+    DWORD cert_name_info_size = 0;
+
+    INT result = -1;
+
+    PSTR attribute_value = NULL;
+
+    ByteArray *attribute_ptr = NULL;
+
+    if (cert_name_blob == NULL || attributes == NULL)
+      return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObject(X509_ASN_ENCODING, X509_NAME, cert_name_blob->pbData, cert_name_blob->cbData, 0, NULL, &cert_name_info_size));
+
+    cert_name_info = (PCERT_NAME_INFO)yr_malloc(cert_name_info_size);
+    GOTO_EXIT_ON_NULL(cert_name_info, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObject(X509_ASN_ENCODING, X509_NAME, cert_name_blob->pbData, cert_name_blob->cbData, 0, cert_name_info, &cert_name_info_size));
+
+    for (DWORD rdn_index = 0; rdn_index < cert_name_info->cRDN; rdn_index++)
+    {
+        for (DWORD rdn_attr_index = 0;
+            rdn_attr_index < cert_name_info->rgRDN[rdn_index].cRDNAttr;
+            rdn_attr_index++)
+        {
+            PCOID_DATA oid_data = NULL;
+            PCERT_RDN_ATTR rdnAttribute = &cert_name_info->rgRDN[rdn_index].rgRDNAttr[rdn_attr_index];
+
+            oid_data = find_oid_attribute_data(rdnAttribute->pszObjId);
+            if (oid_data == NULL)
+                continue;
+
+            switch (oid_data->attribute_type)
+            {
+            case ATTRIBUTE_COMMON_NAME:
+                attribute_ptr = &attributes->commonName;
+                break;
+            case ATTRIBUTE_SURNAME:
+                attribute_ptr = &attributes->surname;
+                break;
+            case ATTRIBUTE_SERIAL_NUMBER:
+                attribute_ptr = &attributes->serialNumber;
+                break;
+            case ATTRIBUTE_COUNTRY_NAME:
+                attribute_ptr = &attributes->country;
+                break;
+            case ATTRIBUTE_ORGANIZATION_NAME:
+                attribute_ptr = &attributes->organization;
+                break;
+            case ATTRIBUTE_ORGANIZATION_UNIT_NAME:
+                attribute_ptr = &attributes->organizationalUnit;
+                break;
+            case ATTRIBUTE_GENERATION_QUALIFIER:
+                attribute_ptr = &attributes->generationQualifier;
+                break;
+            case ATTRIBUTE_PSEUDONYM:
+                attribute_ptr = &attributes->pseudonym;
+                break;
+            case ATTRIBUTE_INITIALS:
+                attribute_ptr = &attributes->initials;
+                break;
+            case ATTRIBUTE_GIVEN_NAME:
+                attribute_ptr = &attributes->givenName;
+                break;
+            case ATTRIBUTE_TITLE:
+                attribute_ptr = &attributes->title;
+                break;
+            case ATTRIBUTE_LOCALITY_NAME:
+                attribute_ptr = &attributes->locality;
+                break;
+            case ATTRIBUTE_STATE_OR_PROVINCE_NAME:
+                attribute_ptr = &attributes->state;
+                break;
+            case ATTRIBUTE_DN_QUALIFIER:
+                attribute_ptr = &attributes->nameQualifier;
+                break;
+            case ATTRIBUTE_EMAIL_ADDRESS:
+                attribute_ptr = &attributes->emailAddress;
+                break;
+
+            default:
+                // not a mapped attribute, we continue
+                continue;
+            }
+
+            // should not happen
+            if (attribute_ptr == NULL)
+                continue;
+
+            GOTO_EXIT_ON_ERROR(get_string_value_from_cert_rdn_value_blob(rdnAttribute, &attribute_value));
+
+            // fill the attribute
+            attribute_ptr->len = strlen(attribute_value);
+            attribute_ptr->data = (uint8_t*)attribute_value;
+            attribute_value = NULL;
+        }
+    }
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (attribute_value != NULL)
+    {
+        yr_free(attribute_value);
+        attribute_value = NULL;
+    }
+
+    if (cert_name_info != NULL)
+    {
+        yr_free(cert_name_info);
+        cert_name_info = NULL;
+    }
+
+    return result;
+}
+
+INT find_signer_certificate_from_signer_info(
+  _In_      CONST   HCERTSTORE                  cert_store,
+  _In_      CONST   PCMSG_SIGNER_INFO           signer_info,
+  _Outptr_          PCERT_CONTEXT       *CONST  cert_context
+)
+{
+    INT result = -1;
+
+    CERT_INFO lookup_cert_info = {0};
+
+    if (cert_store == NULL || signer_info == NULL || cert_context == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Use (issuer, serialnumber) from signerinfo to look up certificate from store
+    lookup_cert_info.Issuer = signer_info->Issuer;
+    lookup_cert_info.SerialNumber = signer_info->SerialNumber;
+
+    *cert_context = CertFindCertificateInStore(cert_store,
+        X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        0,
+        CERT_FIND_SUBJECT_CERT,
+        &lookup_cert_info,
+        NULL);
+    GOTO_EXIT_ON_NULL(*cert_context, ERROR_INVALID_VALUE);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    return result;
+}
+
+INT build_certificate_chain_from_signer_info(
+    _In_    CONST   HCERTSTORE                  cert_store,
+    _In_    CONST   PCMSG_SIGNER_INFO           signer_info,
+    _Out_           CertificateArray*   *CONST  certificate_chain_array
+)
+{
+    INT result = -1;
+
+    PCERT_CONTEXT cert_context = NULL;
+
+    if (cert_store == NULL || signer_info == NULL || certificate_chain_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_ERROR(find_signer_certificate_from_signer_info(cert_store, signer_info, &cert_context));
+    // Current user certificates store inherit from local machine certificates store (https://learn.microsoft.com/en-us/windows-hardware/drivers/install/local-machine-and-current-user-certificate-stores)
+    GOTO_EXIT_ON_ERROR(build_certificate_chain_authenticode(cert_store, cert_context, HCCE_CURRENT_USER, certificate_chain_array));
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (cert_context != NULL)
+    {
+        CertFreeCertificateContext(cert_context);
+        cert_context = NULL;
+    }
+
+    return result;
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/cleanup.c
+++ b/libyara/modules/pe/authenticode-parser/windows/cleanup.c
@@ -1,0 +1,227 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <authenticode-parser/authenticode.h>
+
+#include <yara/mem.h>
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/windows/cleanup.h>
+
+#define CUSTOM_FREE(data)   \
+    if (data != NULL)       \
+    {                       \
+        yr_free(data);      \
+        data = NULL;        \
+    }
+
+VOID cleanup_byte_array(
+    _Inout_ ByteArray   *CONST  byte_array
+)
+{
+    if (byte_array == NULL)
+    {
+        return;
+    }
+
+    CUSTOM_FREE(byte_array->data);
+
+    byte_array->len = 0;
+}
+
+VOID cleanup_attributes(
+    _Inout_ Attributes  *CONST attributes
+)
+{
+    if (attributes == NULL)
+    {
+        return;
+    }
+
+    cleanup_byte_array(&attributes->country);
+    cleanup_byte_array(&attributes->organization);
+    cleanup_byte_array(&attributes->organizationalUnit);
+    cleanup_byte_array(&attributes->nameQualifier);
+    cleanup_byte_array(&attributes->state);
+    cleanup_byte_array(&attributes->commonName);
+    cleanup_byte_array(&attributes->serialNumber);
+    cleanup_byte_array(&attributes->locality);
+    cleanup_byte_array(&attributes->title);
+    cleanup_byte_array(&attributes->surname);
+    cleanup_byte_array(&attributes->givenName);
+    cleanup_byte_array(&attributes->initials);
+    cleanup_byte_array(&attributes->pseudonym);
+    cleanup_byte_array(&attributes->generationQualifier);
+    cleanup_byte_array(&attributes->emailAddress);
+}
+
+VOID destroy_certificate(
+    _In_ _Post_ptr_invalid_ Certificate *CONST  certificate
+)
+{
+    if (certificate == NULL)
+    {
+        return;
+    }
+
+    CUSTOM_FREE(certificate->issuer);
+    CUSTOM_FREE(certificate->subject);
+    CUSTOM_FREE(certificate->serial);
+    cleanup_byte_array(&certificate->sha1);
+    cleanup_byte_array(&certificate->sha256);
+    CUSTOM_FREE(certificate->key_alg);
+    CUSTOM_FREE(certificate->sig_alg);
+    CUSTOM_FREE(certificate->sig_alg_oid);
+    CUSTOM_FREE(certificate->key);
+    cleanup_attributes(&certificate->issuer_attrs);
+    cleanup_attributes(&certificate->subject_attrs);
+
+    yr_free(certificate);
+}
+
+VOID destroy_certificate_array(
+    _In_ _Post_ptr_invalid_ CertificateArray    *CONST  certificate_array
+)
+{
+    if (certificate_array == NULL)
+    {
+        return;
+    }
+
+    if (certificate_array->certs != NULL)
+    {
+        for (int index = 0; index < certificate_array->count; index++)
+        {
+            destroy_certificate(certificate_array->certs[index]);
+            certificate_array->certs[index] = NULL;
+        }
+
+        yr_free(certificate_array->certs);
+        certificate_array->certs = NULL;
+    }
+
+    certificate_array->count = 0;
+
+    yr_free(certificate_array);
+}
+
+VOID destroy_signer(
+    _In_ _Post_ptr_invalid_ Signer  *CONST signer
+)
+{
+    if (signer == NULL)
+    {
+        return;
+    }
+
+    destroy_certificate_array(signer->chain);
+    signer->chain = NULL;
+
+    cleanup_byte_array(&signer->digest);
+
+    CUSTOM_FREE(signer->digest_alg);
+    CUSTOM_FREE(signer->program_name);
+
+    yr_free(signer);
+}
+
+VOID destroy_countersignature(
+    _In_ _Post_ptr_invalid_ Countersignature    *CONST  countersignature
+)
+{
+    if (countersignature == NULL)
+    {
+        return;
+    }
+
+    destroy_certificate_array(countersignature->certs);
+    countersignature->certs = NULL;
+
+    destroy_certificate_array(countersignature->chain);
+    countersignature->chain = NULL;
+
+    cleanup_byte_array(&countersignature->digest);
+    CUSTOM_FREE(countersignature->digest_alg);
+
+    yr_free(countersignature);
+}
+
+VOID destroy_countersignature_array(
+    _In_ _Post_ptr_invalid_ CountersignatureArray   *CONST  array
+)
+{
+    if (array == NULL)
+    {
+        return; 
+    }
+
+    for (DWORD index = 0; index < array->count; index++)
+    {
+        destroy_countersignature(array->counters[index]);
+        array->counters[index] = NULL;
+    }
+
+    CUSTOM_FREE(array->counters);
+    yr_free(array);
+}
+
+VOID destroy_authenticode(
+    _In_ _Post_ptr_invalid_ Authenticode    *CONST  authenticode
+)
+{
+    if (authenticode == NULL)
+    {
+        return;
+    }
+
+    cleanup_byte_array(&authenticode->digest);
+    cleanup_byte_array(&authenticode->file_digest);
+    CUSTOM_FREE(authenticode->digest_alg);
+    destroy_signer(authenticode->signer);
+    authenticode->signer = NULL;
+    destroy_certificate_array(authenticode->certs);
+    authenticode->certs = NULL;
+    destroy_countersignature_array(authenticode->countersigs);
+    authenticode->countersigs = NULL;
+    yr_free(authenticode);
+}
+
+VOID destroy_authenticode_array(
+    _In_ _Post_ptr_invalid_ AuthenticodeArray   *CONST  array
+)
+{
+    if (array == NULL)
+    {
+        return;
+    }
+
+    for (size_t i = 0; i < array->count; ++i)
+    {
+        destroy_authenticode(array->signatures[i]);
+        array->signatures[i] = NULL;
+    }
+
+    CUSTOM_FREE(array->signatures);
+    yr_free(array);
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/countersignature.c
+++ b/libyara/modules/pe/authenticode-parser/windows/countersignature.c
@@ -1,0 +1,546 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/windows/tools.h>
+#include <authenticode-parser/windows/certificate.h>
+#include <authenticode-parser/windows/cleanup.h>
+#include <authenticode-parser/windows/countersignature.h>
+#include <authenticode-parser/windows/oid.h>
+#include <authenticode-parser/windows/signer.h>
+
+#include <authenticode-parser/authenticode.h>
+#include "../countersignature.h"
+
+#include <yara/error.h>
+#include <yara/mem.h>
+
+/// @brief Parse RSA countersignature from the given RSA countersignature data blob (which is a signer info blob)
+/// @param[in]      cert_store                  Signature certificates store
+/// @param[in]      data                        RSA countersignature data blob (which is a signer info blob)
+/// @param[in]      length                      RSA countersignature data blob length
+/// @param[in]      signature_encrypted_digest  Encrypted digest from signature signature info, which is the signature blob
+/// @param[in, out] countersignature_array  Countersignatures array, where this countersignature will be appended
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT parse_rsa_countersignature(
+    _In_    CONST   HCERTSTORE                      cert_store,
+    _In_    CONST   PBYTE                           data,
+    _In_    CONST   DWORD                           length,
+    _In_    CONST   PCRYPT_DATA_BLOB                signature_encrypted_digest,
+    _Inout_         CountersignatureArray   *CONST  countersignature_array
+)
+{
+    INT result = -1;
+
+    Countersignature* local_countersignature = NULL;
+
+    PCMSG_SIGNER_INFO signer_info = NULL;
+    DWORD counter_signature_signer_info_size = 0;
+
+    PCWSTR countersigned_digest_bcrypt_algorithm = NULL;
+    PBYTE countersigned_data_digest = NULL;
+    DWORD countersigned_data_digest_length = 0;
+
+    PCWSTR countersignature_signed_attributes_bcrypt_algorithm = NULL;
+    PBYTE encoded_signed_attributes_digest = NULL;
+    DWORD encoded_signed_attributes_digest_length = 0;
+
+    PBYTE encoded_signed_attributes = NULL;
+    DWORD encoded_signed_attributes_length = 0;
+
+    BOOL is_valid = FALSE;
+
+    if (cert_store == NULL || data == NULL || length == 0 || signature_encrypted_digest == NULL || countersignature_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Decode content of the signed message which is signer info
+    GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        PKCS7_SIGNER_INFO,
+        data, length,
+        0,
+        NULL,
+        NULL,
+        &counter_signature_signer_info_size));
+
+    signer_info = yr_calloc(1, counter_signature_signer_info_size);
+    GOTO_EXIT_ON_NULL(signer_info, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        PKCS7_SIGNER_INFO,
+        data, length,
+        0,
+        NULL,
+        signer_info,
+        &counter_signature_signer_info_size));
+
+    local_countersignature = yr_calloc(1, sizeof(Countersignature));
+    GOTO_EXIT_ON_NULL(local_countersignature, ERROR_INSUFFICIENT_MEMORY);
+
+    // Get digest algorithm
+    local_countersignature->digest_alg = get_algorithmname_from_oid(signer_info->HashAlgorithm.pszObjId);
+    GOTO_EXIT_ON_NULL(local_countersignature->digest_alg, ERROR_INSUFFICIENT_MEMORY);
+
+    // Get digest
+    GOTO_EXIT_ON_ERROR(get_digest_attribute_from_crypt_attributes(&signer_info->AuthAttrs, szOID_PKCS_9_MESSAGE_DIGEST, &local_countersignature->digest, NULL));
+
+    // Get signing time
+    GOTO_EXIT_ON_ERROR(get_rsa_signing_time_attribute_from_crypt_attributes(&signer_info->AuthAttrs, &local_countersignature->sign_time, NULL));
+
+    // Build certificate chain
+    GOTO_EXIT_ON_ERROR(build_certificate_chain_from_signer_info(cert_store, signer_info, &local_countersignature->chain));
+
+    // ----------------------------------------
+    // Check if countersigned data are matching
+    // ----------------------------------------
+
+    countersigned_digest_bcrypt_algorithm = find_algorithm_from_algorithm_name(local_countersignature->digest_alg);
+    GOTO_EXIT_ON_NULL(countersigned_digest_bcrypt_algorithm, ERROR_INVALID_VALUE);
+
+    // Compute countersigned data digest
+    GOTO_EXIT_ON_ERROR(compute_blob_digest(countersigned_digest_bcrypt_algorithm,
+        signature_encrypted_digest->pbData,
+        signature_encrypted_digest->cbData,
+        &countersigned_data_digest,
+        &countersigned_data_digest_length));
+
+    // Check if the digests match
+    GOTO_EXIT_ON_FAIL(local_countersignature->digest.len == countersigned_data_digest_length);
+    if (memcmp(countersigned_data_digest, local_countersignature->digest.data, countersigned_data_digest_length) != 0)
+    {
+        // Do not loose the initial error, if any
+        if (local_countersignature->verify_flags == COUNTERSIGNATURE_VFY_VALID)
+            local_countersignature->verify_flags = COUNTERSIGNATURE_VFY_DOESNT_MATCH_SIGNATURE;
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------------------------------
+    // Check if countersignature is valid, doing what's specified at https://datatracker.ietf.org/doc/html/rfc5652#section-5.4
+    // If signed attributes exist, get its DER representation and change it from CONTEXT SPECIFIC (A0) to EXPLICIT SET (31), compute its digest
+    // based on message digest algorithm
+    // Here we use CryptEncodeObject to encode the signed attributes so we do not need to change A0 to 31, it is done by encoding
+    // ----------------------------------------------------------------------------------------------------------------------------------------
+
+    // Encode signed attributes
+    GOTO_EXIT_ON_FAIL(CryptEncodeObject(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        PKCS_ATTRIBUTES,
+        &signer_info->AuthAttrs,
+        NULL,
+        &encoded_signed_attributes_length));
+    encoded_signed_attributes = yr_calloc(encoded_signed_attributes_length, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(encoded_signed_attributes, ERROR_INSUFFICIENT_MEMORY);
+    GOTO_EXIT_ON_FAIL(CryptEncodeObject(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+        PKCS_ATTRIBUTES,
+        &signer_info->AuthAttrs,
+        encoded_signed_attributes,
+        &encoded_signed_attributes_length));
+
+    // Get BCrypt algorithm
+    GOTO_EXIT_ON_ERROR(find_bcrypt_algorithm_from_oid(signer_info->HashAlgorithm.pszObjId,
+        &countersignature_signed_attributes_bcrypt_algorithm));
+    GOTO_EXIT_ON_NULL(countersignature_signed_attributes_bcrypt_algorithm, ERROR_INVALID_VALUE);
+
+    // Compute the signed attributes DER encoding digest, based on countersignature signer info's digest algorithm
+    GOTO_EXIT_ON_ERROR(compute_blob_digest(countersignature_signed_attributes_bcrypt_algorithm, encoded_signed_attributes, encoded_signed_attributes_length, &encoded_signed_attributes_digest, &encoded_signed_attributes_digest_length));
+
+    // Ensure countersignature is correctly signed
+    GOTO_EXIT_ON_ERROR(verify_signature_from_signer_info(cert_store, signer_info, encoded_signed_attributes_digest, encoded_signed_attributes_digest_length, &is_valid));
+    if (is_valid == FALSE)
+    {
+        // Do not loose the initial error, if any
+        if (local_countersignature->verify_flags == COUNTERSIGNATURE_VFY_VALID)
+            local_countersignature->verify_flags = COUNTERSIGNATURE_VFY_INVALID;
+    }
+
+    GOTO_EXIT_ON_ERROR(countersignature_array_insert(countersignature_array, local_countersignature));
+    local_countersignature = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (encoded_signed_attributes != NULL)
+    {
+        yr_free(encoded_signed_attributes);
+        encoded_signed_attributes = NULL;
+    }
+
+    if (encoded_signed_attributes_digest != NULL)
+    {
+        yr_free(encoded_signed_attributes_digest);
+        encoded_signed_attributes_digest = NULL;
+    }
+
+    if (countersigned_data_digest != NULL)
+    {
+        yr_free(countersigned_data_digest);
+        countersigned_data_digest = NULL;
+    }
+
+    if (local_countersignature != NULL)
+    {
+        destroy_countersignature(local_countersignature);
+        local_countersignature = NULL;
+    }
+
+    if (signer_info != NULL)
+    {
+        yr_free(signer_info);
+        signer_info = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Appends countersignature certificates to all certificates array
+/// @param[in]      cert_store          Countersignature certificates store to extract all certificates from
+/// @param[in, out] certificate_array   Certificates array to insert countersignatures certificates into
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note This is only used for microsoft RFC3161 countersignatures which carry certificates in it, whereas RSA countersignatures expect countersignature certificates to be in parent signer info
+static INT append_counter_signature_certificates_to_all_certificates(
+  _In_      CONST   HCERTSTORE                  cert_store,
+  _Inout_           CertificateArray    *CONST  certificate_array
+)
+{
+    INT result = -1;
+
+    CertificateArray* local_certificate_array = NULL;
+    Certificate** local_certificates = NULL;
+
+    DWORD certificate_total_count = 0;
+
+    if (cert_store == NULL || certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_ERROR(get_all_certificates_authenticode(cert_store, &local_certificate_array));
+
+    // There should be at least one certificate
+    GOTO_EXIT_ON_FAIL(local_certificate_array->count > 0);
+
+    certificate_total_count = local_certificate_array->count + certificate_array->count;
+
+    local_certificates = yr_calloc(certificate_total_count, sizeof(Certificate*));
+    GOTO_EXIT_ON_NULL(local_certificates, ERROR_INSUFFICIENT_MEMORY);
+
+    memcpy(local_certificates, certificate_array->certs, certificate_array->count * sizeof(Certificate*));
+    memcpy(local_certificates + certificate_array->count, local_certificate_array->certs, local_certificate_array->count * sizeof(Certificate*));
+
+    if (certificate_array->certs != NULL)
+        // Free container but not elements
+        yr_free(certificate_array->certs);
+
+    certificate_array->certs = local_certificates;
+    certificate_array->count = certificate_total_count;
+
+    // We need to keep elements intacts so we only free the containers
+    yr_free(local_certificate_array->certs);
+    yr_free(local_certificate_array);
+    local_certificate_array = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_certificate_array != NULL)
+    {
+        destroy_certificate_array(local_certificate_array);
+        local_certificate_array = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Parse MS countersignature (RFC3161) from the given MS countersignature data blob (which is a PKCS7 data blob)
+/// @param[in]      signature_cert_store    Certificates store of the signature
+/// @param[in]      signature_signer_info   Signer info of the signature
+/// @param[in]      data                    Countersignature data blob (which is a PKCS7 data blob)
+/// @param[in]      length                  Countersignature data blob length
+/// @param[in, out] countersignature_array  Countersignatures array where to insert parsed countersignature
+/// @param[in, out] certificate_array       Certificate array where countersignature certificates are to be inserted
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+static INT parse_ms_countersignature(
+    _In_    CONST   HCERTSTORE                      signature_cert_store,
+    _In_    CONST   PCMSG_SIGNER_INFO               signature_signer_info,
+    _In_    CONST   PBYTE                           data,
+    _In_    CONST   DWORD                           length,
+    _Inout_         CountersignatureArray   *CONST  countersignature_array,
+    _Inout_         CertificateArray        *CONST  certificate_array
+)
+{
+    INT result = -1;
+
+    HCERTSTORE countersignature_cert_store = NULL;
+    HCRYPTMSG countersignature_crypt_msg = NULL;
+
+    PCRYPT_TIMESTAMP_CONTEXT timestamp_context = NULL;
+    PCRYPT_TIMESTAMP_INFO timestamp_info = NULL;
+    PCMSG_SIGNER_INFO signer_info = NULL;
+
+    // Point to the timestamp info to be used, as it can come from either CryptVerifyTimeStampSignature result or countersignature content parsing. Not to be freed
+    PCRYPT_TIMESTAMP_INFO timestamp_info_to_use = NULL;
+
+    PBYTE countersign_content_blob_data = NULL;
+    DWORD countersign_content_blob_size = 0;
+
+    DWORD timestamp_buffer_size = 0;
+
+    Countersignature* local_countersignature = NULL;
+
+    CERT_BLOB cert_blob = {
+        .pbData = data,
+        .cbData = length
+    };
+
+    if (signature_cert_store == NULL || signature_signer_info == NULL || data == NULL || length == 0 || countersignature_array == NULL || certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(CryptQueryObject(
+        CERT_QUERY_OBJECT_BLOB,
+        &cert_blob,
+        CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED | CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
+        CERT_QUERY_FORMAT_FLAG_BINARY,
+        0,
+        NULL,
+        NULL,
+        NULL,
+        &countersignature_cert_store,
+        &countersignature_crypt_msg,
+        NULL));
+
+    // Add ms countersignature certificates to signature all certificates
+    GOTO_EXIT_ON_ERROR(append_counter_signature_certificates_to_all_certificates(countersignature_cert_store, certificate_array));
+
+    local_countersignature = yr_calloc(1, sizeof(Countersignature));
+    GOTO_EXIT_ON_NULL(local_countersignature, ERROR_INSUFFICIENT_MEMORY);
+
+    // Get all certificates from countersignature certificates store
+    GOTO_EXIT_ON_ERROR(get_all_certificates_authenticode(countersignature_cert_store, &local_countersignature->certs));
+
+    if (CryptVerifyTimeStampSignature(data, length,
+        signature_signer_info->EncryptedHash.pbData, signature_signer_info->EncryptedHash.cbData,
+        signature_cert_store,
+        &timestamp_context, NULL,
+        NULL))
+    {
+        // Countersignature is valid, we can get data from timestamp context's timestamp info
+        local_countersignature->verify_flags = COUNTERSIGNATURE_VFY_VALID;
+
+        timestamp_info_to_use = timestamp_context->pTimeStamp;
+    }
+    else
+    {
+        // Countersignature is invalid, we have to decode message content to get timestamp info
+        local_countersignature->verify_flags = COUNTERSIGNATURE_VFY_DOESNT_MATCH_SIGNATURE;
+
+        // Read content of the signed message
+        GOTO_EXIT_ON_FAIL(CryptMsgGetParam(countersignature_crypt_msg, CMSG_CONTENT_PARAM, 0, NULL, &countersign_content_blob_size));
+
+        countersign_content_blob_data = yr_calloc(countersign_content_blob_size, sizeof(BYTE));
+        GOTO_EXIT_ON_NULL(countersign_content_blob_data, ERROR_INSUFFICIENT_MEMORY);
+
+        GOTO_EXIT_ON_FAIL(CryptMsgGetParam(countersignature_crypt_msg, CMSG_CONTENT_PARAM, 0, countersign_content_blob_data, &countersign_content_blob_size));
+
+        // Decode content of the signed message which is CRYPT_TIMESTAMP_INFO
+        GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+            TIMESTAMP_INFO,
+            countersign_content_blob_data, countersign_content_blob_size,
+            0,
+            NULL,
+            NULL,
+            &timestamp_buffer_size));
+
+        timestamp_info = yr_calloc(1, timestamp_buffer_size);
+        GOTO_EXIT_ON_NULL(timestamp_info, ERROR_INSUFFICIENT_MEMORY);
+
+        GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+            TIMESTAMP_INFO,
+            countersign_content_blob_data, countersign_content_blob_size,
+            0,
+            NULL,
+            timestamp_info,
+            &timestamp_buffer_size));
+
+        timestamp_info_to_use = timestamp_info;
+    }
+
+    // Get digest algorithm
+    local_countersignature->digest_alg = get_algorithmname_from_oid(timestamp_info_to_use->HashAlgorithm.pszObjId);
+    GOTO_EXIT_ON_NULL(local_countersignature->digest_alg, ERROR_INSUFFICIENT_MEMORY);
+
+    // Get digest
+    GOTO_EXIT_ON_ERROR(copy_data_to_byte_array(timestamp_info_to_use->HashedMessage.pbData, timestamp_info_to_use->HashedMessage.cbData, &local_countersignature->digest));
+
+    // Get signing time
+    local_countersignature->sign_time = filetime_to_epoch(&timestamp_info_to_use->ftTime);
+
+    GOTO_EXIT_ON_ERROR(get_signer_info_from_crypt_message(countersignature_crypt_msg, 0, &signer_info));
+
+    // Build certificate chain
+    GOTO_EXIT_ON_ERROR(build_certificate_chain_from_signer_info(countersignature_cert_store, signer_info, &local_countersignature->chain));
+
+    GOTO_EXIT_ON_ERROR(countersignature_array_insert(countersignature_array, local_countersignature));
+    local_countersignature = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (timestamp_context != NULL)
+    {
+        CryptMemFree(timestamp_context);
+        timestamp_context = NULL;
+    }
+
+    if (signer_info != NULL)
+    {
+        yr_free(signer_info);
+        signer_info = NULL;
+    }
+
+    if (local_countersignature != NULL)
+    {
+        destroy_countersignature(local_countersignature);
+        local_countersignature = NULL;
+    }
+
+    if (timestamp_info != NULL)
+    {
+        yr_free(timestamp_info);
+        timestamp_info = NULL;
+    }
+
+    if (countersign_content_blob_data != NULL)
+    {
+        yr_free(countersign_content_blob_data);
+        countersign_content_blob_data = NULL;
+    }
+
+    if (countersignature_cert_store != NULL)
+    {
+        CertCloseStore(countersignature_cert_store, CERT_CLOSE_STORE_FORCE_FLAG);
+        countersignature_cert_store = NULL;
+    }
+
+    if (countersignature_crypt_msg != NULL)
+    {
+        CryptMsgClose(countersignature_crypt_msg);
+        countersignature_crypt_msg = NULL;
+    }
+
+    return result;
+}
+
+INT look_for_counter_signature_authenticode(
+    _In_        CONST   HCRYPTMSG                       crypt_msg,
+    _In_        CONST   HCERTSTORE                      cert_store,
+    _In_        CONST   DWORD                           signature_index,
+    _Outptr_            CountersignatureArray*  *CONST  countersignature_array,
+    _Inout_             CertificateArray        *CONST  certificate_array
+)
+{
+    INT result = -1;
+
+    PCRYPT_ATTRIBUTES crypt_attributes = NULL;
+
+    ByteArray rsa_countersignature_byte_array = {0};
+    ByteArray ms_countersignature_byte_array = {0};
+
+    CountersignatureArray* local_countersignature_array = NULL;
+
+    PCMSG_SIGNER_INFO signer_info = NULL;
+
+    if (crypt_msg == NULL || cert_store == NULL || countersignature_array == NULL || certificate_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    local_countersignature_array = yr_calloc(1, sizeof(CountersignatureArray));
+    GOTO_EXIT_ON_NULL(local_countersignature_array, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_ERROR(get_unauthenticated_attributes_from_crypt_message(crypt_msg, signature_index, &crypt_attributes));
+    // If there is no unauthenticated attributes, the previous function doesn't end up in error. We therefore need to check crypt_attributes
+    if (crypt_attributes != NULL)
+    {
+        BOOL has_countersignature = FALSE;
+
+        GOTO_EXIT_ON_ERROR(get_signer_info_from_crypt_message(crypt_msg, signature_index, &signer_info));
+
+        // check for RFC3161 countersignature
+        GOTO_EXIT_ON_ERROR(get_attribute_from_crypt_attributes(crypt_attributes, szOID_RFC3161_counterSign, &ms_countersignature_byte_array, &has_countersignature));
+        if (has_countersignature)
+        {
+            // ms counter signature has countersignature data into its content
+            GOTO_EXIT_ON_ERROR(
+                parse_ms_countersignature(
+                    cert_store,
+                    signer_info,
+                    ms_countersignature_byte_array.data, ms_countersignature_byte_array.len,
+                    local_countersignature_array,
+                    certificate_array
+                )
+            );
+        }
+
+        // check for RSA countersignature
+        GOTO_EXIT_ON_ERROR(get_attribute_from_crypt_attributes(crypt_attributes, szOID_RSA_counterSign, &rsa_countersignature_byte_array, &has_countersignature));
+        if (has_countersignature)
+        {
+            // counter signature blob is another PKCS7 data blob to be parsed, where we should find authenticated attributes digest/timestamp, and digest algorithm in signer infos
+            GOTO_EXIT_ON_ERROR(
+                parse_rsa_countersignature(
+                    cert_store,
+                    rsa_countersignature_byte_array.data, rsa_countersignature_byte_array.len,
+                    &signer_info->EncryptedHash,
+                    local_countersignature_array
+                )
+            );
+        }
+    }
+
+    *countersignature_array = local_countersignature_array;
+    local_countersignature_array = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (signer_info != NULL)
+    {
+        yr_free(signer_info);
+        signer_info = NULL;
+    }
+
+    if (local_countersignature_array != NULL)
+    {
+        destroy_countersignature_array(local_countersignature_array);
+        local_countersignature_array = NULL;
+    }
+
+    cleanup_byte_array(&rsa_countersignature_byte_array);
+    cleanup_byte_array(&ms_countersignature_byte_array);
+
+    if (crypt_attributes != NULL)
+    {
+        yr_free(crypt_attributes);
+        crypt_attributes = NULL;
+    }
+
+    return result;
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/extractors.c
+++ b/libyara/modules/pe/authenticode-parser/windows/extractors.c
@@ -1,0 +1,248 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/windows/tools.h>
+#include <authenticode-parser/windows/certificate.h>
+#include <authenticode-parser/windows/extractors.h>
+#include <authenticode-parser/windows/oid.h>
+
+#include <yara/error.h>
+#include <yara/mem.h>
+#include <yara/modules.h>
+
+#include <crypto.h>
+
+/// @brief Computes the cert data digest using the requested algorithm
+/// @param[in]      certificate_context     Certificate context to compute the digest for
+/// @param[in]      algorithm               Microsoft digest algorithm identifier
+/// @param[in]      expected_digest_length  Expected length of the digest for the given digest algorithm
+/// @param[in,out]  digest                  Computed digest, to be freed using yr_free
+static VOID compute_cert_data_digest(
+    _In_    CONST   PCCERT_CONTEXT          certificate_context,
+    _In_    CONST   ALG_ID                  algorithm,
+    _In_    CONST   DWORD                   expected_digest_length,
+    _Inout_         ByteArray       *CONST  digest
+)
+{
+    PSTR buffer = NULL;
+    DWORD buffer_size = 0;
+    INT result = -1;
+
+    if (certificate_context == NULL || expected_digest_length == 0 || digest == NULL)
+        return;
+
+    GOTO_EXIT_ON_FAIL(CryptHashCertificate(
+        0,
+        algorithm,
+        0,
+        certificate_context->pbCertEncoded,
+        certificate_context->cbCertEncoded,
+        NULL,
+        &buffer_size));
+
+    GOTO_EXIT_ON_FAIL(buffer_size == expected_digest_length);
+
+    buffer = (PSTR)yr_malloc(buffer_size);
+    GOTO_EXIT_ON_NULL(buffer, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptHashCertificate(
+        0,
+        algorithm,
+        0,
+        certificate_context->pbCertEncoded,
+        certificate_context->cbCertEncoded,
+        (BYTE*)buffer,
+        &buffer_size));
+
+    digest->len = buffer_size;
+    digest->data = (uint8_t*)yr_calloc(buffer_size, sizeof(char));
+    GOTO_EXIT_ON_NULL(digest->data, ERROR_INSUFFICIENT_MEMORY);
+
+    memcpy(digest->data, buffer, buffer_size * sizeof(char));
+
+_exit:
+
+    if (buffer != NULL)
+    {
+        yr_free(buffer);
+        buffer = NULL;
+    }
+}
+
+VOID retrieve_sha1_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    compute_cert_data_digest(certificate_context, CALG_SHA1, YR_SHA1_LEN, &certificate->sha1);
+}
+
+VOID retrieve_sha256_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    compute_cert_data_digest(certificate_context, CALG_SHA_256, YR_SHA256_LEN, &certificate->sha256);
+}
+
+VOID retrieve_subject_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    INT result = -1;
+
+    PSTR formatted_subject = NULL;
+
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    GOTO_EXIT_ON_ERROR(format_cert_name_blob_using_known_oid(&certificate_context->pCertInfo->Subject, &formatted_subject));
+    GOTO_EXIT_ON_ERROR(fill_attributes_using_cert_name_blob(&certificate_context->pCertInfo->Subject, &certificate->subject_attrs));
+
+    certificate->subject = formatted_subject;
+    formatted_subject = NULL;
+
+_exit:
+
+    if (formatted_subject != NULL)
+    {
+        yr_free(formatted_subject);
+        formatted_subject = NULL;
+    }
+}
+
+VOID retrieve_issuer_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    INT result = -1;
+
+    PSTR formatted_issuer = NULL;
+
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    GOTO_EXIT_ON_ERROR(format_cert_name_blob_using_known_oid(&certificate_context->pCertInfo->Issuer, &formatted_issuer));
+    GOTO_EXIT_ON_ERROR(fill_attributes_using_cert_name_blob(&certificate_context->pCertInfo->Issuer, &certificate->issuer_attrs));
+
+    certificate->issuer = formatted_issuer;
+    formatted_issuer = NULL;
+
+_exit:
+
+    if (formatted_issuer != NULL)
+    {
+        yr_free(formatted_issuer);
+        formatted_issuer = NULL;
+    }
+}
+
+VOID retrieve_version_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    // version are 0 based, but one increment is done by yara in write_certificate maccro
+    certificate->version = certificate_context->pCertInfo->dwVersion;
+}
+
+VOID retrieve_signature_algorithm_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    PCSTR algo_display_name = NULL;
+
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+    {
+        return;
+    }
+
+    certificate->sig_alg = get_algorithmname_from_oid(certificate_context->pCertInfo->SignatureAlgorithm.pszObjId);
+    certificate->sig_alg_oid = duplicate_string(certificate_context->pCertInfo->SignatureAlgorithm.pszObjId);
+}
+
+VOID retrieve_serial_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    char* buffer = NULL;
+    PCRYPT_INTEGER_BLOB serial_number = NULL;
+    int result = -1;
+
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    serial_number = (PCRYPT_INTEGER_BLOB) &certificate_context->pCertInfo->SerialNumber;
+
+    // About the SerialNumber member:
+    // http://msdn.microsoft.com/en-us/library/windows/desktop/aa377200(v=vs.85).aspx
+    // A BLOB that contains the serial number of a certificate.
+    // The least significant byte is the zero byte of the pbData member of
+    // SerialNumber. The index for the last byte of pbData, is one less than the
+    // value of the cbData member of SerialNumber. The most significant byte is
+    // the last byte of pbData. Leading 0x00 or 0xFF bytes are removed.
+
+    GOTO_EXIT_ON_ERROR(buffer_to_hex(serial_number->cbData, serial_number->pbData, NULL, &buffer, ':', true));
+
+    certificate->serial = duplicate_string(buffer);
+    GOTO_EXIT_ON_NULL(certificate->serial, ERROR_INSUFFICIENT_MEMORY);
+
+_exit:
+
+    if (buffer != NULL)
+    {
+        yr_free(buffer);
+        buffer = NULL;
+    }
+}
+
+VOID retrieve_not_before_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    certificate->not_before = filetime_to_epoch(&certificate_context->pCertInfo->NotBefore);
+}
+
+VOID retrieve_not_after_from_cert_authenticode(
+    _In_    PCCERT_CONTEXT          certificate_context,
+    _Inout_ Certificate     *CONST  certificate
+)
+{
+    if (certificate == NULL || certificate_context == NULL || certificate_context->pCertInfo == NULL)
+        return;
+
+    certificate->not_after = filetime_to_epoch(&certificate_context->pCertInfo->NotAfter);
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/oid.c
+++ b/libyara/modules/pe/authenticode-parser/windows/oid.c
@@ -1,0 +1,327 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <yara/error.h>
+#include <yara/mem.h>
+
+#include <authenticode-parser/windows/tools.h>
+#include <authenticode-parser/windows/oid.h>
+
+/// @brief Algorithm name to wincrypt algorithm data structure
+typedef struct _ALGORITHM_NAME_TO_WINCRYPT_ALGORITHM
+{
+    // Algorithm name, as expressed by OpenSSL (see algorithm_oid_name_matching)
+    PCSTR algorithm_name;
+
+    // Cryptographic algorithm equivalent
+    PCWSTR cryptographic_algorithm;
+} ALGORITHM_NAME_TO_WINCRYPT_ALGORITHM;
+
+/// @brief Mappings between digest algorithm name and BCrypt constant
+static CONST ALGORITHM_NAME_TO_WINCRYPT_ALGORITHM digest_algorithm_name_to_algorithm[] =
+{
+    {"md2",     BCRYPT_MD2_ALGORITHM    },
+    {"md4",     BCRYPT_MD4_ALGORITHM    },
+    {"md5",     BCRYPT_MD5_ALGORITHM    },
+    {"sha",     BCRYPT_SHA1_ALGORITHM   },
+    {"sha1",    BCRYPT_SHA1_ALGORITHM   },
+    {"sha256",  BCRYPT_SHA256_ALGORITHM },
+    {"sha384",  BCRYPT_SHA384_ALGORITHM },
+    {"sha512",  BCRYPT_SHA512_ALGORITHM },
+};
+
+// This list is put together with the algorithm short names definitions from the
+// OpenSSL sources. This avoids discrepancies between using OpenSSL and Wincrypt
+// uses which would cause different results for the same Yara rule evaluation.
+static CONST OID_DATA algorithm_oid_name_matching[] =
+{
+    {"1.2.840.10040.4.1", "dsaEncryption"},
+    {"1.2.840.10040.4.3", "dsaWithSHA1"},
+
+    {"1.2.840.113533.7.66.10", "CAST5-CBC"},
+    {"1.2.840.113533.7.66.12", "pbeWithMD5AndCast5CBC"},
+    {"1.2.840.113533.7.66.13", "id-PasswordBasedMAC"},
+    {"1.2.840.113533.7.66.30", "Diffie-Hellman based MAC"},
+
+    {"1.2.840.113549.1", "pkcs"},
+    {"1.2.840.113549.1.1", "pkcs1"},
+    {"1.2.840.113549.1.1.1", "rsaEncryption"},
+    {"1.2.840.113549.1.1.2", "md2WithRSAEncryption"},
+    {"1.2.840.113549.1.1.3", "md4WithRSAEncryption"},
+    {"1.2.840.113549.1.1.4", "md5WithRSAEncryption"},
+    {"1.2.840.113549.1.1.5", "sha1WithRSAEncryption"},
+    {"1.2.840.113549.1.1.7", "rsaesOaep"},
+    {"1.2.840.113549.1.1.8", "mgf1"},
+    {"1.2.840.113549.1.1.9", "pSpecified"},
+    {"1.2.840.113549.1.1.10", "rsassaPss"},
+    {"1.2.840.113549.1.1.11", "sha256WithRSAEncryption"},
+    {"1.2.840.113549.1.1.12", "sha384WithRSAEncryption"},
+    {"1.2.840.113549.1.1.13", "sha512WithRSAEncryption"},
+    {"1.2.840.113549.1.1.14", "sha224WithRSAEncryption"},
+    {"1.2.840.113549.1.1.15", "sha512-224WithRSAEncryption"},
+    {"1.2.840.113549.1.1.16", "sha512-256WithRSAEncryption"},
+
+    {"1.2.840.113549.2.2", "md2"},
+    {"1.2.840.113549.2.4", "md4"},
+    {"1.2.840.113549.2.5", "md5"},
+    {"1.2.840.113549.2.6", "hmacWithMD5"},
+    {"1.2.840.113549.2.7", "hmacWithSHA1"},
+    {"1.2.840.113549.2.8", "hmacWithSHA224"},
+    {"1.2.840.113549.2.9", "hmacWithSHA256"},
+    {"1.2.840.113549.2.10", "hmacWithSHA384"},
+    {"1.2.840.113549.2.11", "hmacWithSHA512"},
+    {"1.2.840.113549.2.12", "hmacWithSHA512-224"},
+    {"1.2.840.113549.2.13", "hmacWithSHA512-256"},
+
+    {"1.2.840.113549.3.2", "rc2-cbc"},
+    {"1.2.840.113549.3.4", "rc4"},
+    {"1.2.840.113549.3.7", "des-ede3-cbc"},
+    {"1.2.840.113549.3.8", "rc5-cbc"},
+    {"1.2.840.113549.3.10", "des-cdmf"},
+
+    {"1.2.840.10040", "X9.57"},
+    {"1.2.840.10040.4.1", "dsaEncryption"},
+    {"1.2.840.10040.4.3", "dsaWithSHA1"},
+
+    {"1.2.840.10046.2.1", "X9.42 DH"},
+
+    {"1.3.14.3.2.18", "sha"},
+    {"1.3.14.3.2.26", "sha1"},
+
+    {"2.16.840.1.101.3.4.2.1", "sha256"},
+    {"2.16.840.1.101.3.4.2.2", "sha384"},
+    {"2.16.840.1.101.3.4.2.3", "sha512"},
+    {"2.16.840.1.101.3.4.2.4", "sha224"},
+    {"2.16.840.1.101.3.4.2.5", "sha512-224"},
+    {"2.16.840.1.101.3.4.2.6", "sha512-256"},
+};
+
+// This list is put together with the DN attribute short names definitions from
+// the OpenSSL sources. This avoids discrepancies between using OpenSSL and
+// Wincrypt uses which would cause different results for the same Yara rule
+// evaluation. When OpenSSL does not define a short name for an entry, regular
+// name is used.
+static CONST OID_DATA attribute_name_oid_short_name_matching[] =
+{
+    {"2.5.4.3", "CN", ATTRIBUTE_COMMON_NAME},
+    {"2.5.4.4", "SN", ATTRIBUTE_SURNAME},
+    {"2.5.4.5", "serialNumber", ATTRIBUTE_SERIAL_NUMBER},
+    {"2.5.4.6", "C", ATTRIBUTE_COUNTRY_NAME},
+    {"2.5.4.7", "L", ATTRIBUTE_LOCALITY_NAME},
+    {"2.5.4.8", "ST", ATTRIBUTE_STATE_OR_PROVINCE_NAME},
+    {"2.5.4.9", "street", ATTRIBUTE_STREET},
+    {"2.5.4.10", "O", ATTRIBUTE_ORGANIZATION_NAME},
+    {"2.5.4.11", "OU", ATTRIBUTE_ORGANIZATION_UNIT_NAME},
+    {"2.5.4.12", "title", ATTRIBUTE_TITLE},
+    {"2.5.4.13", "description", ATTRIBUTE_DESCRIPTION},
+    {"2.5.4.14", "searchGuide", ATTRIBUTE_SEARCH_GUIDE},
+    {"2.5.4.15", "businessCategory", ATTRIBUTE_BUSINESS_CATEGORY},
+    {"2.5.4.16", "postalAddress", ATTRIBUTE_POSTAL_ADDRESS},
+    {"2.5.4.17", "postalCode", ATTRIBUTE_POSTAL_CODE},
+    {"2.5.4.18", "postOfficeBox", ATTRIBUTE_POSTAL_OFFICE_BOX},
+    {"2.5.4.19", "physicalDeliveryOfficeName", ATTRIBUTE_PHYSICAL_DELIVERY_OFFICE_NAME},
+    {"2.5.4.20", "telephoneNumber", ATTRIBUTE_TELEPHONE_NUMBER},
+    {"2.5.4.21", "telexNumber", ATTRIBUTE_TELEX_NUMBER},
+    {"2.5.4.22", "teletexTerminalIdentifier", ATTRIBUTE_TELETEX_TERMINAL_IDENTIFIER},
+    {"2.5.4.23", "facsimileTelephoneNumber", ATTRIBUTE_FACSIMILE_TELEPHONE_NUMBER},
+    {"2.5.4.24", "x121Address", ATTRIBUTE_X121_ADDRESS},
+    {"2.5.4.25", "internationalISDNNumber", ATTRIBUTE_INTERNATIONAL_ISDN_NUMBER},
+    {"2.5.4.26", "registeredAddress", ATTRIBUTE_REGISTERED_ADDRESS},
+    {"2.5.4.27", "destinationIndicator", ATTRIBUTE_DESTINATION_INDICATOR},
+    {"2.5.4.28", "preferredDeliveryMethod", ATTRIBUTE_PREFERRED_DELIVERY_METHOD},
+    {"2.5.4.29", "presentationAddress", ATTRIBUTE_PRESENTATION_ADDRESS},
+    {"2.5.4.30", "supportedApplicationContext", ATTRIBUTE_SUPPORTED_APPLICATION_CONTEXT},
+    {"2.5.4.31", "member", ATTRIBUTE_MEMBER},
+    {"2.5.4.32", "owner", ATTRIBUTE_OWNER},
+    {"2.5.4.33", "roleOccupant", ATTRIBUTE_ROLE_OCCUPANT},
+    {"2.5.4.34", "seeAlso", ATTRIBUTE_SEE_ALSO},
+    {"2.5.4.35", "userPassword", ATTRIBUTE_USER_PASSWORD},
+    {"2.5.4.36", "userCertificate", ATTRIBUTE_USER_CERTIFICATE},
+    {"2.5.4.37", "cACertificate", ATTRIBUTE_CA_CERTIFICATE},
+    {"2.5.4.38", "authorityRevocationList", ATTRIBUTE_AUTHORITY_REVOCATION_LIST},
+    {"2.5.4.39", "certificateRevocationList", ATTRIBUTE_CERTIFICATE_REVOCATION_LIST},
+    {"2.5.4.40", "crossCertificatePair", ATTRIBUTE_CROSS_CERTIFICATE_PAIR},
+    {"2.5.4.41", "name", ATTRIBUTE_NAME},
+    {"2.5.4.42", "GN", ATTRIBUTE_GIVEN_NAME},
+    {"2.5.4.43", "initials", ATTRIBUTE_INITIALS},
+    {"2.5.4.44", "generationQualifier", ATTRIBUTE_GENERATION_QUALIFIER},
+    {"2.5.4.45", "x500UniqueIdentifier", ATTRIBUTE_X500_UNIQUE_IDENTIFIER},
+    {"2.5.4.46", "dnQualifier", ATTRIBUTE_DN_QUALIFIER},
+    {"2.5.4.47", "enhancedSearchGuide", ATTRIBUTE_ENHANCED_SEARCH_GUIDE},
+    {"2.5.4.48", "protocolInformation", ATTRIBUTE_PROTOCOL_INFORMATION},
+    {"2.5.4.49", "distinguishedName", ATTRIBUTE_DISTINGUISHED_NAME},
+    {"2.5.4.50", "uniqueMember", ATTRIBUTE_UNIQUE_MEMBER},
+    {"2.5.4.51", "houseIdentifier", ATTRIBUTE_HOUSE_IDENTIFIER},
+    {"2.5.4.52", "supportedAlgorithms", ATTRIBUTE_SUPPORTED_ALGORITHMS},
+    {"2.5.4.53", "deltaRevocationList", ATTRIBUTE_DELTA_REVOCATION_LIST},
+    {"2.5.4.54", "dmdName", ATTRIBUTE_DMD_NAME},
+    {"2.5.4.65", "pseudonym", ATTRIBUTE_PSEUDONYM},
+    {"2.5.4.72", "role", ATTRIBUTE_ROLE},
+    {"2.5.4.97", "organizationIdentifier", ATTRIBUTE_ORGANIZATION_IDENTIFIER},
+    {"2.5.4.98", "c3", ATTRIBUTE_C3},
+    {"2.5.4.99", "n3", ATTRIBUTE_N3},
+    {"2.5.4.100", "dnsName", ATTRIBUTE_DNS_NAME},
+    {"1.3.6.1.4.1.311.60.2.1.1", "jurisdictionL", ATTRIBUTE_JURISDICTION_OF_INCORPORATION_LOCALITY_NAME},
+    {"1.3.6.1.4.1.311.60.2.1.2", "jurisdictionST", ATTRIBUTE_JURISDICTION_OF_INCORPORATION_STATE_OR_PROVINCE_NAME},
+    {"1.3.6.1.4.1.311.60.2.1.3", "jurisdictionC", ATTRIBUTE_JURISDICTION_OF_INCORPORATION_COUNTRY_NAME},
+    {"1.2.840.113549.1.9.1", "emailAddress", ATTRIBUTE_EMAIL_ADDRESS}, // deprecated but used by Yara to fill attributes
+};
+
+/// @brief Looks through an array of OID_TO_NAME for the given entry and returns
+/// @brief the matching oid. The matching is case sensistive.
+/// @brief This function is a private helper function and is not meant to be
+/// used directly.
+/// @param[in] oid The OID for which we want the display name
+/// @param[in] oid_table An array of OID_TO_NAME matching structures
+/// @param[in] oid_table_size The number of elements in oid_table
+/// @return A pointer to an oid structure on success, not to be freed
+/// @return NULL otherwise.
+static PCOID_DATA lookup_oid_data(
+    _In_ PCSTR oid,
+    _In_ PCOID_DATA oid_table,
+    _In_ size_t oid_table_size)
+{
+    // we do not test parameters since we are in a private function. Caller is
+    // responsible for what is passed to it.
+
+    for (size_t algo_index = 0; algo_index < oid_table_size; algo_index++)
+    {
+        if (strcmp(oid_table[algo_index].oid, oid) == 0)
+            return &oid_table[algo_index];
+    }
+
+    return NULL;
+}
+
+/// @brief Looks through an array of OID_TO_NAME for the given entry and returns
+/// @brief the matching display name. The matching is case sensistive.
+/// @brief This function is a private helper function and is not meant to be
+/// used directly.
+/// @param[in] oid The OID for which we want the display name
+/// @param[in] oid_table An array of OID_TO_NAME matching structures
+/// @param[in] oid_table_size The number of elements in oid_table
+/// @return A pointer to a string containing the display name on success, not to be freed
+/// @return NULL otherwise.
+static PCSTR lookup_oid_display_name(
+    _In_ PCSTR oid,
+    _In_ PCOID_DATA oid_table,
+    _In_ size_t oid_table_size)
+{
+    // we do not test parameters since we are in a private function. Caller is
+    // responsible for what is passed to it.
+
+    PCOID_DATA data = lookup_oid_data(oid, oid_table, oid_table_size);
+    if (data == NULL)
+    {
+        return NULL;
+    }
+    else
+    {
+        return data->display_name;
+    }
+}
+
+PCSTR get_algorithmname_from_oid(
+    _In_ PCSTR algorithm_oid
+)
+{
+    PCSTR algorithm_display_name = NULL;
+
+    if (algorithm_oid == NULL)
+        return NULL;
+
+    algorithm_display_name = lookup_oid_display_name(
+        algorithm_oid,
+        algorithm_oid_name_matching,
+        _countof(algorithm_oid_name_matching));
+    if (algorithm_display_name == NULL)
+        return NULL;
+
+    return duplicate_string(algorithm_display_name);
+}
+
+PCOID_DATA find_oid_attribute_data(
+    _In_ PCSTR attr_name_oid
+)
+{
+    if (attr_name_oid == NULL)
+        return NULL;
+
+    return lookup_oid_data(
+        attr_name_oid,
+        attribute_name_oid_short_name_matching,
+        _countof(attribute_name_oid_short_name_matching));
+}
+
+PCWSTR find_algorithm_from_algorithm_name(
+    _In_    CONST   PCSTR   algorithm_name
+)
+{
+    if (algorithm_name == NULL)
+      return NULL;
+
+    for (DWORD algorithm_index = 0; algorithm_index < _countof(digest_algorithm_name_to_algorithm); algorithm_index++)
+    {
+        if (strcmp(algorithm_name, digest_algorithm_name_to_algorithm[algorithm_index].algorithm_name) == 0)
+        {
+            return digest_algorithm_name_to_algorithm[algorithm_index].cryptographic_algorithm;
+        }
+    }
+
+    return NULL;
+}
+
+
+INT find_bcrypt_algorithm_from_oid(
+    _In_    PCSTR           algorithm_oid,
+    _Out_   PCWSTR  *CONST  bcrypt_algorithm
+)
+{
+    INT result = -1;
+
+    PCSTR algorithm_name = NULL;
+
+    if (algorithm_oid == NULL || bcrypt_algorithm == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    algorithm_name = get_algorithmname_from_oid(algorithm_oid);
+    if (algorithm_name == NULL)
+        return ERROR_INVALID_VALUE;
+
+    *bcrypt_algorithm = find_algorithm_from_algorithm_name(algorithm_name);
+    GOTO_EXIT_ON_NULL((*bcrypt_algorithm), ERROR_INVALID_VALUE);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (algorithm_name != NULL)
+    {
+        yr_free(algorithm_name);
+        algorithm_name = NULL;
+    }
+
+    return result;
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/signer.c
+++ b/libyara/modules/pe/authenticode-parser/windows/signer.c
@@ -1,0 +1,332 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/authenticode.h>
+
+#include <yara/error.h>
+#include <yara/mem.h>
+
+#include <crypto.h>
+
+#include <authenticode-parser/windows/tools.h>
+#include <authenticode-parser/windows/certificate.h>
+#include <authenticode-parser/windows/cleanup.h>
+#include <authenticode-parser/windows/oid.h>
+#include <authenticode-parser/windows/signer.h>
+
+INT get_signer_info_from_crypt_message(
+    _In_        CONST   HCRYPTMSG           crypt_msg,
+    _In_        CONST   DWORD               signature_index,
+    _Outptr_            PCMSG_SIGNER_INFO*  signer_info
+)
+{
+    INT result = -1;
+
+    PCMSG_SIGNER_INFO local_signer_info = NULL;
+    DWORD signer_info_buffer_size = 0;
+
+    if (crypt_msg == NULL || signer_info == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_SIGNER_INFO_PARAM, signature_index, NULL, &signer_info_buffer_size));
+
+    local_signer_info = (PCMSG_SIGNER_INFO)yr_malloc(signer_info_buffer_size);
+    GOTO_EXIT_ON_NULL(local_signer_info, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_SIGNER_INFO_PARAM, signature_index, local_signer_info, &signer_info_buffer_size));
+
+    *signer_info = local_signer_info;
+    local_signer_info = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_signer_info != NULL)
+    {
+        yr_free(local_signer_info);
+        local_signer_info = NULL;
+    }
+
+    return result;
+}
+
+INT get_unauthenticated_attributes_from_crypt_message(
+    _In_      CONST   HCRYPTMSG           crypt_msg,
+    _In_      CONST   DWORD               signature_index,
+    _Outptr_          PCRYPT_ATTRIBUTES*  crypt_attributes
+)
+{
+    INT result = -1;
+
+    PCRYPT_ATTRIBUTES local_crypt_attributes = NULL;
+    DWORD crypt_attributes_buf_size = 0;
+
+    if (crypt_msg == NULL || crypt_attributes == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    if (CryptMsgGetParam(
+        crypt_msg,
+        CMSG_SIGNER_UNAUTH_ATTR_PARAM,
+        signature_index,
+        NULL,
+        &crypt_attributes_buf_size) == FALSE)
+    {
+        DWORD last_error = GetLastError();
+
+        if (last_error == CRYPT_E_ATTRIBUTES_MISSING)
+        {
+            // This means there is no unauthenticated attribute (no nested signature for example), do not exit with error
+            result = ERROR_SUCCESS;
+        }
+
+        goto _exit;
+    }
+
+    local_crypt_attributes = (PCRYPT_ATTRIBUTES)yr_calloc(1, crypt_attributes_buf_size);
+    GOTO_EXIT_ON_NULL(local_crypt_attributes, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(CryptMsgGetParam(crypt_msg, CMSG_SIGNER_UNAUTH_ATTR_PARAM, signature_index, local_crypt_attributes, &crypt_attributes_buf_size));
+
+    *crypt_attributes = local_crypt_attributes;
+    local_crypt_attributes = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_crypt_attributes != NULL)
+    {
+        yr_free(local_crypt_attributes);
+        local_crypt_attributes = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Look for SPC_SP_OPUS_INFO_OBJID authenticated attribute into signer info, and parse it to get the program name
+/// @param[in]  signer_info Signer info from which to extract the program name
+/// @param[out] signer      Signer Yara data structure into which to store the found program name, if found
+/// @return ERROR_SUCCESS if everything went well, a Yara error code otherwise
+/// @note To get program name, we have to decode SPC_SP_OPUS_INFO_OBJID attribute into SPC_SP_OPUS_INFO has not documented at https://learn.microsoft.com/en-us/windows/win32/seccrypto/constants-for-cryptencodeobject-and-cryptdecodeobject
+static INT extract_program_name_from_signer_info(
+    _In_      CONST   PCMSG_SIGNER_INFO           signer_info,
+    _Inout_           Signer              *CONST  signer
+)
+{
+    INT result = -1;
+
+    ByteArray opus_info_byte_array = {0};
+    BOOL has_opus_info = FALSE;
+
+    PSPC_SP_OPUS_INFO opus_info = NULL;
+
+    PSTR local_program_name = NULL;
+
+    if (signer_info == NULL || signer == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_ERROR(get_attribute_from_crypt_attributes(&signer_info->AuthAttrs, SPC_SP_OPUS_INFO_OBJID, &opus_info_byte_array, &has_opus_info));
+
+    // Should always be present as it is mandatory. But we won't complain if it not present
+    if (has_opus_info)
+    {
+        DWORD opus_info_size = 0;
+
+        // Decode content of the signed message which is CRYPT_TIMESTAMP_INFO
+        GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+            SPC_SP_OPUS_INFO_OBJID,
+            opus_info_byte_array.data, opus_info_byte_array.len,
+            0,
+            NULL,
+            NULL,
+            &opus_info_size));
+
+        opus_info = yr_calloc(1, opus_info_size);
+        GOTO_EXIT_ON_NULL(opus_info, ERROR_INSUFFICIENT_MEMORY);
+        
+        GOTO_EXIT_ON_FAIL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+            SPC_SP_OPUS_INFO_OBJID,
+            opus_info_byte_array.data, opus_info_byte_array.len,
+            0,
+            NULL,
+            opus_info,
+            &opus_info_size));
+
+        // Opus info attribute is mandatory, but program name is not
+        if (opus_info->pwszProgramName != NULL)
+        {
+            GOTO_EXIT_ON_ERROR(widechar_utf8_to_multibytes(opus_info->pwszProgramName,
+                wcslen(opus_info->pwszProgramName),
+                &signer->program_name));
+        }
+    }
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (opus_info != NULL)
+    {
+        yr_free(opus_info);
+        opus_info = NULL;
+    }
+
+    cleanup_byte_array(&opus_info_byte_array);
+
+    return result;
+}
+
+INT parse_signer_authenticode(
+  _In_      CONST   PCMSG_SIGNER_INFO           signer_info,
+  _In_      CONST   HCERTSTORE                  cert_store,
+  _Outptr_          Signer*             *CONST  signer
+)
+{
+    INT result = -1;
+
+    Signer* local_signer = NULL;
+
+    if (signer == NULL || signer_info == NULL || cert_store == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    local_signer = yr_calloc(1, sizeof(Signer));
+    GOTO_EXIT_ON_NULL(local_signer, ERROR_INSUFFICIENT_MEMORY);
+
+    // Get digest algorithm
+    {
+        PCSTR hash_algorithm = get_algorithmname_from_oid(signer_info->HashAlgorithm.pszObjId);
+        if (hash_algorithm != NULL)
+        {
+            local_signer->digest_alg = duplicate_string(hash_algorithm);
+            GOTO_EXIT_ON_NULL(local_signer->digest_alg, ERROR_INSUFFICIENT_MEMORY);
+        }
+    }
+
+    // Get program name
+    GOTO_EXIT_ON_ERROR(extract_program_name_from_signer_info(signer_info, local_signer));
+
+    // Get digest
+    GOTO_EXIT_ON_ERROR(get_digest_attribute_from_crypt_attributes(&signer_info->AuthAttrs, szOID_PKCS_9_MESSAGE_DIGEST, &local_signer->digest, NULL));
+
+    // Build certificate chain
+    GOTO_EXIT_ON_ERROR(build_certificate_chain_from_signer_info(cert_store, signer_info, &local_signer->chain));
+
+    *signer = local_signer;
+    local_signer = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_signer != NULL)
+    {
+        destroy_signer(local_signer);
+        local_signer = NULL;
+    }
+
+    return result;
+}
+
+INT verify_signature_from_signer_info(
+    _In_    CONST   HCERTSTORE          cert_store,
+    _In_    CONST   PCMSG_SIGNER_INFO   signer_info,
+    _In_    CONST   PBYTE               digest,
+    _In_    CONST   DWORD               digest_length,
+    _Out_           PBOOL               is_verified
+)
+{
+    INT result = -1;
+    NTSTATUS status = 0;
+
+    PCERT_CONTEXT cert_context = NULL;
+    BCRYPT_KEY_HANDLE key_handle = NULL;
+
+    BCRYPT_PKCS1_PADDING_INFO padding_info = {0};
+
+    if (cert_store == NULL || signer_info == NULL || is_verified == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Extract public key from signer info
+    result = find_signer_certificate_from_signer_info(cert_store, signer_info, &cert_context);
+    GOTO_EXIT_ON_ERROR(result);
+    GOTO_EXIT_ON_FAIL(CryptImportPublicKeyInfoEx2(
+        X509_ASN_ENCODING,
+        &cert_context->pCertInfo->SubjectPublicKeyInfo,
+        0,
+        NULL,
+        &key_handle
+    ));
+
+    // ---------------------------------------------------------------------------------------------------------------------------------------
+    // How to verify signature, quoting https://stackoverflow.com/a/12945098
+    //
+    // Person with private key generating message and signature
+    // originalHash = GenerateHashOfMessage(message);
+    // signature = RsaDecrypt(originalHash, privateKey);
+    //
+    // Receiver validating signed message
+    // hash = GenerateHashOfMessage(message);
+    // originalHash = RsaEncrypt(signature, publicKey);
+    // messageValid = (hash == originalHash);
+    //
+    // If you ever need to check what's inside the "encrypted digest", you can do it like so:
+    //
+    // BYTE buffer[2048] = {0};
+    // DWORD size = 0;
+    // BCryptEncrypt(key_handle, signer_info->EncryptedHash.pbData, signer_info->EncryptedHash.cbData, NULL, NULL, 0, buffer, 2048, &size, 0);
+    //
+    // You'll have to ignore the padding, and decode what's after [0xff][0x00], starting with 0x30
+    // ---------------------------------------------------------------------------------------------------------------------------------------
+
+    // Get BCrypt algorithm constant from hash algorithm object id
+    GOTO_EXIT_ON_ERROR(find_bcrypt_algorithm_from_oid(signer_info->HashAlgorithm.pszObjId, &padding_info.pszAlgId));
+
+    // Verify signature (RSAEncrypt with PKCS1 padding/memcmp)
+    status = BCryptVerifySignature(key_handle,
+        &padding_info,
+        digest, digest_length,
+        signer_info->EncryptedHash.pbData, signer_info->EncryptedHash.cbData,
+        BCRYPT_PAD_PKCS1);
+    *is_verified = (status == 0);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (key_handle != NULL)
+    {
+        BCryptDestroyKey(key_handle);
+        key_handle = NULL;
+    }
+
+    if (cert_context != NULL)
+    {
+        CertFreeCertificateContext(cert_context);
+        cert_context = NULL;
+    }
+
+    return result;
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/authenticode-parser/windows/tools.c
+++ b/libyara/modules/pe/authenticode-parser/windows/tools.c
@@ -1,0 +1,690 @@
+/* Copyright (c) 2024 Stormshield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <yara/error.h>
+#include <yara/mem.h>
+
+#ifdef USE_WINCRYPT_AUTHENTICODE
+
+#include <authenticode-parser/windows/oid.h>
+#include <authenticode-parser/windows/tools.h>
+
+// DER blob types
+// https://luca.ntop.org/Teaching/Appunti/asn1.html
+#define OCTET_STRING_TYPE       0x04
+
+uint64_t filetime_to_epoch(
+    _In_ CONST PFILETIME filetime
+)
+{
+    // FILETIME unit is 100-nanosecond while Unix time base time is the second
+    // 1 / 100e-9 = 10e7
+    CONST uint64_t BASE_TIME_RATIO = 10000000LL;
+
+    // Time offset, in seconds, between FILETIME time reference which is
+    // January 1, 1601 (UTC) and Unix time reference which is January 1, 1970 (UTC)
+    CONST uint64_t SEC_TO_UNIX_EPOCH = 11644473600LL;
+
+    if (filetime == NULL)
+        return 0;
+
+    return ((filetime->dwLowDateTime | (uint64_t)filetime->dwHighDateTime << 32) /
+        BASE_TIME_RATIO -
+        SEC_TO_UNIX_EPOCH);
+}
+
+INT buffer_to_hex(
+    _In_        CONST   size_t          in_buffer_size,
+    _In_        CONST   PBYTE           in_buffer,
+    _Out_               size_t  *CONST  out_buffer_size,
+    _Outptr_            PCSTR   *CONST  out_buffer,
+    _In_        CONST   CHAR            separator,
+    _In_        CONST   BOOL            reverse
+)
+{
+    PSTR out_buffer_local = NULL;
+    size_t out_buffer_size_local = 0;
+    INT result = -1;
+
+    INT input_index = 0;
+    PSTR output_writer = NULL;
+    INT increment = 0;
+
+    if (in_buffer == NULL || out_buffer == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Compute required size (BufferSize * TwoChar + EndString)
+    out_buffer_size_local = in_buffer_size * 2 + 1;
+
+    // Add a place for separator for each element, except the last one
+    if (separator != PE_WINCRYPT_TOOLS_NO_SEPARATOR_CHAR)
+        out_buffer_size_local += (in_buffer_size - 1);
+
+    out_buffer_local = yr_calloc(out_buffer_size_local, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(out_buffer_local, ERROR_INSUFFICIENT_MEMORY);
+
+    output_writer = out_buffer_local;
+
+    if (reverse == FALSE)
+    {
+        input_index = 0;
+        increment = 1;
+    }
+    else
+    {
+        input_index = in_buffer_size - 1;
+        increment = -1;
+    }
+
+    for (size_t processed_counter = 0; processed_counter < in_buffer_size; processed_counter++)
+    {
+        CONST BOOL is_last = processed_counter == (in_buffer_size - 1);
+
+        CONST size_t consumed_size = output_writer - out_buffer_local;
+        CONST size_t available_size = out_buffer_size_local - consumed_size;
+
+        output_writer += sprintf_s(
+            output_writer, available_size, "%02x", in_buffer[input_index]);
+
+        if (separator != PE_WINCRYPT_TOOLS_NO_SEPARATOR_CHAR && is_last == false)
+        {
+            *output_writer = separator;
+            output_writer++;
+        }
+
+        input_index += increment;
+    }
+
+    out_buffer_local[out_buffer_size_local - 1] = '\0';
+
+    if (out_buffer_size != NULL)
+        *out_buffer_size = out_buffer_size_local;
+
+    *out_buffer = out_buffer_local;
+    out_buffer_local = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (out_buffer_local != NULL)
+    {
+        yr_free(out_buffer_local);
+        out_buffer_local = NULL;
+    }
+
+    return result;
+}
+
+PSTR duplicate_string(
+    _In_  PCSTR source
+)
+{
+    size_t length = 0;
+
+    if (source == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen(source);
+    if (length <= 0)
+        return NULL;
+
+    PSTR output = (PSTR)yr_calloc(length + 1, sizeof(CHAR));
+    if (output == NULL)
+        return NULL;
+
+    return strcpy(output, source);
+}
+
+INT widechar_utf8_to_multibytes(
+  _In_      CONST   PVOID           data,
+  _In_      CONST   DWORD           data_length,
+  _Outptr_          PSTR    *CONST  multibyte_string
+)
+{
+    INT result = -1;
+
+    PSTR buffer = NULL;
+
+    INT needed_length = 0;
+
+    if (data == NULL || multibyte_string == NULL)
+    {
+        return ERROR_INVALID_ARGUMENT;
+    }
+
+    needed_length = WideCharToMultiByte(CP_UTF8, 0,
+        (PWCH)data, data_length,
+        NULL, 0,
+        NULL, NULL);
+    GOTO_EXIT_ON_FAIL(needed_length > 0);
+
+    needed_length++;
+
+    buffer = (PSTR)yr_calloc(needed_length, sizeof(char));
+    GOTO_EXIT_ON_NULL(buffer, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(WideCharToMultiByte(CP_UTF8, 0,
+        (PWCH)data, data_length,
+        buffer, needed_length,
+        NULL, NULL) < needed_length);
+
+    *multibyte_string = buffer;
+    buffer = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (buffer != NULL)
+    {
+        yr_free(buffer);
+        buffer = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Converts the given widechar UTF8 string to a multibyte one, and converts non ASCII character into \xXX to match OpenSSL behavior
+/// @param[in]  data            Widechar UTF8 data blob
+/// @param[in]  data_length     Length of the widechar UTF8 data blob
+/// @param[out] final_string    Resulting string, to be freed using yr_free
+static INT convert_to_multibyte_formatting_unknown_character_to_hexa(
+    _In_      CONST   PVOID           data,
+    _In_      CONST   DWORD           data_length,
+    _Outptr_          PSTR    *CONST  final_string
+)
+{
+    INT result = -1;
+
+    PSTR buffer = NULL;
+    size_t buffer_length = 0;
+
+    DYNAMIC_STRING dynstring = {0};
+
+    GOTO_EXIT_ON_ERROR(widechar_utf8_to_multibytes(data, (DWORD)wcsnlen_s(data, data_length), &buffer));
+
+    GOTO_EXIT_ON_ERROR(dynamic_string_init(&dynstring));
+
+    buffer_length = strlen(buffer);
+    for (size_t index = 0; index < buffer_length; index++)
+    {
+        if ((unsigned char)buffer[index] >= 128)
+        {
+            BYTE character[5] = {0};
+            sprintf_s(character, 5, "\\x%02X", (BYTE)buffer[index]);
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring, character));
+        }
+        else
+        {
+            BYTE character[2] = {buffer[index], 0};
+            GOTO_EXIT_ON_ERROR(dynamic_string_append(&dynstring, character));
+        }
+    }
+
+    *final_string = duplicate_string(dynstring.buffer);
+    if (*final_string == NULL)
+    {
+        result = ERROR_INSUFFICIENT_MEMORY;
+        goto _exit;
+    }
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    dynamic_string_free(&dynstring);
+
+    if (buffer != NULL)
+    {
+        yr_free(buffer);
+        buffer = NULL;
+    }
+
+  return result;
+}
+
+INT get_string_value_from_cert_rdn_value_blob(
+    _In_        CONST   PCERT_RDN_ATTR          cert_rdn_attr,
+    _Outptr_            PSTR            *CONST  value
+)
+{
+    INT result = -1;
+
+    PSTR local_value = NULL;
+
+    switch (cert_rdn_attr->dwValueType)
+    {
+    case CERT_RDN_UTF8_STRING:
+        GOTO_EXIT_ON_ERROR(convert_to_multibyte_formatting_unknown_character_to_hexa(cert_rdn_attr->Value.pbData, cert_rdn_attr->Value.cbData, &local_value));
+        break;
+
+    default:
+        local_value = duplicate_string(cert_rdn_attr->Value.pbData);
+        GOTO_EXIT_ON_NULL(local_value, ERROR_INSUFFICIENT_MEMORY);
+        break;
+    }
+
+    *value = local_value;
+    local_value = NULL;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_value != NULL)
+    {
+        yr_free(local_value);
+        local_value = NULL;
+    }
+
+    return result;
+}
+
+INT get_digest_attribute_from_crypt_attributes(
+    _In_    CONST   PCRYPT_ATTRIBUTES           crypt_attributes,
+    _In_            PCSTR                       attribute_oid,
+    _Out_           ByteArray           *CONST  byte_array,
+    _Out_opt_       PBOOL                       is_found
+)
+{
+    BOOL local_is_found = FALSE;
+
+    if (crypt_attributes == NULL || attribute_oid == NULL || byte_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    for (DWORD index = 0; index < crypt_attributes->cAttr; index++)
+    {
+        PCRYPT_ATTRIBUTE crypt_attribute = &crypt_attributes->rgAttr[index];
+
+        if (strcmp(crypt_attribute->pszObjId, attribute_oid) == 0 &&
+            // as we want to check header, we need to make sure the length is correct (1 byte for type/1 byte for length)
+            crypt_attribute->rgValue[0].cbData > 2 &&
+            // check if this is indeed an OCTET STRING
+            crypt_attribute->rgValue[0].pbData[0] == OCTET_STRING_TYPE)
+        {
+            copy_data_to_byte_array(
+                crypt_attribute->rgValue[0].pbData + 2 /* exclude DER header */,
+                crypt_attribute->rgValue[0].cbData - 2 /* exclude DER header */,
+                byte_array
+            );
+
+            local_is_found = TRUE;
+
+            break;
+        }
+    }
+
+    if (is_found != NULL)
+        *is_found = local_is_found;
+    
+    return ERROR_SUCCESS;
+}
+
+INT get_rsa_signing_time_attribute_from_crypt_attributes(
+    _In_    CONST   PCRYPT_ATTRIBUTES   crypt_attributes,
+    _Out_           PULONGLONG          epoch,
+    _Out_opt_       PBOOL               is_found
+)
+{
+    BOOL local_is_found = FALSE;
+
+    if (crypt_attributes == NULL || time == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    for (DWORD index = 0; index < crypt_attributes->cAttr; index++)
+    {
+        PCRYPT_ATTRIBUTE crypt_attribute = &crypt_attributes->rgAttr[index];
+
+        if (strcmp(crypt_attribute->pszObjId, szOID_RSA_signingTime) == 0)
+        {
+            FILETIME file_time = {0};
+            DWORD size = sizeof(FILETIME);
+
+            if (CryptDecodeObject(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, szOID_RSA_signingTime, crypt_attribute->rgValue[0].pbData, crypt_attribute->rgValue[0].cbData, 0, &file_time, &size) == FALSE)
+            {
+                return ERROR_INVALID_VALUE;
+            }
+
+            *epoch = filetime_to_epoch(&file_time);
+
+            local_is_found = TRUE;
+
+            break;
+        }
+    }
+
+    if (is_found != NULL)
+        *is_found = local_is_found;
+
+    return ERROR_SUCCESS;
+}
+
+INT copy_data_to_byte_array(
+    _In_    CONST   PBYTE               data,
+    _In_    CONST   DWORD               length,
+    _Out_           ByteArray   *CONST  byte_array
+)
+{
+    INT result = -1;
+
+    if (data == NULL || length == 0 || byte_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    byte_array->data = yr_calloc(length, sizeof(uint8_t));
+    GOTO_EXIT_ON_NULL(byte_array->data, ERROR_INSUFFICIENT_MEMORY);
+
+    byte_array->len = length;
+    memcpy(byte_array->data, data, byte_array->len);
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    return result;
+}
+
+INT get_attribute_from_crypt_attributes(
+    _In_        CONST   PCRYPT_ATTRIBUTES           crypt_attributes,
+    _In_                PCSTR                       attribute_oid,
+    _Out_               ByteArray           *CONST  byte_array,
+    _Out_opt_           PBOOL                       is_found
+)
+{
+    INT result = -1;
+
+    BOOL local_is_found = FALSE;
+
+    if (crypt_attributes == NULL || attribute_oid == NULL || byte_array == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    for (DWORD index = 0; index < crypt_attributes->cAttr; index++)
+    {
+        PCRYPT_ATTRIBUTE crypt_attribute = &crypt_attributes->rgAttr[index];
+
+        if (strcmp(crypt_attribute->pszObjId, attribute_oid) == 0)
+        {
+            GOTO_EXIT_ON_ERROR(copy_data_to_byte_array(crypt_attribute->rgValue[0].pbData, crypt_attribute->rgValue[0].cbData, byte_array));
+            local_is_found = TRUE;
+            break;
+        }
+    }
+
+    if (is_found != NULL)
+        *is_found = local_is_found;
+  
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    return result;
+}
+
+INT compute_blob_digest(
+    _In_        CONST   PCWSTR          bcrypt_digest_algorithm,
+    _In_        CONST   PBYTE           data_to_digest,
+    _In_        CONST   DWORD           data_to_digest_length,
+    _Outptr_            PBYTE   *CONST  digest,
+    _Out_               PDWORD          digest_length
+)
+{
+    INT result = -1;
+
+    BCRYPT_ALG_HANDLE algorithm_handle = NULL;
+    BCRYPT_HASH_HANDLE hash_handle = NULL;
+
+    DWORD bytes_copied = 0;
+
+    PBYTE digest_object = NULL;
+    DWORD digest_object_size = 0;
+
+    PBYTE local_digest = NULL;
+    DWORD local_digest_length = 0;
+
+    if (bcrypt_digest_algorithm == NULL || data_to_digest == NULL || digest == NULL || digest_length == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&algorithm_handle, bcrypt_digest_algorithm, NULL, 0))
+    );
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptGetProperty(algorithm_handle, BCRYPT_OBJECT_LENGTH, (PBYTE)&digest_object_size, sizeof(DWORD), &bytes_copied, 0))
+    );
+    GOTO_EXIT_ON_FAIL(bytes_copied == sizeof(DWORD));
+
+    digest_object = yr_calloc(digest_object_size, sizeof(UCHAR));
+    GOTO_EXIT_ON_NULL(digest_object, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptCreateHash(algorithm_handle, &hash_handle, digest_object, digest_object_size, NULL, 0, 0))
+    );
+
+    /* Calculate size of the space between file start and PE header */
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptHashData(hash_handle, data_to_digest, data_to_digest_length, 0))
+    );
+
+    // Finalize digest
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptGetProperty(algorithm_handle, BCRYPT_HASH_LENGTH, (PBYTE)&local_digest_length, sizeof(DWORD), &bytes_copied, 0))
+    );
+    GOTO_EXIT_ON_FAIL(bytes_copied == sizeof(DWORD));
+
+    local_digest = (PUCHAR)yr_calloc(local_digest_length, sizeof(BYTE));
+    GOTO_EXIT_ON_NULL(local_digest, ERROR_INSUFFICIENT_MEMORY);
+
+    GOTO_EXIT_ON_FAIL(
+        BCRYPT_SUCCESS(BCryptFinishHash(hash_handle, local_digest, local_digest_length, 0))
+    );
+
+    *digest = local_digest;
+    local_digest = NULL;
+    *digest_length = local_digest_length;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    if (local_digest != NULL)
+    {
+        yr_free(local_digest);
+        local_digest = NULL;
+    }
+
+    if (hash_handle != NULL)
+    {
+        BCryptDestroyHash(hash_handle);
+        hash_handle = NULL;
+    }
+
+    if (digest_object != NULL)
+    {
+        yr_free(digest_object);
+        digest_object = NULL;
+    }
+
+    if (algorithm_handle != NULL)
+    {
+        BCryptCloseAlgorithmProvider(algorithm_handle, 0);
+        algorithm_handle = NULL;
+    }
+
+    return result;
+}
+
+/// @brief Evaluates the immediate superior value that is a powers of 2 for the
+///        given parameter
+/// @param[in] requested_size The value to be rounded to the closest higher
+///                           power of 2 value.
+/// @return The computed power of 2.
+static __inline size_t dynamic_string_compute_power_of_2(
+  _In_  CONST   size_t  requested_size
+)
+{
+    DWORD leading_zeroes = 0;
+
+    // Here we just detect which is the bit index of the msb in requested_size,
+    // then we add one to this index and we use it as a bit shift to compute the
+    // final result The values zero and and one are special values: in these
+    // cases, we return 1.
+    if (requested_size != 1 &&
+        _BitScanReverse(&leading_zeroes, requested_size - 1))
+    {
+        return 1 << (1 + leading_zeroes);
+    }
+
+    return 1;
+}
+
+/// @brief Performs a buffer allocation for a DYNAMIC_STRING, following a "power of 2" rule
+///        for the requested size, meaning that the size asked by the caller will be rounded 
+///        to the closest higher value that is a 2^n. This can limit the impact of fast reallocation
+///        due to small size requests.
+/// @param[in] requested_size The number of bytes to allocate. This value will be rounded to the 
+///                           closest higher power of 2 value. For instance, if the caller asks
+///                           for a 37 bytes, 2^6 = 64 bytes will be effectively allocated.
+/// @param[out] dynamic_string A pointer to the DYNAMIC_STRING for which we perform the allocation
+/// @return ERROR_SUCCESS on success
+/// @return A Yara error code otherwise
+/// @note A potential already existing buffer of a DYNAMIC_STRING is not tested or managed
+/// @note by this function. The memory asociated can therefore be lost. It is of the responsibilty 
+/// @note of the caller to ensure that the passed DYNAMIC_STRING is clear.
+/// @note The maximum allocation 
+static INT dynamic_string_allocate_power_of_2(
+    _In_  CONST   size_t          requested_size,
+    _Out_ CONST   PDYNAMIC_STRING dynamic_string
+)
+{
+    INT result = -1;
+
+    CONST size_t max_allocation_size = 0x1000;
+
+    LPSTR tmp_buffer = NULL;
+    size_t allocation_size = 0;
+
+    if (dynamic_string == NULL || requested_size == 0 || requested_size > max_allocation_size)
+        return ERROR_INVALID_ARGUMENT;
+
+    // Find the closest 2^n value
+    allocation_size = dynamic_string_compute_power_of_2(requested_size);
+
+    tmp_buffer = yr_malloc(allocation_size);
+    GOTO_EXIT_ON_NULL(tmp_buffer, ERROR_INSUFFICIENT_MEMORY);
+
+    dynamic_string->buffer = tmp_buffer;
+    tmp_buffer = NULL;
+
+    dynamic_string->buffer_size = allocation_size;
+
+    result = ERROR_SUCCESS;
+
+_exit:
+
+    return result;
+}
+
+/// @brief Reallocates the buffer of a DYNAMIC_STRING if the new requested size is higher than the current capacity.
+///        If so, the previous buffer is released. The content is preserved and copied to the new buffer.
+/// @param[in] requested_size The size in bytes for the new buffer.
+/// @param[in,out] dynamic_string A pointer to the DYNAMIC_STRING to update.
+/// @return ERROR_SUCCESS on success
+/// @return A Yara error code otherwise
+static INT dynamic_string_extend_buffer(
+    _In_    CONST   size_t          requested_size,
+    _Inout_ CONST   PDYNAMIC_STRING dynamic_string
+)
+{
+    DYNAMIC_STRING tmp_dynamic_string = {0};
+
+    if (dynamic_string == NULL || requested_size == 0)
+        return ERROR_INVALID_ARGUMENT;
+
+    if (requested_size <= dynamic_string->buffer_size)
+        return ERROR_SUCCESS;  // nothing to do
+
+    FAIL_ON_ERROR(dynamic_string_allocate_power_of_2(requested_size, &tmp_dynamic_string));
+
+    memcpy(tmp_dynamic_string.buffer, dynamic_string->buffer, dynamic_string->buffer_size);
+
+    yr_free(dynamic_string->buffer);
+
+    *dynamic_string = tmp_dynamic_string;
+
+    return ERROR_SUCCESS;
+}
+
+INT dynamic_string_append(
+  _Inout_   CONST   PDYNAMIC_STRING dynamic_string,
+  _In_              PCSTR           str_append
+)
+{
+    size_t current_size = 0;
+    size_t required_size = 0;
+
+    INT result = -1;
+
+    if (dynamic_string == NULL || str_append == NULL)
+        return ERROR_INVALID_ARGUMENT;
+
+    current_size = strnlen_s(dynamic_string->buffer, dynamic_string->buffer_size);
+    required_size = current_size + strlen(str_append) + 1;
+
+    if (dynamic_string->buffer_size < required_size)
+    {
+        FAIL_ON_ERROR(dynamic_string_extend_buffer(required_size, dynamic_string));
+    }
+
+    memcpy(dynamic_string->buffer + current_size, str_append, strlen(str_append));
+
+    return ERROR_SUCCESS;
+}
+
+INT dynamic_string_init(
+    _Out_   CONST   PDYNAMIC_STRING dynamic_string
+)
+{
+    CONST size_t default_size = 64;
+
+    if (dynamic_string == NULL ||
+        dynamic_string->buffer != NULL ||
+        dynamic_string->buffer_size > 0)
+        return ERROR_INVALID_ARGUMENT;
+
+    return dynamic_string_allocate_power_of_2(default_size, dynamic_string);
+}
+
+VOID dynamic_string_free(
+  _Inout_   PDYNAMIC_STRING dynamic_string
+)
+{
+    if (dynamic_string == NULL)
+        return;
+
+    if (dynamic_string->buffer != NULL)
+        yr_free(dynamic_string->buffer);
+
+    dynamic_string->buffer = NULL;
+    dynamic_string->buffer_size = 0;
+}
+
+#endif // USE_WINCRYPT_AUTHENTICODE

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -32,10 +32,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 
 #include "../crypto.h"
-#if defined(HAVE_LIBCRYPTO)
+#if defined(HAVE_LIBCRYPTO) || (defined(HAVE_CRYPTO_WINCRYPT) && defined(USE_WINCRYPT_AUTHENTICODE))
 #include <authenticode-parser/authenticode.h>
+#endif // HAVE_LIBCRYPTO || (HAVE_CRYPTO_WINCRYPT && USE_WINCRYPT_AUTHENTICODE)
+
+#if defined(HAVE_LIBCRYPTO)
 #include <openssl/evp.h>
-#endif
+#endif // HAVE_LIBCRYPTO
 
 #include <yara/dotnet.h>
 #include <yara/endian.h>
@@ -1697,7 +1700,7 @@ static void pe_parse_exports(PE* pe)
 // some features used in pe_parse_certificates, if you are using BoringSSL
 // instead of OpenSSL you should define BORINGSSL for YARA to compile properly,
 // but you won't have signature-related features in the PE module.
-#if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
+#if (defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)) || (defined(HAVE_CRYPTO_WINCRYPT) && defined(USE_WINCRYPT_AUTHENTICODE))
 
 #define write_certificate(cert, pe, fmt, ...)                                  \
   do                                                                           \
@@ -3835,7 +3838,7 @@ begin_declarations
   declare_integer("number_of_resources");
   declare_string("pdb_path");
 
-#if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
+#if (defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)) || (defined(HAVE_CRYPTO_WINCRYPT) && defined(USE_WINCRYPT_AUTHENTICODE))
   begin_struct_array("signatures")
     declare_string("thumbprint");
     declare_string("issuer");
@@ -3921,7 +3924,7 @@ end_declarations
 
 int module_initialize(YR_MODULE* module)
 {
-#if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
+#if (defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)) || (defined(HAVE_CRYPTO_WINCRYPT) && defined(USE_WINCRYPT_AUTHENTICODE))
   // Initialize OpenSSL global objects for the auth library before any
   // multithreaded environment as it is not thread-safe. This can
   // only be called once per process.
@@ -4328,7 +4331,7 @@ int module_load(
         pe_parse_rich_signature(pe, block->base);
         pe_parse_debug_directory(pe);
 
-#if defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)
+#if (defined(HAVE_LIBCRYPTO) && !defined(BORINGSSL)) || (defined(HAVE_CRYPTO_WINCRYPT) && defined(USE_WINCRYPT_AUTHENTICODE))
         pe_parse_certificates(pe);
 #endif
 

--- a/windows/vs2015/libyara/libyara.vcxproj
+++ b/windows/vs2015/libyara/libyara.vcxproj
@@ -89,7 +89,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -116,7 +116,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVER_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -143,7 +143,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -168,7 +168,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -195,7 +195,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B;NDEBUG=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B;NDEBUG=1</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -252,6 +252,14 @@
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\countersignature.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\structs.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\authenticode.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\cleanup.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\countersignature.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\extractors.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\oid.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\signer.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\tools.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe_utils.c" />
     <ClCompile Include="..\..\..\libyara\modules\string\string.c" />
     <ClCompile Include="..\..\..\libyara\modules\tests\tests.c" />

--- a/windows/vs2015/libyara/libyara.vcxproj
+++ b/windows/vs2015/libyara/libyara.vcxproj
@@ -116,7 +116,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVER_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>

--- a/windows/vs2015/yara/yara.vcxproj
+++ b/windows/vs2015/yara/yara.vcxproj
@@ -101,7 +101,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -120,7 +120,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
@@ -142,7 +142,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>
@@ -167,7 +167,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>

--- a/windows/vs2015/yarac/yarac.vcxproj
+++ b/windows/vs2015/yarac/yarac.vcxproj
@@ -102,7 +102,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -121,7 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -144,7 +144,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
@@ -166,7 +166,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>

--- a/windows/vs2017/libyara/libyara.vcxproj
+++ b/windows/vs2017/libyara/libyara.vcxproj
@@ -88,7 +88,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -115,7 +115,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -142,7 +142,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -167,7 +167,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -194,7 +194,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;NDEBUG=1;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;NDEBUG=1;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -251,6 +251,14 @@
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\countersignature.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\structs.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\authenticode.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\cleanup.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\countersignature.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\extractors.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\oid.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\signer.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\tools.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe_utils.c" />
     <ClCompile Include="..\..\..\libyara\modules\string\string.c" />
     <ClCompile Include="..\..\..\libyara\modules\tests\tests.c" />

--- a/windows/vs2017/yara/yara.vcxproj
+++ b/windows/vs2017/yara/yara.vcxproj
@@ -101,7 +101,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -120,7 +120,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
@@ -142,7 +142,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>
@@ -167,7 +167,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>

--- a/windows/vs2017/yarac/yarac.vcxproj
+++ b/windows/vs2017/yarac/yarac.vcxproj
@@ -102,7 +102,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -121,7 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -144,7 +144,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
@@ -166,7 +166,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>

--- a/windows/vs2019/libyara/libyara.vcxproj
+++ b/windows/vs2019/libyara/libyara.vcxproj
@@ -88,7 +88,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -115,7 +115,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIBC;YR_PROFILING_ENABLED;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -142,7 +142,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x86.1.1.0\include;..\packages\YARA.OpenSSL.x86.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -167,7 +167,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -194,7 +194,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='StaticRelease|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_LIBCRYPTO;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;NDEBUG=1;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_WINCRYPT_AUTHENTICODE;_CRT_SECURE_NO_WARNINGS;CUCKOO_MODULE;HASH_MODULE;DOTNET_MODULE;HAVE_WINCRYPT_H;USE_WINDOWS_PROC;YR_BUILDING_STATIC_LIB;NDEBUG=1;BUCKETS_128;CHECKSUM_1B</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\libyara;..\..\..\libyara\include;..\..\..;..\packages\YARA.Jansson.x64.1.1.0\include;..\packages\YARA.OpenSSL.x64.1.1.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4005;4273;4090</DisableSpecificWarnings>
       <CompileAs>CompileAsC</CompileAs>
@@ -251,6 +251,14 @@
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\countersignature.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\structs.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\authenticode.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\certificate.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\cleanup.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\countersignature.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\extractors.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\oid.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\signer.c" />
+    <ClCompile Include="..\..\..\libyara\modules\pe\authenticode-parser\windows\tools.c" />
     <ClCompile Include="..\..\..\libyara\modules\pe\pe_utils.c" />
     <ClCompile Include="..\..\..\libyara\modules\string\string.c" />
     <ClCompile Include="..\..\..\libyara\modules\tests\tests.c" />

--- a/windows/vs2019/yara/yara.vcxproj
+++ b/windows/vs2019/yara/yara.vcxproj
@@ -101,7 +101,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -120,7 +120,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
@@ -142,7 +142,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>
@@ -167,7 +167,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>No</GenerateDebugInformation>

--- a/windows/vs2019/yarac/yarac.vcxproj
+++ b/windows/vs2019/yarac/yarac.vcxproj
@@ -102,7 +102,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -121,7 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
@@ -144,7 +144,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
@@ -166,7 +166,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\libyara\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;ws2_32.lib;crypt32.lib;libyara$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Hi,

In the context of a Stormshield internal project, we could not use OpenSSL in libyara. Due to this fact, we developped an alternate version of authenticode parser using only Windows APIs.
We decided to go opensource on it as it could help others in the same situation to go without OpenSSL.

We're opened to do edits on anything if needed,
Best regards.