### PR TITLE
Update of documentation - added info about yr_fetch_block_data

### DIFF
--- a/docs/writingmodules.rst
+++ b/docs/writingmodules.rst
@@ -659,7 +659,7 @@ checks in your code nevertheless). In those cases you can use the
         block = first_memory_block(context);
         if (block != NULL)
         {
-          block_data = block->fetch_data(block)
+          block_data = yr_fetch_block_data(block)
 
           if (block_data != NULL)
           {
@@ -668,15 +668,15 @@ checks in your code nevertheless). In those cases you can use the
         }
     }
 
-In the previous example you can also see how to use the ``fetch_data`` function.
-This function, which is a member of the ``YR_MEMORY_BLOCK`` structure, receives
-a pointer to the same block (as a ``self`` or ``this`` pointer) and returns a
-pointer to the block's data. Your module doesn't own the memory pointed to by
-this pointer, freeing that memory is not your responsibility. However keep in
-mind that the pointer is valid only until you ask for the next memory block. As
-long as you use the pointer within the scope of a ``foreach_memory_block`` you
-are on the safe side. Also take into account that ``fetch_data`` can return a
-NULL pointer, your code must be prepared for that case.
+In the previous example you can also see how to use the ``yr_fetch_block_data``
+function. This function receives a pointer to the same block (as a ``self`` or
+``this`` pointer) and returns a pointer to the block's data. Your module
+doesn't own the memory pointed to by this pointer, freeing that memory is not
+your responsibility. However keep in mind that the pointer is valid only until
+you ask for the next memory block. As long as you use the pointer within the
+scope of a ``foreach_memory_block`` you are on the safe side. Also take into
+account that ``yr_fetch_block_data`` can return a NULL pointer, your code must
+be prepared for that case.
 
 .. code-block:: c
 
@@ -684,7 +684,7 @@ NULL pointer, your code must be prepared for that case.
 
     foreach_memory_block(context, block)
     {
-      block_data = block->fetch_data(block);
+      block_data = yr_fetch_block_data(block);
 
       if (block_data != NULL)
       {


### PR DESCRIPTION
Hi, I noticed that in [PR#2020](https://github.com/VirusTotal/yara/pull/2020) the function `yr_fetch_block_data`  has been added  for better exception handling. This function has replaced the previous "raw" call of `block->fetch_data` in modules. But saw that the new function for fetching data is not mentioned in the documentation (especially in the [writingmodules.rst](https://github.com/VirusTotal/yara/blob/master/docs/writingmodules.rst#accessing-the-scanned-data) file, where there is a section focused on fetching the data), which in my opinion can be misleading for devs, that will be creating the new modules. Therefore I've changed this section to make it more up-to-date and to suggest the new function for fetching the data.
