### PR TITLE
Fix the workflow that runs tests in MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         run: make clean && make
 
   macosx-build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
For some reason the `jansson` library is not being found in the latest MacOS version, even though `brew` seems to be installing it.