### PR TITLE
Add --strict-escape to CLI --help and docs

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -148,6 +148,12 @@ Available options are:
 
   Scan files listed in FILE, one per line.
 
+.. option:: --strict-escape
+
+  Print warnings if a string contains an invalid escape sequence.
+
+  .. versionadded:: 4.5.0
+
 .. option:: -z <size> --skip-larger=<size>
 
   Skip files larger than the given <size> in bytes when scanning a directory.

--- a/yara.man
+++ b/yara.man
@@ -103,6 +103,9 @@ in bytes when scanning a directory.
 Set maximum stack size to the specified number of
 .I slots.
 .TP
+.BI "    --strict-escape"
+Print warnings if rules contain ambiguous escape statements.
+.TP
 .BI \-t " tag" " --tag=" tag
 Print rules tagged as
 .I tag


### PR DESCRIPTION
While looking at the release docs i saw there is a new option --strict-escape which didn't make it into the docs. Here I attempt to fix this.

Special attention should be given to the .man file as I have never edited a file of this type previously.