### PR TITLE
filemap: define PROC_SUPER_MAGIC, avoid linux/magic.h

### DIFF
--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -159,7 +159,12 @@ YR_API int yr_filemap_map_fd(
 
 #ifdef __linux__
 #include <sys/vfs.h>
-#include <linux/magic.h>
+// This constant can be found in linux/magic.h and the statfs(2) manpage.
+// 
+// We don't want to include linux/magic.h here because it may not be
+// available in cross-build environments, see
+// https://github.com/Hugal31/yara-rust/issues/115
+#define PROC_SUPER_MAGIC 0x9fa0
 #endif
 
 #define MAP_EXTRA_FLAGS 0


### PR DESCRIPTION
PR #1848 caused build issues with some "unusual" build configurations – apparently we can't rely on linux/magic.h being present when cross-building for musl libc.

Defining PROC_SUPER_MAGIC should not cause a problems since it should be considered part of the Linux kernel/user API and it is unlikely to change.