### PR TITLE
Split YR_MAX_ATOM_LENGTH for string and re, and optimize the extract algorithm of regular atom to speed up the scan.

### DIFF
--- a/libyara/include/yara/atoms.h
+++ b/libyara/include/yara/atoms.h
@@ -41,6 +41,7 @@ typedef struct YR_ATOM YR_ATOM;
 typedef struct YR_ATOM_TREE_NODE YR_ATOM_TREE_NODE;
 typedef struct YR_ATOM_TREE YR_ATOM_TREE;
 
+typedef struct YR_ATOM_NODE_LIST YR_ATOM_NODE_LIST;
 typedef struct YR_ATOM_LIST_ITEM YR_ATOM_LIST_ITEM;
 
 typedef struct YR_ATOM_QUALITY_TABLE_ENTRY YR_ATOM_QUALITY_TABLE_ENTRY;
@@ -70,6 +71,13 @@ struct YR_ATOM_TREE_NODE
 struct YR_ATOM_TREE
 {
   YR_ATOM_TREE_NODE* root_node;
+};
+
+struct YR_ATOM_NODE_LIST
+{
+    YR_ATOM atom;
+    RE_NODE* re_nodes[YR_MAX_ATOM_RE_LENGTH];
+    YR_ATOM_NODE_LIST* next;
 };
 
 struct YR_ATOM_LIST_ITEM

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -60,11 +60,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_MAX_COMPILER_ERROR_EXTRA_INFO 256
 #endif
 
-// Maximum size for the substring (atoms) extracted from strings and regular
+// Maximum size for the substring (atoms) extracted from regular
 // expressions and put into the Aho-Corasick automaton. The maximum allows size
 // for this constant is 255.
+#ifndef YR_MAX_ATOM_RE_LENGTH
+#define YR_MAX_ATOM_RE_LENGTH 8
+#endif
+
+// Maximum size for the substring (atoms) extracted from strings
+// and put into the Aho-Corasick automaton. The maximum allows size
+// for this constant is 255.
 #ifndef YR_MAX_ATOM_LENGTH
-#define YR_MAX_ATOM_LENGTH 4
+#define YR_MAX_ATOM_LENGTH 8
+#endif
+
+// Minimum size for the substring(atoms) extracted from regular
+// expressions and put into the Aho-Corasick automaton. The minimum 
+// is advised to set based on real rules. If the minimum is too large,
+// the atom may be extracted failed, and if the minimum is too small, the quality of atom may be a little low.
+#ifndef YR_MIN_VALID_ATOM_LENGTH
+#define YR_MIN_VALID_ATOM_LENGTH 4
 #endif
 
 #ifndef YR_MAX_ATOM_QUALITY


### PR DESCRIPTION
First, split YR_MAX_ATOM_LENGTH to YR_MAX_ATOM_RE_LENGTH and YR_MAX_ATOM_LENGTH. For string, its length could  increase from 4 to more large e.g. 8, and this change can speed up the scan. For re, if we just increase the length of re atom, the number atoms may increases exponentially becase of wildcards and the memory will explode , so we optimized re atom extract algorithm. On the one hand, increase string YR_MAX_ATOM_LENGTH to speed up the scan, On the other hand, control the selected re atom contains at most one wildcard.
re atom extract algorithm: after 