### PR TITLE
Split YR_MAX_ATOM_LENGTH for string and re, and optimize the extract algorithm of regular atom to speed up the scan.

### DIFF
--- a/libyara/include/yara/atoms.h
+++ b/libyara/include/yara/atoms.h
@@ -41,6 +41,7 @@ typedef struct YR_ATOM YR_ATOM;
 typedef struct YR_ATOM_TREE_NODE YR_ATOM_TREE_NODE;
 typedef struct YR_ATOM_TREE YR_ATOM_TREE;
 
+typedef struct YR_ATOM_NODE_LIST YR_ATOM_NODE_LIST;
 typedef struct YR_ATOM_LIST_ITEM YR_ATOM_LIST_ITEM;
 
 typedef struct YR_ATOM_QUALITY_TABLE_ENTRY YR_ATOM_QUALITY_TABLE_ENTRY;
@@ -70,6 +71,13 @@ struct YR_ATOM_TREE_NODE
 struct YR_ATOM_TREE
 {
   YR_ATOM_TREE_NODE* root_node;
+};
+
+struct YR_ATOM_NODE_LIST
+{
+    YR_ATOM atom;
+    RE_NODE* re_nodes[YR_MAX_ATOM_RE_LENGTH];
+    YR_ATOM_NODE_LIST* next;
 };
 
 struct YR_ATOM_LIST_ITEM

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -60,11 +60,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define YR_MAX_COMPILER_ERROR_EXTRA_INFO 256
 #endif
 
-// Maximum size for the substring (atoms) extracted from strings and regular
+// Maximum size for the substring (atoms) extracted from regular
 // expressions and put into the Aho-Corasick automaton. The maximum allows size
 // for this constant is 255.
+#ifndef YR_MAX_ATOM_RE_LENGTH
+#define YR_MAX_ATOM_RE_LENGTH 8
+#endif
+
+// Maximum size for the substring (atoms) extracted from strings
+// and put into the Aho-Corasick automaton. The maximum allows size
+// for this constant is 255.
 #ifndef YR_MAX_ATOM_LENGTH
-#define YR_MAX_ATOM_LENGTH 4
+#define YR_MAX_ATOM_LENGTH 8
+#endif
+
+// Minimum size for the substring(atoms) extracted from regular
+// expressions and put into the Aho-Corasick automaton. The minimum 
+// is advised to set based on real rules. If the minimum is too large,
+// the atom may be extracted failed, and if the minimum is too small, the quality of atom may be a little low.
+#ifndef YR_MIN_VALID_ATOM_LENGTH
+#define YR_MIN_VALID_ATOM_LENGTH 4
 #endif
 
 #ifndef YR_MAX_ATOM_QUALITY


### PR DESCRIPTION
Split YR_MAX_ATOM_LENGTH to YR_MAX_ATOM_RE_LENGTH and YR_MAX_ATOM_LENGTH will speed up the scan. For string, its length could increase from 4 to more large e.g. 8, and this change can speed up the scan. For re, if we just increase the length of re atom, the number atoms may increases exponentially because of wildcards and the memory will explode , so we optimized re atom extract algorithm. On the one hand, increase string YR_MAX_ATOM_LENGTH to speed up the scan. On the other hand, control the selected re atom contains at most one wildcard.
After finishing atom extract on line 1164 of atoms.c , we count the number of wildcards in the re atom. If the count above 1, we will further extract from atom, the following is the explain.

1. find best child atom in every length from the atom, the range of length is [1, YR_MAX_ATOM_RE_LENGTH]. Every best child atom must meet 2 requirements, first it is the best quality, second the number of wildcards is below 1.
2. select one highest quality atom that dost not contain any wildcard (no-wildcard atom) and save it in best_atom[0].
3. select one highest quality atom that contains half wildcard ( half-wildcard atom) and save in best_atom[1]. For example, {01 0? 03} contains half wildcard.
4. select one highest quality atom that contains one wildcard (one-wildcard) and save in best_atom[2].
5. To avoid no-wildcard atom and half-wildcard atom length is too short, we set YR_MIN_VALID_ATOM_LENGTH. If no-wildcard atom length greater than or equal to YR_MIN_VALID_ATOM_LENGTH, we will select it as the final best atom and stop the select algorithm. Or else if the half-wildcard atom length greater than or equal to YR_MIN_VALID_ATOM_LENGTH+1, we will select it as the final best atom and stop the select algorithm. Or else we will choose the longest atom as the best atom.

By following the above optimization, the scanning speed was increased by 6 times in our test.