### PR TITLE
Fix bug when parsing imports from 32bit PE.

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -939,7 +939,7 @@ static IMPORT_FUNCTION* pe_parse_import_descriptor(
 
     while (struct_fits_in_pe(pe, thunks32, IMAGE_THUNK_DATA32) &&
            yr_le32toh(thunks32->u1.Ordinal) != 0 &&
-           *num_function_imports < MAX_PE_IMPORTS)
+           parsed_imports < MAX_PE_IMPORTS)
     {
       char* name = NULL;
       uint16_t ordinal = 0;


### PR DESCRIPTION
There is a bug when parsing [1] which turns out to be incorrectly checking the number of successfully parsed imported functions and not the number of parsed attempts. This particular sample is badly malformed and is causing excessive loops in the parser while attempting to parse invalid data. With this fix it will finish in a few seconds on my laptop.

[1]: 9c8e4dfa84b1ce7e919964978d33eada266d58b2aacdbef44b0618cc178ea421