### PR TITLE
fix: correct indentation issues

### DIFF
--- a/libyara/proc/linux.c
+++ b/libyara/proc/linux.c
@@ -412,7 +412,7 @@ YR_API YR_MEMORY_BLOCK* yr_process_get_next_memory_block(
     }
     else
     {
-      YR_DEBUG_FPRINTF(2, stderr, "+ %s() = NULL\n", __FUNCTION__);
+      YR_DEBUG_FPRINTF(2, stderr, "- %s() = NULL\n", __FUNCTION__);
       return NULL;
     }
   }

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -3921,6 +3921,8 @@ void test_defined()
 
 static void test_pass(int pass)
 {
+  YR_DEBUG_FPRINTF(1, stderr, "+ %s() { \n", __FUNCTION__);
+
   switch (pass)
   {
   case 1:


### PR DESCRIPTION
There were two minor issues in the YR_DEBUG_FPRINTF statements: 

- yr_process_get_next_memory_block had a debug statement starting with `+`, which YR_DEBUG_FPRINTF interpreted as a function starting, but since there was no corresponding `}`, this caused indentation to permanently increase by 1
- test_pass had a closing debug statement at its end, which decreased indentation (and possibly caused the test to fail if indentation was already 0), but no opening debug statement, causing indentation to effectively decrease by 1

This can be reproduced with `./configure --with-debug-verbose=2`.