### PR TITLE
fix: restore debug output indentation in catch clause

### DIFF
--- a/libyara/exception.h
+++ b/libyara/exception.h
@@ -223,13 +223,14 @@ static void exception_handler(int sig, siginfo_t * info, void *context)
 
 // Keep debug output indentation level consistent
 #if 0 == YR_DEBUG_VERBOSITY
-#define YR_DEBUG_INDENT_RESET_INIT
-#define YR_DEBUG_INDENT_RESET_RESTORE
+#define YR_DEBUG_INDENT_INITIAL 0
+#define YR_DEBUG_INDENT_SET(x)  ;
 #else
 extern YR_TLS int yr_debug_indent;
 // Ugly, but unfortunately cannot use ifdef macros inside a macro
-#define YR_DEBUG_INDENT_RESET_INIT    int yr_debug_indent_before_jump = yr_debug_indent;
-#define YR_DEBUG_INDENT_RESET_RESTORE yr_debug_indent = yr_debug_indent_before_jump;
+#define YR_DEBUG_INDENT_INITIAL yr_debug_indent
+#define YR_DEBUG_INDENT_SET(x)  yr_debug_indent = (x);
+
 #endif
 
 typedef struct sigaction sa;
@@ -255,7 +256,7 @@ typedef struct sigaction sa;
       exception_handler_usecount++;                                   \
       pthread_mutex_unlock(&exception_handler_mutex);                 \
       /* Save the current debug indentation level before the jump. */ \
-      YR_DEBUG_INDENT_RESET_INIT                                      \
+      int yr_debug_indent_before_jump = YR_DEBUG_INDENT_INITIAL;      \
       jumpinfo ji;                                                    \
       ji.memfault_from = 0;                                           \
       ji.memfault_to = 0;                                             \
@@ -270,7 +271,7 @@ typedef struct sigaction sa;
       else                                                            \
       {                                                               \
         /* Restore debug output indentation in case of failure */     \
-        YR_DEBUG_INDENT_RESET_RESTORE                                 \
+        YR_DEBUG_INDENT_SET(yr_debug_indent_before_jump);             \
                                                                       \
         _catch_clause_                                                \
       }                                                               \

--- a/libyara/exception.h
+++ b/libyara/exception.h
@@ -221,6 +221,17 @@ static void exception_handler(int sig, siginfo_t * info, void *context)
   }
 }
 
+// Keep debug output indentation level consistent
+#if 0 == YR_DEBUG_VERBOSITY
+#define YR_DEBUG_INDENT_RESET_INIT
+#define YR_DEBUG_INDENT_RESET_RESTORE
+#else
+extern YR_TLS int yr_debug_indent;
+// Ugly, but unfortunately cannot use ifdef macros inside a macro
+#define YR_DEBUG_INDENT_RESET_INIT    int yr_debug_indent_before_jump = yr_debug_indent;
+#define YR_DEBUG_INDENT_RESET_RESTORE yr_debug_indent = yr_debug_indent_before_jump;
+#endif
+
 typedef struct sigaction sa;
 
 #define YR_TRYCATCH(_do_, _try_clause_, _catch_clause_)               \
@@ -243,6 +254,8 @@ typedef struct sigaction sa;
       }                                                               \
       exception_handler_usecount++;                                   \
       pthread_mutex_unlock(&exception_handler_mutex);                 \
+      /* Save the current debug indentation level before the jump. */ \
+      YR_DEBUG_INDENT_RESET_INIT                                      \
       jumpinfo ji;                                                    \
       ji.memfault_from = 0;                                           \
       ji.memfault_to = 0;                                             \
@@ -256,6 +269,9 @@ typedef struct sigaction sa;
       }                                                               \
       else                                                            \
       {                                                               \
+        /* Restore debug output indentation in case of failure */     \
+        YR_DEBUG_INDENT_RESET_RESTORE                                 \
+                                                                      \
         _catch_clause_                                                \
       }                                                               \
       pthread_mutex_lock(&exception_handler_mutex);                   \


### PR DESCRIPTION
Verbose debug output (e.g., `--with-debug-verbose=2`) may run into an inconsistent indentation when nested function calls are disturbed by signals (`SIGBUS` or `SIGSEGV`): the closing statement is never executed, cf. https://github.com/VirusTotal/yara/pull/2133#issuecomment-2580799502 . Thanks @secDre4mer for pointing this out.

This patch restores the indentation in this case. The resulting output is obviously incomplete because it misses the closing statement but the subsequently reported error should be a sufficient hint to assess the situation. For instance,
```
2.256372 11010464 + yr_scanner_scan_mem(buffer=a0000004e891000 buffer_size=1048576) {
2.256429 11010464   + yr_scanner_scan_mem_blocks() {
2.256468 11010464     - _yr_get_first_block() {} = 116503290 // default iterator; single memory block, blocking
2.257259 11010464     + _yr_scanner_scan_mem_block(block_data=a0000004e891000 block->base=0x0 block->size=1048576) {
2.274888 11010464     - _yr_scanner_clean_matches() {}
2.274940 11010464   } = 4 AKA ERROR_COULD_NOT_MAP_FILE // yr_scanner_scan_mem_blocks()
2.275003 11010464 } = 4 AKA ERROR_COULD_NOT_MAP_FILE // yr_scanner_scan_mem()
```
does not contain the closing `_yr_scanner_scan_mem_block` statement.