### PR TITLE
Calculate a fully matching regex for base64 strings

### DIFF
--- a/libyara/include/yara/base64.h
+++ b/libyara/include/yara/base64.h
@@ -38,6 +38,8 @@ typedef struct BASE64_NODE BASE64_NODE;
 
 struct BASE64_NODE
 {
+  SIZED_STRING* pre;
+  SIZED_STRING* post;
   SIZED_STRING* str;
   int escaped;
   BASE64_NODE* next;


### PR DESCRIPTION
Hi folks!

This is a proof-of-concept and needs some serious clean-up, but for now 
I've left it needlessly verbose to hopefully demonstrate better what I'm 
doing and that hopefully I'm not barking up the wrong tree and my 
assumptions (largely gleaned from the Wikipedia page on base64) are 
correct.

It's long been annoying to me that Yara's implementation of base64 is 
fairly naive, particularly not matching terribly well on shorter strings, 
due to it throwing away up to the first couple of characters and the last 
characters if they're a partial match, when it's possible to write a 
regex that'll match it correctly. This is because when there's a partial 
match (the character is covered by two encoded characters), I believe 
there's only a limited subset of characters it can potentially be - 
either 4 or 16 to be precise.

Take for example the string `<?php`. This can have the following 
representations:

```
$ = /PD9waH[ABCD]/
$ = /[DTjz]w\/cGhw/
$ = /[AEIMQUYcgkosw048]8P3Boc[ABCDEFGHIJKLMNOP]/
```

Yara's `base64` keyword however, by throwing away the partial matched 
characters, renders the three possible combinations as:

```
$ = /PD9waH/
$ = /w\/cGhw/
$ = /8P3Boc/
```

This results in the unfortunate behaviour of, for example, `<?phq` 
matching as a false positive.

The changes in this PR add two additional fields to a base64 node: `pre` 
and `post` strings, and adds the combinations of characters that each 
could potentially be, which then `_yr_base64_create_regexp` renders the 
regex at the start/end of the given pattern - we allocate enough space 
for the extra characters and up to two sets of square brackets to 
surround them, leave out the bit that was formerly dropped off and 
replace it with the start and end patterns.

I'm not sure if this is the best way to do it, but it seemed reasonable?

As mentioned at the beginning, this needs cleaning up a lot - I'm very 
rusty at C, probably wasn't great at my prime, my comments are garbage, 
the code is needlessly verbose in places and not readable in others, and 
I'm making various assumptions.

I'm making the following assumptions that I'm aware of:

* That my bitwise math is correct, in all my testing it seems to be 
correct.
* That my math on figuring out the sizes to allocate is correct.
* That yr_free() doesn't free null pointers.
* that _yr_base64_destroy_nodes() cleans up memory I'm allocating 
correctly.
* That yr_free() frees children inside nodes (as I write this I'm now 
fairly sure this isn't correct and I'll need to fix that?)
* That the wide-text mode still works correctly - I'm not 100% sure I 
didn't mess this up.
* That allowing what would have formerly been a zero-length string to go 
through is okay. I'm aware it's fairly disastrous for rule performance, 
but searching for a single character string encoded to base64 now works - 
though one of the three representations renders as a regex with two sets 
of four possible characters with no static characters whatsoever.

Please let me know if any of these look incorrect.

If it's otherwise not objectionable I should be able to put the work in 
to cleaning this up so it's mergeable, writing some tests, and updating 
the documentation, but I am happy if someone else hammers it into shape 
as well.

## Test cases for your perusal

Strings that should match the pattern `$ = "<?php" base64`, currently do, 
and do after the patch:

```
PD9waHAK
IDw/cGhwCg==
QUE8P3BocAo=
```

Some strings that currently match that shouldn't, and don't after the 
patch:

```
PD9waHEK
ICA8P3BocQo=
```
