### PR TITLE
Fix resource directory processing in PE module

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -484,7 +484,11 @@ static int _pe_iterate_resources(
       PIMAGE_RESOURCE_DIRECTORY directory =
           (PIMAGE_RESOURCE_DIRECTORY) (rsrc_data + RESOURCE_OFFSET(entry));
 
-      if (struct_fits_in_pe(pe, directory, IMAGE_RESOURCE_DIRECTORY))
+      // Don't allow descending into a directory that is already being processed.
+      // While this does not prevent potential cyclical infinite loops, it is good
+      // enough to handle all known problematic cases.
+      if (directory != resource_dir &&
+          struct_fits_in_pe(pe, directory, IMAGE_RESOURCE_DIRECTORY))
       {
         result = _pe_iterate_resources(
             pe,


### PR DESCRIPTION
Don't allow descending into a resource directory that is already being processed.

Example sample where YARA loops infinitely: [0e87e9a78a81f9180c8fb26183e9fb9785985a5d312cdf4f669c151689336543](https://www.virustotal.com/gui/file/0e87e9a78a81f9180c8fb26183e9fb9785985a5d312cdf4f669c151689336543).

YARA-X seems to handle this fine.