### PR TITLE
Fix heap overflow

### DIFF
--- a/libyara/arena.c
+++ b/libyara/arena.c
@@ -597,9 +597,11 @@ int yr_arena_load_stream(YR_STREAM* stream, YR_ARENA** arena)
   {
     YR_ARENA_BUFFER* b = &new_arena->buffers[reloc_ref.buffer_id];
 
-    if (reloc_ref.buffer_id >= new_arena->num_buffers ||
-        reloc_ref.offset > b->used - sizeof(void*) ||
-        b->data == NULL)
+    if (b->data == NULL || 
+        b->used < sizeof(void*) ||
+        b->used > b->size ||
+        reloc_ref.buffer_id >= new_arena->num_buffers ||
+        reloc_ref.offset > b->used - sizeof(void*))
     {
       yr_arena_release(new_arena);
       return ERROR_CORRUPT_FILE;


### PR DESCRIPTION
A heap overflow could occur when loading a hand-crafted compiled rules file. If the `used` field is less than `sizeof(void)` an integer overflow occurs that bypasses the file validation and causes heap overflow later on.