### PR TITLE
Make yr_string_set_destroy non-public

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -1079,7 +1079,7 @@ YR_API char* yr_compiler_get_error_message(
   return buffer;
 }
 
-YR_API int yr_string_set_destroy(YR_STRING_SET string_set)
+int yr_string_set_destroy(YR_STRING_SET string_set)
 {
   YR_STRING_SET_ELEMENT* head = string_set.head;
   while (head != NULL) {

--- a/libyara/include/yara/compiler.h
+++ b/libyara/include/yara/compiler.h
@@ -93,7 +93,7 @@ typedef struct _YR_STRING_SET
   YR_STRING_SET_ELEMENT* head;
 } YR_STRING_SET;
 
-YR_API int yr_string_set_destroy(YR_STRING_SET string_set);
+int yr_string_set_destroy(YR_STRING_SET string_set);
 
 typedef struct _YR_EXPRESSION
 {


### PR DESCRIPTION
The function is only called from within the compiler; there's no need to expose it to users of the library.