### PR TITLE
Add a new module for OOXML

### DIFF
--- a/docs/modules/ooxml.md
+++ b/docs/modules/ooxml.md
@@ -1,0 +1,150 @@
+Office Open XML, also known as OpenXML or OOXML, is an XML-based format for office documents that was developed by Microsoft and later adopted/standardised by ISO and IEC as ISO/IEC 29500. OOXML is now the default format of all Microsoft Office documents (.docx, .xlsx, and .pptx). There is a difference between Transitional variation that Microsoft use and the Strict variation that can be used as an open standard for documents.  
+
+OOXML files (such as `.docx`, `.xlsx`, and `.pptx`) are essentially ZIP archives that bundle multiple XML files, media files, and other resources together into a single package and thereby follow the Open Packaging Conventions (OPC) standard, which uses the ZIP container format. Older document formats may also support OOXML format.
+
+The inspiration behind the development of the ooxml module was to focus on modern documents often used by adversaries during initial access as droppers or downloaders for next stage payloads. Hence, efforts have been made to differentiate ooxml files from wider PKZip files that are not necessarily documents. 
+
+The module is built using the specification listed here https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html through incorporation of the end of central directory record and central directory file headers for each entry in central directory. It performs header and trailer check for the PKZIP signature but also optionally checks for the presence of Content_Types.xml which is listed in the first few entries of the central directory using the is_ooxml Boolean property in the module.
+
+The module does not extract the identified file entries from the central directory but rather relies on the metadata surrounding the entries.
+## Module Structure
+
+type is_ooxml
+Return true if file matches characteristics of an OOXML file.  
+*Example: ooxml.is_ooxml*
+
+type number_of_on_disk_entries
+The number of entries in the central directory on this disk.
+*Example: ooxml.number_of_on_disk_entries == 15*
+
+type number_of_total_entries
+Total number of entries in the central directory.
+*Example: ooxml.number_of_total_entries == 13*
+
+**NOTE:** Typically the value of number_of_on_disk_entries and number_of_total_entries should be identical
+
+type central_dir_size
+Size of the central directory in bytes.
+*Example: ooxml.central_dir_size < 4KB*
+
+type central_dir_offset
+Raw offset of the start of central directory on the disk.
+*Example: ooxml.central_dir_offset == 0x3220* 
+
+type zip_comment_len
+The length of the ZIP comment field in Bytes.
+*Example: ooxml.zip_comment_len > 0*
+
+type zip_comment_str
+Optional comment for the Zip file.
+*Example: ooxml.zip_comment_str == "Some Random Zip Comment"*
+
+**NOTE:** Two attributes from the end of central directory record (Disk Number and Disk # w/cd) were intentionally ignored due to irrelevance of their corresponding values.
+
+type entries
+A zero-based array of central directory entries, one for each entry the PKZIP has. Individual entries can be accessed by using the [ ] operator. Each central directory record has the following attributes:
+
+**NOTE:** In the module, no limits have been set to restrict the scanning of a given number of entries to avoid those bloated or corrupted PKZIP files which have a significant higher number of entries (i.e. more than 100)
+
+type name_string
+Entry's name.
+*Example: ooxml.entries[0].name_string == "[Content_Types].xml"*
+
+type name_length
+Entry's  name length in bytes.
+*Example: ooxml.entries[0].name_length == 19*
+
+type compressed_size 
+Compressed size of the Entry in Bytes.
+*Example: ooxml.entries[3].compressed_size > 250*
+
+type uncompressed_size
+Uncompressed size of the Entry in Bytes.
+*Example: ooxml.entries[3].compressed_size == 252*
+
+type crc32_checksum
+Value computed over file data of an entry by CRC-32 algorithm with 'magic number' 0xdebb20e3 (little endian).
+*Example: ooxml.entries[5].crc32_checksum == 0x4CE962CA*
+
+type compression_method_value UNTIL HERE
+Raw value of the compression method used on the entry.
+*Example: ooxml.entries[6].compression_method_value == 0x08 //Deflated*
+
+type compression_method_name 
+Derived name of the compression method used on the entry based on the mappings defined in the PKZIP specification.
+*Example: ooxml.entries[6].compression_method_name == "Deflated"*
+
+type mod_time_raw
+Entry's modification time stored in standard MS-DOS format.
+*Example: ooxml.entries[7].mod_time_raw == 0x7d1c //15:40:36*
+
+type mod_date_raw
+Entry's modification date stored in standard MS-DOS format.
+*Example: ooxml.entries[7].mod_time_raw == 0x354b //10/11/2006*
+
+type flags
+Raw value of general purpose bit flag for the entry
+
+type version_made_by
+Raw value that constitutes the OS name and ZIP specification version used to create the entry. Upper Byte provides the OS name and lower Byte gives the ZIP version.
+*Example: ooxml.entries[8].version_made_by == 0x0317 //03 -> UNIX  INT 23 -> 2.3*
+
+type os_name
+OS name used to create the entry which is derived from the  version_made_by raw value and the specificaiton mappings related to it.
+*Example: ooxml.entries[8].os_name == "Unix"*
+
+type spec_version
+Raw value of ZIP specification version which is derived from the version_made_by raw value.
+*Example: ooxml.entries[8].spec_version == 22 //2.2*
+
+type version_needed
+PKZip version needed to extract the entry
+*Example: ooxml.entries[8].version_needed == 20 //2.0*
+
+**NOTE:** Typically version_needed is equal to spec_version
+
+## Mappings
+
+Following mappings are for the compression_method_name and os_name
+
+*compression_method_name*
+
+	  {8, "Deflate"},
+    {0, "Store"},    
+    {9, "Deflate64"},
+    {14, "LZMA"},
+    {12, "BZIP2"},
+    {1, "Shrink"},
+    {2, "Reduce1"},
+    {3, "Reduce2"},
+    {4, "Reduce3"},
+    {5, "Reduce4"},
+    {6, "Implode"},
+    {98, "PPMd"},
+    {19, "LZ77"},
+    {0, NULL}
+
+*os_name*
+
+	  {0, "FAT"},
+    {1, "Amiga"},
+    {2, "VMS"},
+    {3, "Unix"},
+    {4, "VM/CMS"},
+    {5, "Atari ST"},
+    {6, "HPFS"},
+    {7, "Macintosh"},
+    {10, "NTFS"},
+    {11, "MVS"},
+    {14, "VFAT"},
+    {18, "IBM OS/2"},
+    {19, "Macintosh OSX"},
+    {0, NULL}
+    
+
+**NOTE:** Extra field length, File comment length, Internal/External file attributes, Extra field and file comment are yet to be implemented in the module. The rest of the properties from PKZIP specification were intentionally left out. Additionally, the modification date and time will be parsed into human readable timestamps.
+
+
+
+
+

--- a/libyara/include/yara/ooxml.h
+++ b/libyara/include/yara/ooxml.h
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _OOXML_H
+#define _OOXML_H
+
+#include <yara/integers.h>
+
+#define SIG_LOCAL_FILE_HEADER 0x04034b50
+#define SIG_CENTRAL_DIR 0x02014b50
+#define SIG_END_OF_CENTRAL_DIR 0x06054b50
+
+typedef struct {
+    uint16_t id;
+    const char* name;
+} CompressionMethod;
+
+static const CompressionMethod COMPRESSION_METHODS[] = {
+    {8, "Deflate"},
+    {0, "Store"},    
+    {9, "Deflate64"},
+    {14, "LZMA"},
+    {12, "BZIP2"},
+    {1, "Shrink"},
+    {2, "Reduce1"},
+    {3, "Reduce2"},
+    {4, "Reduce3"},
+    {5, "Reduce4"},
+    {6, "Implode"},
+    {98, "PPMd"},
+    {19, "LZ77"},
+    {0, NULL}
+};
+
+typedef struct {
+    uint8_t id;
+    const char* name;
+} HostOS;
+
+static const HostOS HOST_OS_SYSTEMS[] = {
+    {0, "FAT"},
+    {1, "Amiga"},
+    {2, "VMS"},
+    {3, "Unix"},
+    {4, "VM/CMS"},
+    {5, "Atari ST"},
+    {6, "HPFS"},
+    {7, "Macintosh"},
+    {10, "NTFS"},
+    {11, "MVS"},
+    {14, "VFAT"},
+    {18, "IBM OS/2"},
+    {19, "Macintosh OSX"},
+    {0, NULL}
+};
+
+#define FLAG_ENCRYPTED      0x0001 // Bit 0
+#define FLAG_COMP_OPT1      0x0002 // Bit 1
+#define FLAG_COMP_OPT2      0x0004 // Bit 2
+#define FLAG_DATA_DESC      0x0008 // Bit 3
+#define FLAG_ENHANCED_DEF   0x0010 // Bit 4
+#define FLAG_PATCHED        0x0020 // Bit 5
+#define FLAG_STRONG_ENC     0x0040 // Bit 6
+#define FLAG_UTF8           0x0800 // Bit 11
+#define FLAG_MASK_HEADER    0x2000 // Bit 13
+
+#pragma pack(push, 1)
+
+typedef struct 
+{
+    uint32_t signature;
+    uint16_t disk_number; //Not Used
+    uint16_t start_disk_position;  //Not Used
+    uint16_t total_entries_on_disk;
+    uint16_t total_entries;
+    uint32_t size_central_dir;
+    uint32_t offset_central_dir;
+    uint16_t zip_comment_len;
+} ooxml_end_of_central_directory_record;
+
+typedef struct 
+{
+    uint32_t signature;          
+    uint16_t version_made_by;
+    uint16_t version_needed;
+    uint16_t flags;              
+    uint16_t compression_method;
+    uint16_t last_mod_time;      
+    uint16_t last_mod_date;    
+    uint32_t crc32;
+    uint32_t compressed_size;
+    uint32_t uncompressed_size;
+    uint16_t filename_len;
+    uint16_t extra_field_len;
+    uint16_t file_comment_len;
+    uint16_t disk_number_start;
+    uint16_t internal_attrs;
+    uint32_t external_attrs;
+    uint32_t relative_offset; 
+} ooxml_central_directory_file_header;
+
+#pragma pack(pop)
+
+#endif

--- a/libyara/modules/ooxml/ooxml.c
+++ b/libyara/modules/ooxml/ooxml.c
@@ -1,0 +1,249 @@
+/*
+Copyright (c) 2014. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string.h>
+#include <yara/modules.h>
+#include <yara/endian.h>
+#include <yara/ooxml.h>
+
+#define MODULE_NAME ooxml
+
+// Helper functions 
+static uint32_t read_le32(const uint8_t* data, size_t offset, size_t max_size) {
+    if (offset + sizeof(uint32_t) > max_size) return 0;
+    uint32_t value;
+    memcpy(&value, data + offset, sizeof(uint32_t));
+    return yr_le32toh(value);
+}
+
+static uint16_t read_le16(const uint8_t* data, size_t offset, size_t max_size) {
+    if (offset + sizeof(uint16_t) > max_size) return 0;
+    uint16_t value;
+    memcpy(&value, data + offset, sizeof(uint16_t));
+    return yr_le16toh(value);
+}
+
+static const char* lookup_compression(uint16_t id) {
+    for (int i = 0; COMPRESSION_METHODS[i].name != NULL; i++) {
+        if (COMPRESSION_METHODS[i].id == id) {
+            return COMPRESSION_METHODS[i].name;
+        }
+    }
+    return "Unknown";
+}
+
+static const char* lookup_os(uint8_t id) {
+    for (int i = 0; HOST_OS_SYSTEMS[i].name != NULL; i++) {
+        if (HOST_OS_SYSTEMS[i].id == id) {
+            return HOST_OS_SYSTEMS[i].name;
+        }
+    }
+    return "Unknown";
+}
+
+begin_declarations;
+    begin_struct_array("entries");
+        declare_string("name_string");
+        declare_integer("name_length");
+        declare_integer("compressed_size");
+        declare_integer("uncompressed_size");
+        declare_integer("crc32_checksum");
+        declare_integer("compression_method_value");
+        declare_string("compression_method_name");
+        declare_integer("mod_time_raw");
+        declare_integer("mod_date_raw");
+        declare_integer("flags");
+        declare_integer("version_needed");
+
+        declare_integer("version_made_by");
+        declare_string("os_name");
+        declare_integer("spec_version");
+    end_struct_array("entries");
+
+    declare_integer("is_ooxml");
+    declare_integer("number_of_on_disk_entries");
+    declare_integer("number_of_total_entries");
+    declare_integer("central_dir_size");
+    declare_integer("central_dir_offset");
+    declare_integer("zip_comment_len");
+    declare_string("zip_comment_str");
+end_declarations;
+
+int module_initialize(YR_MODULE* module) {
+    return ERROR_SUCCESS;
+}
+
+int module_finalize(YR_MODULE* module) {
+    return ERROR_SUCCESS;
+}
+
+int module_load(
+    YR_SCAN_CONTEXT* context, 
+    YR_OBJECT* module_object, 
+    void* module_data, 
+    size_t module_data_size) 
+  {
+    
+    YR_MEMORY_BLOCK* block = first_memory_block(context);
+    if (block == NULL) return ERROR_SUCCESS;
+
+    const uint8_t* data = block->fetch_data(block);
+    if (data == NULL) return ERROR_SUCCESS;
+    
+    size_t data_size = block->size;
+    if (data_size < 22) return ERROR_SUCCESS; // Smallest PKZIP File Check
+
+    uint32_t signature = read_le32(data, 0, data_size);
+    if (signature != SIG_LOCAL_FILE_HEADER) {
+        return ERROR_SUCCESS; // PKZIP File Header Check
+    }
+
+    size_t eocd_offset = 0;
+    int found_eocd = 0;
+
+    size_t max_comment_size = 65535;
+    size_t scanable_space = data_size - 22;
+    
+    // Only scan the smaller of the max comment size or the available file space
+    size_t scan_len = (scanable_space > max_comment_size) ? max_comment_size : scanable_space;
+
+    for (size_t i = 0; i < scan_len; i++) {
+        size_t current_idx = data_size - 22 - i;
+        // PKZIP File Trailer Check from end of file
+        if (data[current_idx] == 0x50 && 
+            data[current_idx + 1] == 0x4b && 
+            data[current_idx + 2] == 0x05 && 
+            data[current_idx + 3] == 0x06) {
+            
+            uint16_t comment_len = read_le16(data, current_idx + 20, data_size);
+            if (current_idx + 22 + comment_len == data_size) {
+                eocd_offset = current_idx;
+                found_eocd = 1;
+                break;
+            }
+        }
+    }
+
+    if (!found_eocd) return ERROR_SUCCESS;
+
+    // EOCD (End of Central Directory) data
+    uint16_t on_dsk_cd_num = read_le16(data, eocd_offset + 8, data_size);
+    uint16_t total_entries = read_le16(data, eocd_offset + 10, data_size);
+    uint32_t cd_size = read_le32(data, eocd_offset + 12, data_size);
+    uint32_t cd_offset = read_le32(data, eocd_offset + 16, data_size);
+    uint16_t comment_len = read_le16(data, eocd_offset + 20, data_size);
+
+    yr_set_integer(on_dsk_cd_num, module_object, "number_of_on_disk_entries");
+    yr_set_integer(total_entries, module_object, "number_of_total_entries");
+    yr_set_integer(cd_size, module_object, "central_dir_size");
+    yr_set_integer(cd_offset, module_object, "central_dir_offset");
+    yr_set_integer(comment_len, module_object, "zip_comment_len");
+
+
+    if (comment_len > 0 && (eocd_offset + 22 + comment_len <= data_size)) {
+        yr_set_sized_string((const char*)(data + eocd_offset + 22), comment_len, module_object, "zip_comment_str");
+    }
+
+    if (cd_offset + cd_size > data_size) return ERROR_SUCCESS;
+
+
+    size_t current_offset = cd_offset;
+    int found_content_types = 0;
+
+    for (int i = 0; i < total_entries; i++) {
+        if (current_offset + 46 > data_size) break; 
+
+        if (read_le32(data, current_offset, data_size) != SIG_CENTRAL_DIR) break;
+
+        // Below 3 are required to dynamically calculate and update the offset to next entry
+        uint16_t fname_len = read_le16(data, current_offset + 28, data_size);
+        uint16_t extra_len = read_le16(data, current_offset + 30, data_size);
+        uint16_t file_comment_len = read_le16(data, current_offset + 32, data_size);
+        
+        if (fname_len == 19) {
+            if (current_offset + 46 + 19 <= data_size) {
+            const char* name_ptr = (const char*)(data + current_offset + 46);
+            if (memcmp(name_ptr, "[Content_Types].xml", 19) == 0) {
+                found_content_types = 1; // Check for [Content_Types].xml in first few entries to qualify as ooxml
+            }
+          }  
+        }
+
+        // CD (Central Directory) Entry Data
+        uint16_t version_made = read_le16(data, current_offset + 4, data_size);
+        uint8_t spec_ver_raw = (version_made & 0xFF);
+
+        uint16_t version_need = read_le16(data, current_offset + 6, data_size);
+        uint16_t flag = read_le16(data, current_offset + 8, data_size);
+        uint16_t compress_method = read_le16(data, current_offset + 10, data_size);
+        uint16_t dos_time_raw = read_le16(data, current_offset + 12, data_size);
+        uint16_t dos_date_raw = read_le16(data, current_offset + 14, data_size);
+        uint32_t crc32 = read_le32(data, current_offset + 16, data_size);
+        uint32_t comp_size = read_le32(data, current_offset + 20, data_size);
+        uint32_t uncomp_size = read_le32(data, current_offset + 24, data_size);
+        
+
+        if (current_offset + 46 + fname_len > data_size) break;
+
+        yr_set_integer(found_content_types, module_object, "is_ooxml");
+        yr_set_integer(version_made, module_object, "entries[%i].version_made_by", i);
+        yr_set_integer(version_need, module_object, "entries[%i].version_needed", i);
+        yr_set_integer(flag, module_object, "entries[%i].flags", i);
+        yr_set_integer(compress_method, module_object, "entries[%i].compression_method_value", i);
+        yr_set_integer(crc32, module_object, "entries[%i].crc32_checksum", i);
+        yr_set_integer(comp_size, module_object, "entries%i].compressed_size", i);
+        yr_set_integer(uncomp_size, module_object, "entries[%i].uncompressed_size", i);
+        yr_set_integer(dos_time_raw, module_object, "entries[%i].mod_time_raw", i);
+        yr_set_integer(dos_date_raw, module_object, "entries[%i].mod_date_raw", i);
+        
+        yr_set_string(lookup_compression(compress_method), module_object, "entries[%i].compression_method_name", i);
+        yr_set_string(lookup_os(version_made >> 8), module_object, "entries[%i].os_name", i);
+        yr_set_integer(spec_ver_raw, module_object, "entries[%i].spec_version", i);
+
+        if (fname_len > 0) {
+            yr_set_sized_string((const char*)(data + current_offset + 46), fname_len, module_object, "entries[%i].name_string", i);
+            yr_set_integer(fname_len, module_object, "entries[%i].name_length", i);
+        }
+
+        current_offset += 46 + fname_len + extra_len + file_comment_len;
+
+    }
+
+    return ERROR_SUCCESS;
+}  
+
+int module_unload(
+    YR_OBJECT* module_object)
+{
+  return ERROR_SUCCESS;
+}
+
+#undef MODULE_NAME
+
+


### PR DESCRIPTION
Hi team, 

This is my first PR to any open-source project so do apologise if I get something wrong :)

I would like to request a new module for OOXML files which are part of the PKZIP specification. The module focuses on parsing the metadata properties of OOXML files and does not attempt to extract each file entity within the ZIP archive. Have used this PKZIP specification to construct the module https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html

I have built this module with limited knowledge of C and have tested it using the YARA tests function against a malicious document. The inspiration behind this is that various threat actors use such modern documents which follow the OOXML format during the initial phase of the intrusions.

The following have been added:
- A ooxml.md file to document and provide brief explanation of the module and its use.
- A ooxml.h which is the header file for the ooxml.c
- A ooxml.c under the modules/ooxml path which is the core module file

I have the supporting files that I can share as well such as modification to existing files (makefile.am, module_list, configure.ac) as well as new files (sample YARA ruleset, test-suite.log after running the make check and others)

Please let me know what is required from my end, I am super thrilled for this to be added as an official YARA module which will be huge for the 100DaysofYARA challenge and beyond, cheers