### PR TITLE
tests: Add new fuzzers to be consumed by OSS-Fuzz

### DIFF
--- a/tests/oss-fuzz/filemap_fuzzer.cc
+++ b/tests/oss-fuzz/filemap_fuzzer.cc
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2026. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+extern "C" {
+#include <yara.h>
+#include <yara/filemap.h>
+}
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+  yr_initialize();
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+  char temp_file[] = "/tmp/yara-filemap-fuzz-XXXXXX";
+  int fd = mkstemp(temp_file);
+  if (fd < 0) return 0;
+
+  if (write(fd, data, size) != (ssize_t) size)
+  {
+    close(fd);
+    unlink(temp_file);
+    return 0;
+  }
+
+  YR_MAPPED_FILE mapped_file;
+  if (yr_filemap_map_fd(fd, 0, size, &mapped_file) == ERROR_SUCCESS)
+  {
+    yr_filemap_unmap_fd(&mapped_file);
+  }
+
+  // Also try with some offsets and different sizes
+  FuzzedDataProvider fdp(data, size);
+  if (size > 0)
+  {
+      size_t offset = fdp.ConsumeIntegralInRange<size_t>(0, size - 1);
+      size_t map_size = fdp.ConsumeIntegralInRange<size_t>(0, size - offset);
+      if (yr_filemap_map_fd(fd, offset, map_size, &mapped_file) == ERROR_SUCCESS)
+      {
+          yr_filemap_unmap_fd(&mapped_file);
+      }
+  }
+
+  close(fd);
+  unlink(temp_file);
+
+  return 0;
+}

--- a/tests/oss-fuzz/math_fuzzer.cc
+++ b/tests/oss-fuzz/math_fuzzer.cc
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2026. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <yara.h>
+
+const char* RULES = "import \"math\""
+                    "rule test {"
+                    " condition:"
+                    "   math.entropy(0, filesize) >= 0 and "
+                    "   math.mean(0, filesize) >= 0 and "
+                    "   math.deviation(0, filesize, 0.0) >= 0 and "
+                    "   math.serial_correlation(0, filesize) >= 0 and "
+                    "   math.monte_carlo_pi(0, filesize) >= 0 and "
+                    "   math.min(0, filesize) >= 0 and "
+                    "   math.max(0, filesize) >= 0 and "
+                    "   math.count(0x00, 0, filesize) >= 0 and "
+                    "   math.percentage(0x00, 0, filesize) >= 0"
+                    "}";
+
+YR_RULES* rules = NULL;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+  YR_COMPILER* compiler;
+
+  if (yr_initialize() != ERROR_SUCCESS)
+    return 0;
+
+  if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+    return 0;
+
+  if (yr_compiler_add_string(compiler, RULES, NULL) == 0)
+    yr_compiler_get_rules(compiler, &rules);
+
+  yr_compiler_destroy(compiler);
+
+  return 0;
+}
+
+
+int callback(
+    YR_SCAN_CONTEXT* context,
+    int message,
+    void* message_data,
+    void* user_data)
+{
+  return CALLBACK_CONTINUE;
+}
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+  if (rules == NULL || size == 0)
+    return 0;
+
+  yr_rules_scan_mem(
+      rules, data, size, SCAN_FLAGS_NO_TRYCATCH, callback, NULL, 0);
+
+  return 0;
+}

--- a/tests/oss-fuzz/tlsh_fuzzer.cc
+++ b/tests/oss-fuzz/tlsh_fuzzer.cc
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2026. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tlshc/tlsh.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+  if (size < 50) // TLSH works better with more data
+    return 0;
+
+  Tlsh* tlsh = tlsh_new();
+  if (!tlsh)
+    return 0;
+
+  // Split data into two parts to exercise update
+  size_t first_part = size / 2;
+  tlsh_update(tlsh, data, first_part);
+  tlsh_final(tlsh, data + first_part, size - first_part, 0);
+
+  tlsh_get_hash(tlsh, true);
+  tlsh_get_hash(tlsh, false);
+
+  tlsh_reset(tlsh);
+  tlsh_free(tlsh);
+
+  return 0;
+}


### PR DESCRIPTION
Adds new fuzzing harnesses that increases the code coverage relative to a recent oss-fuzz coverage report:
https://storage.googleapis.com/oss-fuzz-coverage/yara/reports/20260503/linux/src/report.html

These harnesses will be consumed by OSS-Fuzz and start running once landed.