### PR TITLE
Harden PE delayed import and dotnet blob stream parsing

### DIFF
--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -703,7 +703,7 @@ static char* get_type_def_or_ref_fullname(
 
     TYPESPEC_ROW spec_row;
     bool result = read_typespec(ctx, data, &spec_row);
-    if (result)
+    if (result && spec_row.Signature < ctx->blob_size)
     {
       const uint8_t* sig_data = ctx->blob_heap + spec_row.Signature;
 
@@ -1374,6 +1374,9 @@ static void parse_methods(
     parse_generic_params(ctx, true, methodlist + idx, &method_gen_params);
 
     // Read the blob entry with signature data
+    if (row.Signature >= ctx->blob_size)
+      continue;
+
     const uint8_t* sig_data = ctx->blob_heap + row.Signature;
 
     BLOB_PARSE_RESULT blob_res = dotnet_parse_blob_entry(ctx->pe, sig_data);

--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -1362,6 +1362,9 @@ static void parse_methods(
     if (!result)
       continue;
 
+    if (row.Signature >= ctx->blob_size)
+      continue;  
+
     const char* name = pe_get_dotnet_string(
         ctx->pe, str_heap, str_size, row.Name);
 
@@ -1374,9 +1377,6 @@ static void parse_methods(
     parse_generic_params(ctx, true, methodlist + idx, &method_gen_params);
 
     // Read the blob entry with signature data
-    if (row.Signature >= ctx->blob_size)
-      continue;
-
     const uint8_t* sig_data = ctx->blob_heap + row.Signature;
 
     BLOB_PARSE_RESULT blob_res = dotnet_parse_blob_entry(ctx->pe, sig_data);

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1355,7 +1355,8 @@ static void* pe_parse_delayed_imports(PE* pe)
 
   import_descriptor = (PIMAGE_DELAYLOAD_DESCRIPTOR) (pe->data + offset);
 
-  for (; struct_fits_in_pe(pe, import_descriptor, IMAGE_DELAYLOAD_DESCRIPTOR);
+  for (; struct_fits_in_pe(pe, import_descriptor, IMAGE_DELAYLOAD_DESCRIPTOR) &&
+           num_imports < MAX_PE_IMPORTS;
        import_descriptor++)
   {
     // Check for the termination entry
@@ -1429,7 +1430,7 @@ static void* pe_parse_delayed_imports(PE* pe)
     uint64_t name_rva = ImportNameTableRVA;
     uint64_t func_rva = ImportAddressTableRVA;
 
-    for (;;)
+    for (;num_function_imports < MAX_PE_IMPORTS;)
     {
       uint64_t nameAddress = pe_parse_delay_import_pointer(
           pe, pointer_size, name_rva);


### PR DESCRIPTION
Adds bounds checks to the PE delayed import parser and dotnet blob stream index handling for consistency with existing limits elsewhere in the codebase.

**PE module (`pe.c`):**
- Cap delayed import descriptor and function iteration to `MAX_PE_IMPORTS`, matching the existing limit in `pe_parse_imports` / `pe_parse_import_descriptor`.

**Dotnet module (`dotnet.c`):**
- Validate `Signature` column values against `blob_size` before computing pointers into the blob heap, consistent with how other stream offsets are validated.