### PR TITLE
cast to unsigned char before ctype calls in pe and elf parsers

### DIFF
--- a/libyara/modules/elf/elf.c
+++ b/libyara/modules/elf/elf.c
@@ -132,7 +132,8 @@ define_function(telfhash)
 
     /* Convert it to lowercase */
     int j;
-    for (j = 0; name[j]; j++) clean_names[symbol_count][j] = tolower(name[j]);
+    for (j = 0; name[j]; j++)
+      clean_names[symbol_count][j] = tolower((unsigned char) name[j]);
 
     clean_names[symbol_count][j] = '\0';
 
@@ -227,7 +228,8 @@ define_function(import_md5)
 
     /* Convert it to lowercase */
     int j;
-    for (j = 0; name[j]; j++) clean_names[symbol_count][j] = tolower(name[j]);
+    for (j = 0; name[j]; j++)
+      clean_names[symbol_count][j] = tolower((unsigned char) name[j]);
 
     clean_names[symbol_count][j] = '\0';
 

--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -2060,7 +2060,9 @@ const char* pe_get_section_full_name(
   uint64_t string_index = 0;
 
   // Calculate string index/offset in string table
-  for (int i = 1; i < IMAGE_SIZEOF_SHORT_NAME && isdigit(section_name[i]); i++)
+  for (int i = 1;
+       i < IMAGE_SIZEOF_SHORT_NAME && isdigit((unsigned char) section_name[i]);
+       i++)
     string_index = (string_index * 10) + (section_name[i] - '0');
 
   // Calculate string pointer
@@ -2819,7 +2821,7 @@ define_function(imphash)
       // Lowercase the whole thing.
 
       for (i = 0; i < final_name_len; i++)
-        final_name[i] = tolower(final_name[i]);
+        final_name[i] = tolower((unsigned char) final_name[i]);
 
       yr_md5_update(&ctx, final_name, final_name_len);
 


### PR DESCRIPTION
isdigit/tolower called on a plain char taken from untrusted binaries, which is undefined for byte values over 0x7f and asserts in MSVC debug builds:
- pe_get_section_full_name: isdigit on a COFF section name byte
- imphash: tolower on each import name byte
- telfhash and import_md5: tolower on each elf symbol name byte
Cast to unsigned char like the existing isprint sites in pe.c and console.c.