### PR TITLE
Avoid unaligned pointer casts to prevent HWASan traps

### DIFF
--- a/libyara/grammar.c
+++ b/libyara/grammar.c
@@ -3701,8 +3701,8 @@ yyreduce:
 
         // The fixup entry has a reference to the jump offset that need
         // to be fixed, convert the address into a pointer.
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
-            compiler->arena, &fixup->ref);
+        void* jmp_offset_addr =
+            yr_arena_ref_to_ptr(compiler->arena, &fixup->ref);
 
         // The reference in the fixup entry points to the jump's offset
         // but the jump instruction is one byte before, that's why we add
@@ -3981,8 +3981,8 @@ yyreduce:
 
         fixup = compiler->fixup_stack_head;
 
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
-            compiler->arena, &fixup->ref);
+        void* jmp_offset_addr =
+            yr_arena_ref_to_ptr(compiler->arena, &fixup->ref);
 
         int32_t jmp_offset = \
             yr_arena_get_current_offset(compiler->arena, YR_CODE_SECTION) -
@@ -4038,8 +4038,8 @@ yyreduce:
             yr_arena_get_current_offset(compiler->arena, YR_CODE_SECTION) -
             fixup->ref.offset + 1;
 
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
-            compiler->arena, &fixup->ref);
+        void* jmp_offset_addr =
+            yr_arena_ref_to_ptr(compiler->arena, &fixup->ref);
 
         memcpy(jmp_offset_addr, &jmp_offset, sizeof(jmp_offset));
 

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -1712,7 +1712,7 @@ expression
 
         // The fixup entry has a reference to the jump offset that need
         // to be fixed, convert the address into a pointer.
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
+        void* jmp_offset_addr = yr_arena_ref_to_ptr(
             compiler->arena, &fixup->ref);
 
         // The reference in the fixup entry points to the jump's offset
@@ -1952,7 +1952,7 @@ expression
 
         fixup = compiler->fixup_stack_head;
 
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
+        void* jmp_offset_addr = yr_arena_ref_to_ptr(
             compiler->arena, &fixup->ref);
 
         int32_t jmp_offset = \
@@ -2001,7 +2001,7 @@ expression
             yr_arena_get_current_offset(compiler->arena, YR_CODE_SECTION) -
             fixup->ref.offset + 1;
 
-        int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
+        void* jmp_offset_addr = yr_arena_ref_to_ptr(
             compiler->arena, &fixup->ref);
 
         memcpy(jmp_offset_addr, &jmp_offset, sizeof(jmp_offset));

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -1152,8 +1152,7 @@ int yr_parser_reduce_rule_declaration_phase_2(
 
   fixup = compiler->fixup_stack_head;
 
-  int32_t* jmp_offset_addr = (int32_t*) yr_arena_ref_to_ptr(
-      compiler->arena, &fixup->ref);
+  void* jmp_offset_addr = yr_arena_ref_to_ptr(compiler->arena, &fixup->ref);
 
   int32_t jmp_offset = yr_arena_get_current_offset(
                            compiler->arena, YR_CODE_SECTION) -

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -39,6 +39,7 @@ order to avoid confusion with operating system threads.
 
 #include <assert.h>
 #include <string.h>
+#include <yara/arena.h>
 #include <yara/compiler.h>
 #include <yara/error.h>
 #include <yara/globals.h>
@@ -717,8 +718,8 @@ static int _yr_re_emit(
 
   RE_NODE* child;
 
-  int16_t* split_offset_addr = NULL;
-  int16_t* jmp_offset_addr = NULL;
+  void* split_offset_addr = NULL;
+  void* jmp_offset_addr = NULL;
 
   YR_ARENA_REF instruction_ref = YR_ARENA_NULL_REF;
   YR_ARENA_REF split_offset_ref;
@@ -918,8 +919,8 @@ static int _yr_re_emit(
     jmp_offset = (int16_t) (bookmark_1 - instruction_ref.offset);
 
     // Update split offset.
-    split_offset_addr = (int16_t*) yr_arena_ref_to_ptr(
-        emit_context->arena, &split_offset_ref);
+    split_offset_addr =
+        yr_arena_ref_to_ptr(emit_context->arena, &split_offset_ref);
 
     memcpy(split_offset_addr, &jmp_offset, sizeof(jmp_offset));
     break;
@@ -965,8 +966,8 @@ static int _yr_re_emit(
     jmp_offset = (int16_t) (bookmark_1 - instruction_ref.offset);
 
     // Update split offset.
-    split_offset_addr = (int16_t*) yr_arena_ref_to_ptr(
-        emit_context->arena, &split_offset_ref);
+    split_offset_addr =
+        yr_arena_ref_to_ptr(emit_context->arena, &split_offset_ref);
 
     memcpy(split_offset_addr, &jmp_offset, sizeof(jmp_offset));
 
@@ -982,8 +983,7 @@ static int _yr_re_emit(
     jmp_offset = (int16_t) (bookmark_1 - jmp_instruction_ref.offset);
 
     // Update offset for jmp instruction.
-    jmp_offset_addr = (int16_t*) yr_arena_ref_to_ptr(
-        emit_context->arena, &jmp_offset_ref);
+    jmp_offset_addr = yr_arena_ref_to_ptr(emit_context->arena, &jmp_offset_ref);
 
     memcpy(jmp_offset_addr, &jmp_offset, sizeof(jmp_offset));
     break;
@@ -1166,8 +1166,8 @@ static int _yr_re_emit(
       if (bookmark_2 - bookmark_1 > INT16_MAX)
         return ERROR_REGULAR_EXPRESSION_TOO_LARGE;
 
-      split_offset_addr = (int16_t*) yr_arena_ref_to_ptr(
-          emit_context->arena, &split_offset_ref);
+      split_offset_addr =
+          yr_arena_ref_to_ptr(emit_context->arena, &split_offset_ref);
 
       jmp_offset = (int16_t) (bookmark_2 - bookmark_1);
 


### PR DESCRIPTION
Casting potentially unaligned `void*` pointers (returned by `yr_arena_ref_to_ptr()`) to typed pointers like `int32_t*` or `int16_t*` can trigger compiler-inserted alignment checks. This was observed to cause TRAP errors under HWAddressSanitizer on ARM.

By keeping these variables as `void*` and passing them directly to `memcpy()`, we avoid the alignment assumptions associated with typed pointer casts entirely.

Googlers, see internal b/518256945 and b/521375477.