### PR TITLE
remove double byte-swap of NumberOfNames in pe_parse_exports

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1642,7 +1642,7 @@ static void pe_parse_exports(PE* pe)
     return;
 
   number_of_names = yr_min(
-      yr_le32toh(yr_le32toh(exports->NumberOfNames)), number_of_exports);
+      yr_le32toh(exports->NumberOfNames), number_of_exports);
 
   // Mapping out the exports is a bit janky. We start with the export address
   // array. The index from that array plus the ordinal base is the ordinal for


### PR DESCRIPTION
NumberOfNames is byte-swapped twice when computing number_of_names in pe_parse_exports:
- yr_le32toh(yr_le32toh(...)) is a no-op on little-endian but returns the unswapped value on big-endian
- the names[] bounds check just above uses the single-swapped count, so the export loop then indexes names[j] past it on big-endian, where j is only capped by number_of_exports (MAX_PE_EXPORTS)
- the sibling NumberOfNames reads already use a single yr_le32toh

A crafted PE with a small real name count whose byte-reversed value is large pushes number_of_names up to 16384 while names[] was sized for the small count, reading out of bounds. Dropped the redundant inner call.