### PR TITLE
bound fat arch count against overflow in macho_parse_fat_file

### DIFF
--- a/libyara/modules/macho/macho.c
+++ b/libyara/modules/macho/macho.c
@@ -729,7 +729,7 @@ void macho_parse_fat_file(
   uint32_t count = yr_be32toh(header->nfat_arch);
   yr_set_integer(count, object, "nfat_arch");
 
-  if (size < sizeof(yr_fat_header_t) + count * fat_arch_sz)
+  if (count > (size - sizeof(yr_fat_header_t)) / fat_arch_sz)
     return;
 
   yr_fat_arch_64_t arch;


### PR DESCRIPTION
unchecked length math in the mach-o fat header parser:
- macho_parse_fat_file computes `count * fat_arch_sz` where count is the file's nfat_arch
- on 32-bit builds size_t is 32-bit, so the product wraps and a crafted nfat_arch passes the size check
- the fat arch loop then reads arch entries past the mapped buffer (out-of-bounds read)
checked count against the remaining size by division so the comparison stays 64-bit.