### PR TITLE
avoid pointer wrap for large index in str_table_entry

### DIFF
--- a/libyara/modules/elf/elf.c
+++ b/libyara/modules/elf/elf.c
@@ -338,10 +338,13 @@ static const char* str_table_entry(
   if (index < 0)
     return NULL;
 
-  str_entry = str_table_base + index;
-
-  if (str_entry >= str_table_limit)
+  // Bound the index against the table size before forming the pointer. On
+  // 32-bit builds str_table_base + index can wrap past str_table_limit for a
+  // large index and pass the check below, letting strnlen read out of bounds.
+  if ((size_t) index >= (size_t) (str_table_limit - str_table_base))
     return NULL;
+
+  str_entry = str_table_base + index;
 
   len = strnlen(str_entry, str_table_limit - str_entry);
 


### PR DESCRIPTION
str_table_entry resolves an ELF string-table entry from a 32-bit name field read out of the file (section->name, sym->name, dynsym->name):
- it forms str_table_base + index, then only checks the pointer against the upper limit
- index is capped at 0x7fffffff by the index < 0 check, but on a 32-bit build str_table_base + index can wrap below the base when the mapping sits high in the address space
- the wrapped pointer is under str_table_limit so the check passes and strnlen then reads out of bounds
Compare index against the table size before forming the pointer.