### PR TITLE
cli: honor -w/--no-warnings for the file-too-large skip message

### DIFF
--- a/cli/yara.c
+++ b/cli/yara.c
@@ -519,7 +519,7 @@ static int scan_dir(const char_t* dir, SCAN_OPTIONS* scan_opts)
         {
           result = file_queue_put(path, scan_opts->deadline);
         }
-        else
+        else if (!ignore_warnings)
         {
           _ftprintf(
               stderr,
@@ -719,7 +719,7 @@ static int scan_dir(const char* dir, SCAN_OPTIONS* scan_opts)
           {
             result = file_queue_put(full_path, scan_opts->deadline);
           }
-          else
+          else if (!ignore_warnings)
           {
             fprintf(
                 stderr,


### PR DESCRIPTION
Fixes #2137.

`-w`/`--no-warnings` skips every other warning in `cli/yara.c` but not the "skipping X because it's larger than N bytes" message from `scan_dir`. That one's printed unconditionally on both the POSIX and Windows code paths, so `-w -z <size>` still spams stderr with a line per oversized file.

Wrapped both prints in `if (!ignore_warnings)`, same flag and same pattern already used for the other warnings in this file (e.g. the `CALLBACK_MSG_TOO_SLOW_SCANNING` / `CALLBACK_MSG_TOO_MANY_MATCHES` cases). No behavior change to which files get scanned, just the message.

Didn't have a build toolchain handy to test this on, but it's a one-line `else` -> `else if (!ignore_warnings)` in each of the two `scan_dir` implementations (Unix and Windows), matching the guard style already used three other times in this same file.
