### PR TITLE
fix string leak in cli args_free

### DIFF
--- a/cli/args.c
+++ b/cli/args.c
@@ -257,9 +257,6 @@ int args_parse(args_option_t* options, int argc, const char_t** argv)
     i++;
   }
 
-  // Initialize to NULL the value pointers for all options.
-  for (; options->type != ARGS_OPT_END; options++) options->value = NULL;
-
   return o;
 }
 
@@ -298,11 +295,21 @@ void args_print_usage(args_option_t* options, int help_alignment)
 
 void args_free(args_option_t* options)
 {
+#ifdef _UNICODE
+  // On Windows the string values stored by args_parse_option are ANSI
+  // copies allocated by unicode_to_ansi(), so they must be released here.
+  // On non-Windows builds the string values point directly into argv,
+  // there's nothing to free.
   for (; options->type != ARGS_OPT_END; options++)
   {
-    if (options->type == ARGS_OPT_STRING && options->value != NULL)
-    {
-      free(options->value);
-    }
+    if (options->type != ARGS_OPT_STRING || options->value == NULL)
+      continue;
+
+    char** strings = (char**) options->value;
+
+    for (int i = 0; i < options->count; i++) free(strings[i]);
   }
+#else
+  (void) options;
+#endif
 }


### PR DESCRIPTION
Fixes #1963.

`args_free` never actually frees anything, and even if it did it would be freeing the wrong pointer.

`args_parse` ends with this loop, which runs right before it returns:

```c
// Initialize to NULL the value pointers for all options.
for (; options->type != ARGS_OPT_END; options++) options->value = NULL;
```

That sets every option's `value` to NULL after parsing, so by the time `args_free` runs at exit, its `options->value != NULL` check always fails and the `free()` call is dead code. This has been the case since `args_free` was added in 57057e86 (May 2021).

Even without that, `options->value` is a pointer to the caller's own storage (a static `char*` or a static array like `ext_vars` in yara.c), not a heap pointer. Freeing it would free the address of a static variable instead of the string it points to.

On Windows (`_UNICODE` builds) `args_parse_option` stores a heap copy from `unicode_to_ansi()` for each `ARGS_OPT_STRING` argument, so `-d`, `-x`, `-i`, `--atom-quality-table`, and `--module-data` each leak one allocation per use. On non-Windows builds the string just points into `argv`, so there was never anything to free there.

Fix, both in `cli/args.c`:
- Removed the value-clearing loop in `args_parse`. Nothing reads `options->value` after parsing except `args_free`, so clearing it only served to disable the free.
- Rewrote `args_free` to walk `options->count` entries per string option and free the actual pointers, wrapped in `#ifdef _UNICODE` since those are the only builds where the values are heap-allocated. On other platforms it's a no-op, matching current behavior.

This covers both `OPT_STRING` (single value) and `OPT_STRING_MULTI` (array, e.g. `ext_vars`), and both `cli/yara.c` and `cli/yarac.c` since they share `args_free`.

I don't have a Windows toolchain here to run this under a leak checker, so I verified it by inspection: traced every write to `options->value` in `args_parse_option`, confirmed nothing else in `yara.c`/`yarac.c` reads `.value` after `args_parse` returns, and matched the single vs. multi value layout against how `ext_vars`/`identifiers`/`modules_data` are declared and consumed. The non-Windows path is unchanged (the `#else` branch stays a no-op), so this shouldn't affect Linux/macOS builds at all.
