### PR TITLE
pe: null-terminate authenticode digest/thumbprint hex buffers

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1754,6 +1754,7 @@ static void pe_parse_exports(PE* pe)
     char thumbprint_ascii[YR_SHA1_LEN * 2 + 1];                                \
     for (int j = 0; j < cert->sha1.len; ++j)                                   \
       sprintf(thumbprint_ascii + (j * 2), "%02x", cert->sha1.data[j]);         \
+    thumbprint_ascii[cert->sha1.len * 2] = '\0';                               \
                                                                                \
     yr_set_string(                                                             \
         (char*) thumbprint_ascii, pe->object, fmt ".thumbprint", __VA_ARGS__); \
@@ -1820,6 +1821,7 @@ void _process_authenticode(
       char* digest_ascii = yr_malloc(authenticode->digest.len * 2 + 1);
       for (int j = 0; j < authenticode->digest.len; ++j)
         sprintf(digest_ascii + (j * 2), "%02x", authenticode->digest.data[j]);
+      digest_ascii[authenticode->digest.len * 2] = '\0';
 
       yr_set_string(
           digest_ascii, pe->object, "signatures[%i].digest", *sig_count);
@@ -1832,6 +1834,7 @@ void _process_authenticode(
       for (int j = 0; j < authenticode->file_digest.len; ++j)
         sprintf(
             digest_ascii + (j * 2), "%02x", authenticode->file_digest.data[j]);
+      digest_ascii[authenticode->file_digest.len * 2] = '\0';
 
       yr_set_string(
           digest_ascii, pe->object, "signatures[%i].file_digest", *sig_count);
@@ -1884,6 +1887,7 @@ void _process_authenticode(
         char* digest_ascii = yr_malloc(signer->digest.len * 2 + 1);
         for (int j = 0; j < signer->digest.len; ++j)
           sprintf(digest_ascii + (j * 2), "%02x", signer->digest.data[j]);
+        digest_ascii[signer->digest.len * 2] = '\0';
 
         yr_set_string(
             digest_ascii,
@@ -1950,6 +1954,7 @@ void _process_authenticode(
           char* digest_ascii = yr_malloc(counter->digest.len * 2 + 1);
           for (int j = 0; j < counter->digest.len; ++j)
             sprintf(digest_ascii + (j * 2), "%02x", counter->digest.data[j]);
+          digest_ascii[counter->digest.len * 2] = '\0';
 
           yr_set_string(
               digest_ascii,


### PR DESCRIPTION
Fixes #2176.

All the hex-digest buffers in `_process_authenticode()` (authenticode digest, file_digest, signer digest, countersignature digest) and `thumbprint_ascii` in the `write_certificate` macro are allocated with room for a trailing null (`len * 2 + 1`), but the `sprintf` loop that fills them only ever writes `len * 2` hex characters. Nothing ever sets that last byte, so `yr_set_string()` calling `strlen()` on the buffer reads past the hex digits into whatever uninitialized stack or heap byte happens to follow, until it hits a zero.

This same bug shape was already fixed correctly elsewhere in this file: `pe_get_imphash()` sets `digest_ascii[YR_MD5_LEN * 2] = '\0'` right after its loop. This PR does the same thing at the five spots that were missing it.

This lines up with the failure in #2176 (`test-pe.c`, the `pe.signatures[0].thumbprint` check failing on Rocky 9 but not Rocky 8) — thumbprint comes from exactly the buffer this touches, and reading uninitialized memory would naturally be sensitive to stack layout/compiler version, which is what varies between those two.

Didn't have a build toolchain available to run `make check` locally, so this is verified by code inspection: traced every `sprintf`-into-hex-buffer site in the file, confirmed each buffer's allocation size already reserves the byte, and matched the fix to the existing correct pattern used for imphash three times over. No behavior change to anything except cases where the buffer wasn't already accidentally null-terminated by chance.
