### PR TITLE
validate summary counts in yr_rules_from_arena

### DIFF
--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -331,6 +331,20 @@ int yr_rules_from_arena(YR_ARENA* arena, YR_RULES** rules)
   if (summary == NULL)
     return ERROR_CORRUPT_FILE;
 
+  // The rule, string and namespace counts are taken verbatim from the loaded
+  // summary. Reject any count that doesn't fit the table it indexes, otherwise
+  // the rules_table walk below (and the string/namespace tables the scanner
+  // indexes with these counts) run past the end of the loaded buffers.
+  if ((uint64_t) summary->num_rules * sizeof(YR_RULE) >
+          yr_arena_get_current_offset(arena, YR_RULES_TABLE) ||
+      (uint64_t) summary->num_strings * sizeof(YR_STRING) >
+          yr_arena_get_current_offset(arena, YR_STRINGS_TABLE) ||
+      (uint64_t) summary->num_namespaces * sizeof(YR_NAMESPACE) >
+          yr_arena_get_current_offset(arena, YR_NAMESPACES_TABLE))
+  {
+    return ERROR_CORRUPT_FILE;
+  }
+
   YR_RULES* new_rules = (YR_RULES*) yr_malloc(sizeof(YR_RULES));
 
   if (new_rules == NULL)

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -28,8 +28,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <yara.h>
+#include <yara/compiler.h>
 
 #include "util.h"
 
@@ -641,6 +643,80 @@ void test_save_load_rules()
   }
 
   yr_rules_destroy(rules);
+  yr_finalize();
+}
+
+// A compiled rules file carries a YR_SUMMARY with the rule/string/namespace
+// counts. Loading trusts those counts to walk the corresponding tables, so a
+// crafted file that inflates num_rules must be rejected instead of reading past
+// the loaded YR_RULES_TABLE.
+void test_load_rules_corrupt_summary()
+{
+  YR_COMPILER* compiler = NULL;
+  YR_RULES* rules = NULL;
+
+  yr_initialize();
+
+  if (yr_compiler_create(&compiler) != ERROR_SUCCESS)
+    exit(EXIT_FAILURE);
+
+  if (yr_compiler_add_string(
+          compiler,
+          "rule a { strings: $a = \"aaa\" condition: $a } "
+          "rule b { condition: true }",
+          NULL) != 0)
+    exit(EXIT_FAILURE);
+
+  if (yr_compiler_get_rules(compiler, &rules) != ERROR_SUCCESS)
+    exit(EXIT_FAILURE);
+
+  yr_compiler_destroy(compiler);
+
+  if (yr_rules_save(rules, "test-corrupt-summary.yarc") != ERROR_SUCCESS)
+    exit(EXIT_FAILURE);
+
+  yr_rules_destroy(rules);
+
+  FILE* fh = fopen("test-corrupt-summary.yarc", "rb");
+  assert_true_expr(fh != NULL);
+  fseek(fh, 0, SEEK_END);
+  long size = ftell(fh);
+  fseek(fh, 0, SEEK_SET);
+
+  uint8_t* data = (uint8_t*) malloc(size);
+  assert_true_expr(data != NULL);
+  assert_true_expr(fread(data, 1, size, fh) == (size_t) size);
+  fclose(fh);
+
+  // Arena file layout (see yr_arena_save_stream): a 6-byte header
+  // (magic[4], version, num_buffers) followed by a table of packed 12-byte
+  // {offset(8), size(4)} entries, then the buffer contents. Follow the
+  // YR_SUMMARY_SECTION entry to its content and inflate num_rules, the first
+  // uint32 of YR_SUMMARY.
+  uint64_t summary_offset;
+  memcpy(&summary_offset, data + 6 + 12 * YR_SUMMARY_SECTION, sizeof(uint64_t));
+
+  uint32_t bad_num_rules = 200000;
+  memcpy(data + summary_offset, &bad_num_rules, sizeof(bad_num_rules));
+
+  fh = fopen("test-corrupt-summary.yarc", "wb");
+  assert_true_expr(fh != NULL);
+  assert_true_expr(fwrite(data, 1, size, fh) == (size_t) size);
+  fclose(fh);
+  free(data);
+
+  int result = yr_rules_load("test-corrupt-summary.yarc", &rules);
+
+  if (result != ERROR_CORRUPT_FILE)
+  {
+    fprintf(
+        stderr,
+        "test_load_rules_corrupt_summary: expecting ERROR_CORRUPT_FILE, got "
+        "%d\n",
+        result);
+    exit(EXIT_FAILURE);
+  }
+
   yr_finalize();
 }
 
@@ -1276,6 +1352,7 @@ int main(int argc, char** argv)
   test_too_slow_scanning_slow_string_matches();
   test_include_callback();
   test_save_load_rules();
+  test_load_rules_corrupt_summary();
   test_scanner();
   test_xor_key_string_in_atom();
   test_ast_callback();


### PR DESCRIPTION
Loading a compiled rules file trusts the counts in its summary:
- num_rules drives the rules_table walk in yr_rules_from_arena, so an inflated count reads past YR_RULES_TABLE (ASAN heap-buffer-overflow at rules.c:381, reached through yr_rules_load)
- num_strings and num_namespaces feed scanner-side allocations and index math with the same gap

Reject any count larger than its table's loaded size with ERROR_CORRUPT_FILE. The added test saves a small ruleset, inflates num_rules in the summary, and checks the load is rejected.