### PR TITLE
bound tilde stream row-count read in dotnet_parse_tilde_2

### DIFF
--- a/libyara/modules/dotnet/dotnet.c
+++ b/libyara/modules/dotnet/dotnet.c
@@ -1917,6 +1917,10 @@ void dotnet_parse_tilde_2(
   const uint8_t* string_offset;
   const uint8_t* blob_offset;
 
+  const uint8_t* tilde_stream_end = pe->data + metadata_root +
+                                    yr_le32toh(streams->tilde->Offset) +
+                                    yr_le32toh(streams->tilde->Size);
+
   uint32_t num_rows = 0;
   uint32_t valid_rows = 0;
   uint32_t* row_offset = NULL;
@@ -1992,7 +1996,8 @@ void dotnet_parse_tilde_2(
     if (!((yr_le64toh(tilde_header->Valid) >> bit_check) & 0x01))
       continue;
 
-    if (!fits_in_pe(pe, row_offset + matched_bits, sizeof(uint32_t)))
+    if (!fits_in_pe(pe, row_offset + matched_bits, sizeof(uint32_t)) ||
+        (uint8_t*) (row_offset + matched_bits + 1) > tilde_stream_end)
       return;
 
     num_rows = yr_le32toh(*(row_offset + matched_bits));


### PR DESCRIPTION
Since #2196, `dotnet_parse_tilde` computes `tilde_stream_end` and checks each row-count read against it instead of `fits_in_pe`, because `fits_in_pe` was only bounding the read against the whole PE buffer rather than the `#~` stream's own declared `Size`.

`dotnet_parse_tilde` calls `dotnet_parse_tilde_2` right after, passing the same `tilde_header` and `streams`. But `dotnet_parse_tilde_2` doesn't use the already-validated row counts to drive its own table walk - it independently re-reads the identical row-count array with the old `fits_in_pe` check, which #2196 never touched:

```c
if (!fits_in_pe(pe, row_offset + matched_bits, sizeof(uint32_t)))
  return;

num_rows = yr_le32toh(*(row_offset + matched_bits));
```

So a `#~` stream with an undersized `Size` still lets `dotnet_parse_tilde_2` read row counts (and therefore drive its table_offset walk) from whatever bytes physically follow the stream in the file - padding, another stream, the cert table. That read is still bounded by `fits_in_pe` against the real file allocation, so it's not an overrun of the buffer, but it can surface unrelated file content through `dotnet.*` fields as if it were legitimate metadata table data.

This gives `dotnet_parse_tilde_2` its own `tilde_stream_end` and swaps in the same `<= tilde_stream_end` guard `dotnet_parse_tilde` already uses, so both functions agree on where the stream actually ends.

Built locally and ran the dotnet test binary (`make test-dotnet`), passes clean. Also confirmed by diffing against the commit that closed #2196 - it only touched `dotnet_parse_tilde`, this just brings the sibling in line with it.
