### PR TITLE
bound export name count against 32-bit overflow in pe_parse_exports

### DIFF
--- a/libyara/modules/pe/pe.c
+++ b/libyara/modules/pe/pe.c
@@ -1616,8 +1616,8 @@ static void pe_parse_exports(PE* pe)
     if (offset < 0)
       return;
 
-    if (yr_le32toh(exports->NumberOfNames) * sizeof(DWORD) >
-        pe->data_size - offset)
+    if (yr_le32toh(exports->NumberOfNames) >
+        (pe->data_size - offset) / sizeof(DWORD))
       return;
 
     names = (DWORD*) (pe->data + offset);


### PR DESCRIPTION
**32-bit overflow in the export name count bounds check**
`NumberOfNames` comes straight from the export directory and is multiplied by `sizeof(DWORD)` before the size comparison, so on a 32-bit `size_t` the product wraps to a small value, the check passes, and the `names[]` reads in the export loop run past the mapped file. Rewrote it to bound the count by dividing the remaining size, the same shape already used in `macho_parse_fat_file` and `dex_parse`.