### PR TITLE
cast e_lfanew to int32 before sign check in pe_get_header

### DIFF
--- a/libyara/modules/pe/pe_utils.c
+++ b/libyara/modules/pe/pe_utils.c
@@ -53,7 +53,7 @@ PIMAGE_NT_HEADERS32 pe_get_header(const uint8_t* data, size_t data_size)
   if (yr_le16toh(mz_header->e_magic) != IMAGE_DOS_SIGNATURE)
     return NULL;
 
-  if (yr_le32toh(mz_header->e_lfanew) < 0)
+  if ((int32_t) yr_le32toh(mz_header->e_lfanew) < 0)
     return NULL;
 
   headers_size = yr_le32toh(mz_header->e_lfanew) +


### PR DESCRIPTION
the e_lfanew sign check in pe_get_header is a no-op on big-endian builds:
- yr_le32toh is __builtin_bswap32 there and returns unsigned, so `yr_le32toh(...) < 0` is always false
- e_lfanew then stays unbounded, and on a 32-bit size_t `headers_size = e_lfanew + 24` wraps, so the `data_size < headers_size` guard passes and `data + e_lfanew` is read out of bounds at pe_header->Signature
- yr_get_pe_header in exefiles.c already casts to (int32_t) before the same check

matched it here with the (int32_t) cast.